### PR TITLE
refactor(shared/table/ui): #87 improve table cell styling

### DIFF
--- a/libs/nasa-images/feature/search/src/lib/nasa-images-feature-search/nasa-images-feature-search-table.config.ts
+++ b/libs/nasa-images/feature/search/src/lib/nasa-images-feature-search/nasa-images-feature-search-table.config.ts
@@ -10,7 +10,7 @@ const index: TableColumnFormatting<NasaImage, FormattingTypes.CUSTOM> = {
   key: 'index',
   title: '',
   propertyPath: '',
-  cssClasses: 'max-w-[4rem] lg:max-w-[10rem]',
+  cssClasses: ['max-w-[5rem] bg-gray-5 hidden md:flex'],
   formatting: {
     type: FormattingTypes.CUSTOM,
     execute: (_, __, index) => String(index),
@@ -21,16 +21,18 @@ const id: TableColumnFormatting<NasaImage, FormattingTypes.TEXT> = {
   key: 'id',
   title: 'ID',
   propertyPath: 'id',
+  cssClasses: ['min-w-[9rem] lg:min-w-[12rem]'],
   formatting: {
     type: FormattingTypes.TEXT,
   },
+  sticky: true,
 };
 
 const title: TableColumnFormatting<NasaImage, FormattingTypes.TEXT> = {
   key: 'title',
   title: 'Title',
   propertyPath: 'title',
-  cssClasses: 'min-w-[7rem] lg:min-w-[8rem]',
+  cssClasses: ['min-w-[7rem] lg:max-w-[25rem]'],
   formatting: {
     type: FormattingTypes.TEXT,
   },
@@ -40,7 +42,7 @@ const description: TableColumnFormatting<NasaImage, FormattingTypes.TEXT> = {
   key: 'description',
   title: 'Description',
   propertyPath: 'description',
-  cssClasses: 'min-w-[9rem] 2xl:min-w-[24rem]',
+  cssClasses: ['min-w-[9rem] 2xl:min-w-[24rem]', 'content-center truncate ...'],
   formatting: {
     type: FormattingTypes.TEXT,
   },
@@ -50,6 +52,7 @@ const dateCreated: TableColumnFormatting<NasaImage, FormattingTypes.DATE> = {
   key: 'dateCreated',
   title: 'Created',
   propertyPath: 'dateCreated',
+  cssClasses: ['max-w-[6rem]'],
   formatting: {
     type: FormattingTypes.DATE,
     extras: { numberDigitsInfo: 'longDate' },
@@ -60,6 +63,7 @@ const thumbnail: TableColumnFormatting<NasaImage, FormattingTypes.IMAGE> = {
   key: 'thumbnail',
   title: 'Image',
   propertyPath: 'thumbnail',
+  cssClasses: ['max-w-[120px] min-w-[100px]'],
   formatting: {
     type: FormattingTypes.IMAGE,
     extras: {
@@ -74,7 +78,7 @@ const creator: TableColumnFormatting<NasaImage, FormattingTypes.TEXT> = {
   key: 'creator',
   title: 'Creator',
   propertyPath: 'creator',
-  cssClasses: 'min-w-[6rem] lg:min-w-[6.5rem] xl:min-w-[7rem]',
+  cssClasses: ['max-w-[16rem]', 'xl:whitespace-normal content-center truncate ...'],
   formatting: {
     type: FormattingTypes.TEXT,
   },
@@ -84,7 +88,7 @@ const center: TableColumnFormatting<NasaImage, FormattingTypes.TEXT> = {
   key: 'center',
   title: 'Center',
   propertyPath: 'center',
-  cssClasses: 'min-w-[5rem] lg:min-w-[6rem] xl:min-w-[7.5rem]',
+  cssClasses: ['max-w-[5rem] lg:max-w-[6rem]'],
   formatting: {
     type: FormattingTypes.TEXT,
   },

--- a/libs/shared/table/entities/src/table.interfaces.ts
+++ b/libs/shared/table/entities/src/table.interfaces.ts
@@ -12,9 +12,9 @@ export type TableColumnFormatting<OBJ, TYPE> = PropertyFormatting<OBJ, TYPE> & {
    */
   sorting?: boolean;
   /**
-   * Sets styling by CSS classes passed as a single string for the current column.
+   * Sets styling for the cell and the child container.
    */
-  cssClasses?: string;
+  cssClasses?: [cell?: string, content?: string];
   /**
    * Sets the sticky position value for a given column.
    */

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
@@ -5,8 +5,12 @@
         {{ column.title }}
       </mat-header-cell>
 
-      <mat-cell *matCellDef="let row; let i = index" [ngClass]="column.cssClasses || ''">
-        <div class="table__cell--default" [innerHTML]="row | safeFormatted : column : i + 1"></div>
+      <mat-cell *matCellDef="let row; let i = index" [ngClass]="column.cssClasses?.[0] || ''">
+        <div
+          class="table-cell table__cell--default"
+          [ngClass]="column.cssClasses?.[1] || ''"
+          [innerHTML]="row | safeFormatted : column : i + 1"
+        ></div>
       </mat-cell>
     </ng-container>
 

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.scss
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.scss
@@ -1,4 +1,7 @@
 :host ::ng-deep {
+  .mat-mdc-table mat-row.mat-mdc-row {
+    @apply min-h-[120px];
+  }
   .mat-row {
     @apply items-stretch;
   }


### PR DESCRIPTION
set classes to style both cell and cell content, and apply it for nasa images search table. Truncate text for description cell.

<img width="1808" alt="Captura de pantalla 2023-03-16 a les 11 10 07" src="https://user-images.githubusercontent.com/5324001/225585754-8eb52d68-244c-4e3e-8229-e302e55e0717.png">

<img width="677" alt="Captura de pantalla 2023-03-16 a les 11 09 59" src="https://user-images.githubusercontent.com/5324001/225585770-b6914063-e730-4cae-884d-e0c4c3624854.png">


ISSUES CLOSED: #87