### PR TITLE
feat: set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -11,11 +11,7 @@
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
     },
-    "build": {
-      "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"]
-    },
+    "build": { "cache": true, "dependsOn": ["^build"], "inputs": ["production", "^production"] },
     "@nx/eslint:lint": {
       "cache": true,
       "inputs": [
@@ -28,19 +24,10 @@
     "@nx/jest:jest": {
       "cache": true,
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
-      "options": {
-        "passWithNoTests": true
-      },
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "codeCoverage": true
-        }
-      }
+      "options": { "passWithNoTests": true },
+      "configurations": { "ci": { "ci": true, "codeCoverage": true } }
     },
-    "e2e-ci--**/*": {
-      "dependsOn": ["^build"]
-    },
+    "e2e-ci--**/*": { "dependsOn": ["^build"] },
     "@angular/build:application": {
       "cache": true,
       "dependsOn": ["^build"],
@@ -69,9 +56,7 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.cursorrules", "{workspaceRoot}/.cursor/rules/*.mdc"]
   },
-  "cli": {
-    "packageManager": "yarn"
-  },
+  "cli": { "packageManager": "yarn" },
   "plugins": [
     {
       "plugin": "@nx/cypress/plugin",
@@ -82,12 +67,7 @@
         "ciTargetName": "e2e-ci"
       }
     },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    }
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } }
   ],
   "generators": {
     "@nx/angular:application": {
@@ -109,19 +89,13 @@
       "standalone": true,
       "changeDetection": "OnPush"
     },
-    "@nx/angular:service": {
-      "type": "service"
-    },
-    "@nx/angular:directive": {
-      "type": "directive"
-    },
-    "@nx/angular:pipe": {
-      "type": "pipe"
-    }
+    "@nx/angular:service": { "type": "service" },
+    "@nx/angular:directive": { "type": "directive" },
+    "@nx/angular:pipe": { "type": "pipe" }
   },
   "defaultProject": "llecoop",
   "cacheDirectory": "./tmp/my-cache",
   "defaultBase": "develop",
   "nxCloudAccessToken": "",
-  "nxCloudId": "685169ba2c3aa5b4a81a4f6d"
+  "nxCloudId": "697ca354c3cf06f1eea9b5a7"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/697ca352c3cf06f1eea9b5a1/workspaces/697ca354c3cf06f1eea9b5a7

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.