### PR TITLE
Add test coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const glob = require('@actions/glob');
+            // 'glob' is already available in the context provided by actions/github-script
 
             const globber = await glob.create('coverage/**/coverage-summary.json');
             const files = await globber.glob();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+  pull_request:
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
@@ -11,6 +12,7 @@ env:
 permissions:
   actions: read
   contents: read
+  pull-requests: write
 
 jobs:
   develop:
@@ -40,6 +42,90 @@ jobs:
           yarn i18n:validate
           yarn markdownlint
           npx nx-cloud record -- nx affected --target=lint --exclude=llecoop-firebase --parallel=3
-          npx nx-cloud record -- nx affected --target=test --exclude=llecoop-firebase --parallel=3
+          npx nx-cloud record -- nx affected --target=test --exclude=llecoop-firebase --parallel=3 --code-coverage
           npx nx-cloud record -- nx affected --target=build --exclude=llecoop-firebase --parallel=3
         if: always()
+
+      - name: Report Coverage
+        if: always() && (github.event_name == 'pull_request')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const glob = require('@actions/glob');
+
+            const globber = await glob.create('coverage/**/coverage-summary.json');
+            const files = await globber.glob();
+
+            if (files.length === 0) {
+              console.log('No coverage summary files found.');
+              return;
+            }
+
+            let totalLines = { total: 0, covered: 0 };
+            let totalStatements = { total: 0, covered: 0 };
+            let totalFunctions = { total: 0, covered: 0 };
+            let totalBranches = { total: 0, covered: 0 };
+
+            let markdown = '## Test Coverage Report\n\n';
+            markdown += '| Project | Lines | Statements | Branches | Functions |\n';
+            markdown += '|---|---|---|---|---|\n';
+
+            for (const file of files) {
+              const content = JSON.parse(fs.readFileSync(file, 'utf8'));
+              const total = content.total;
+
+              const dir = path.dirname(file);
+              const relativePath = path.relative(process.cwd(), dir);
+              const projectName = relativePath.replace(/^coverage\//, '');
+
+              const linesPct = total.lines.pct;
+              const stmtsPct = total.statements.pct;
+              const branchesPct = total.branches.pct;
+              const funcsPct = total.functions.pct;
+
+              markdown += `| ${projectName} | ${linesPct}% | ${stmtsPct}% | ${branchesPct}% | ${funcsPct}% |\n`;
+
+              totalLines.total += total.lines.total;
+              totalLines.covered += total.lines.covered;
+              totalStatements.total += total.statements.total;
+              totalStatements.covered += total.statements.covered;
+              totalFunctions.total += total.functions.total;
+              totalFunctions.covered += total.functions.covered;
+              totalBranches.total += total.branches.total;
+              totalBranches.covered += total.branches.covered;
+            }
+
+            const calcPct = (covered, total) => total === 0 ? 100 : ((covered / total) * 100).toFixed(2);
+
+            markdown += `| **Total** | **${calcPct(totalLines.covered, totalLines.total)}%** | **${calcPct(totalStatements.covered, totalStatements.total)}%** | **${calcPct(totalBranches.covered, totalBranches.total)}%** | **${calcPct(totalFunctions.covered, totalFunctions.total)}%** |\n`;
+
+            console.log(markdown);
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+            });
+
+            const botComment = comments.data.find(c => c.body.startsWith('## Test Coverage Report'));
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: botComment.id,
+                body: markdown
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: markdown
+              });
+            }

--- a/apps/eco-store/tsconfig.spec.json
+++ b/apps/eco-store/tsconfig.spec.json
@@ -4,8 +4,9 @@
     "outDir": "../../dist/out-tsc",
     "module": "preserve",
     "target": "es2016",
-    "types": ["jest", "node"],
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "isolatedModules": true,
+    "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -13,7 +13,7 @@ module.exports = {
     ],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
-  coverageReporters: ['html', 'lcov', 'text'],
+  coverageReporters: ['html', 'lcov', 'text', 'cobertura', 'json-summary'],
   coverageDirectory: '../../coverage',
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -240,6 +240,7 @@
     "jsonc-eslint-parser": "^2.1.0",
     "kill-port": "^2.0.1",
     "markdownlint-cli": "^0.47.0",
+    "markdownlint-cli2": "^0.20.0",
     "ng-packagr": "21.1.0",
     "npm-run-all": "^4.1.5",
     "nx": "22.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17206,7 +17206,7 @@ markdownlint-cli@^0.47.0:
     smol-toml "~1.5.2"
     tinyglobby "~0.2.15"
 
-markdownlint@^0.40.0, markdownlint@~0.40.0:
+markdownlint@~0.40.0:
   version "0.40.0"
   resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.40.0.tgz#1c6e29385f810f0b860f0af4866208e572bd8c59"
   integrity sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6514,6 +6514,11 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
+"@sindresorhus/merge-streams@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz#abb11d99aeb6d27f1b563c38147a72d50058e339"
+  integrity sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==
+
 "@sinonjs/commons@^3.0.0", "@sinonjs/commons@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
@@ -12802,7 +12807,7 @@ fast-glob@3.2.7:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-glob@^3.2.7, fast-glob@^3.2.9, fast-glob@^3.3.2:
+fast-glob@^3.2.7, fast-glob@^3.2.9, fast-glob@^3.3.2, fast-glob@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
@@ -13851,6 +13856,18 @@ globalthis@^1.0.4:
   dependencies:
     define-properties "^1.2.1"
     gopd "^1.0.1"
+
+globby@15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-15.0.0.tgz#5dece8d6c38b34f21f710056bbc4103acec125f9"
+  integrity sha512-oB4vkQGqlMl682wL1IlWd02tXCbquGWM4voPEI85QmNKCaw8zGTm1f1rubFgkg3Eli2PtKlFgrnmUqasbQWlkw==
+  dependencies:
+    "@sindresorhus/merge-streams" "^4.0.0"
+    fast-glob "^3.3.3"
+    ignore "^7.0.5"
+    path-type "^6.0.0"
+    slash "^5.1.0"
+    unicorn-magic "^0.3.0"
 
 globby@^11.0.3, globby@^11.1.0:
   version "11.1.0"
@@ -16041,6 +16058,13 @@ js-yaml@4.1.0, js-yaml@^4.0.0, js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+js-yaml@4.1.1, js-yaml@~4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  dependencies:
+    argparse "^2.0.1"
+
 js-yaml@^3.10.0, js-yaml@^3.13.1, js-yaml@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
@@ -16048,13 +16072,6 @@ js-yaml@^3.10.0, js-yaml@^3.13.1, js-yaml@^3.14.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@~4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
-  dependencies:
-    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -17176,7 +17193,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-it@~14.1.0:
+markdown-it@14.1.0, markdown-it@~14.1.0:
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.1.0.tgz#3c3c5992883c633db4714ccb4d7b5935d98b7d45"
   integrity sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==
@@ -17187,6 +17204,24 @@ markdown-it@~14.1.0:
     mdurl "^2.0.0"
     punycode.js "^2.3.1"
     uc.micro "^2.1.0"
+
+markdownlint-cli2-formatter-default@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.6.tgz#aa6db33b2fafc0801f4bbddeedafc19a2499a62c"
+  integrity sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==
+
+markdownlint-cli2@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli2/-/markdownlint-cli2-0.20.0.tgz#22742a65a8d5375a14da8231874600966e20b41a"
+  integrity sha512-esPk+8Qvx/f0bzI7YelUeZp+jCtFOk3KjZ7s9iBQZ6HlymSXoTtWGiIRZP05/9Oy2ehIoIjenVwndxGtxOIJYQ==
+  dependencies:
+    globby "15.0.0"
+    js-yaml "4.1.1"
+    jsonc-parser "3.3.1"
+    markdown-it "14.1.0"
+    markdownlint "0.40.0"
+    markdownlint-cli2-formatter-default "0.0.6"
+    micromatch "4.0.8"
 
 markdownlint-cli@^0.47.0:
   version "0.47.0"
@@ -17206,7 +17241,7 @@ markdownlint-cli@^0.47.0:
     smol-toml "~1.5.2"
     tinyglobby "~0.2.15"
 
-markdownlint@~0.40.0:
+markdownlint@0.40.0, markdownlint@~0.40.0:
   version "0.40.0"
   resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.40.0.tgz#1c6e29385f810f0b860f0af4866208e572bd8c59"
   integrity sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==
@@ -17630,6 +17665,14 @@ micromark@4.0.2:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
 
+micromatch@4.0.8, micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
+    picomatch "^2.3.1"
+
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -17648,14 +17691,6 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
-
-micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
-  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
-  dependencies:
-    braces "^3.0.3"
-    picomatch "^2.3.1"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -19468,6 +19503,11 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+path-type@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-6.0.0.tgz#2f1bb6791a91ce99194caede5d6c5920ed81eb51"
+  integrity sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==
 
 pbkdf2@^3.1.2, pbkdf2@^3.1.5:
   version "3.1.5"
@@ -21654,6 +21694,11 @@ slash@^4.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
+slash@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-5.1.0.tgz#be3adddcdf09ac38eebe8dcdc7b1a57a75b095ce"
+  integrity sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==
+
 slice-ansi@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
@@ -23382,6 +23427,11 @@ unicorn-magic@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
   integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
+
+unicorn-magic@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.3.0.tgz#4efd45c85a69e0dd576d25532fbfa22aa5c8a104"
+  integrity sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Added test coverage reporting to the CI pipeline. The workflow now triggers on pull requests, runs tests with coverage enabled, and posts a consolidated coverage report as a comment on the PR. This uses `json-summary` output from Jest and a custom script to aggregate results from affected projects.

---
*PR created automatically by Jules for task [3211489662995275044](https://jules.google.com/task/3211489662995275044) started by @plastikaweb*