### PR TITLE
refactor(core-cms-layout): #884 fix race condition in widget creation

### DIFF
--- a/apps/llecoop/src/app/app.component.ts
+++ b/apps/llecoop/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { RouterOutlet } from '@angular/router';
 import { activityStore } from '@plastik/shared/activity/data-access';
@@ -15,6 +15,7 @@ import { NotificationUiMatSnackbarDirective } from '@plastik/shared/notification
     NotificationUiMatSnackbarDirective,
   ],
   templateUrl: './app.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {
   protected readonly notificationStore = inject(notificationStore);

--- a/apps/nasa-images/src/app/app.component.ts
+++ b/apps/nasa-images/src/app/app.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { CoreCmsLayoutFeatureComponent } from '@plastik/core/cms-layout';
 
 @Component({
   selector: 'plastik-root',
   imports: [CoreCmsLayoutFeatureComponent],
   templateUrl: './app.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {}

--- a/libs/core/cms-layout/data-access/README.md
+++ b/libs/core/cms-layout/data-access/README.md
@@ -6,6 +6,9 @@
 - [@plastik/core/cms-layout/data-access](#plastikcorecms-layoutdata-access)
   - [Description](#description)
   - [State Management](#state-management)
+    - [`LayoutFacade`](#layoutfacade)
+  - [Services](#services)
+    - [`LayoutObserverService`](#layoutobserverservice)
   - [Tokens](#tokens)
     - [`CORE_CMS_LAYOUT_HEADER_CONFIG`](#core_cms_layout_header_config)
     - [`VIEW_CONFIG`](#view_config)
@@ -20,24 +23,67 @@ Manages **CMS Layout State** (e.g., sidenav status, mobile detection) and provid
 
 ## State Management
 
-**Interface:**
+### `LayoutFacade`
 
-```typescript
-export interface State {
-  isMobile: boolean;
-  sidenavOpened: boolean;
-}
-```
+The main entry point for interacting with the CMS layout state. It abstracts the underlying NgRx store and provides properties and methods to control the layout.
+
+**Properties:**
+
+- `sidenavOpened$`: Observable emitting the current open state of the sidenav.
+- `isMobile$`: Observable emitting whether the current view is considered mobile.
+- `headerConfig`: The injected header configuration.
+- `sidenavConfig`: The injected sidenav view configuration.
+- `isActive`: Signal indicating if there is background activity (loading).
+
+**Methods:**
+
+- `toggleSidenav(opened?: boolean)`: Toggles the sidenav state or sets it to a specific value.
+- `setIsMobile(isMobile: boolean)`: Updates the mobile state in the store.
+- `dispatchAction(action: () => Action)`: Dispatches a generic NgRx action.
 
 ![Layout State Diagram](layout-state.png)
+
+## Services
+
+### `LayoutObserverService`
+
+A utility service that wraps Angular CDK's `BreakpointObserver` to simplify responsive layout detection.
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class LayoutObserverService {
+  /**
+   * Returns an observable that emits true if the current viewport matches the provided breakpoints.
+   * Default breakpoints: Handset, Tablet, Medium.
+   */
+  getMatches(breakpoints?: string[]): Observable<boolean>;
+}
+```
 
 ## Tokens
 
 ### `CORE_CMS_LAYOUT_HEADER_CONFIG`
 
-Injects header configuration (title, icon, buttons).
+Injects header configuration (title, icon, buttons, user menu, widgets).
 
 ```typescript
+export interface CoreCmsLayoutHeaderConfig {
+  showToggleMenuButton: boolean;
+  sidenavPosition?: LayoutPosition;
+  title: string;
+  extendedTitle?: string;
+  mainIcon?: SvgIconConfig;
+  widgetsConfig?: {
+    position: LayoutPosition;
+    widgets: CoreCmsLayoutHeaderWidget[];
+  };
+  userMenuConfig?: {
+    label?: Signal<string>;
+    position: LayoutPosition;
+    config: HeaderMenuConfig<string>[];
+  };
+}
+
 export const CORE_CMS_LAYOUT_HEADER_CONFIG = new InjectionToken<CoreCmsLayoutHeaderConfig>(
   'CORE_CMS_LAYOUT_HEADER_CONFIG'
 );

--- a/libs/core/cms-layout/data-access/src/index.ts
+++ b/libs/core/cms-layout/data-access/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/+state/layout.actions';
 export * from './lib/+state/layout.facade';
 export * from './lib/core-cms-layout-data-access.module';
 export * from './lib/core-cms-view-config';
+export * from './lib/services/layout-observer.service';

--- a/libs/core/cms-layout/data-access/src/lib/services/layout-observer.service.spec.ts
+++ b/libs/core/cms-layout/data-access/src/lib/services/layout-observer.service.spec.ts
@@ -1,0 +1,38 @@
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { LayoutObserverService } from './layout-observer.service';
+
+describe('LayoutObserverService', () => {
+  let service: LayoutObserverService;
+  const breakpointObserverMock = {
+    observe: jest.fn().mockReturnValue(of({ matches: true })),
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        LayoutObserverService,
+        { provide: BreakpointObserver, useValue: breakpointObserverMock },
+      ],
+    });
+    service = TestBed.inject(LayoutObserverService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return handset Matches based on BreakpointObserver', done => {
+    service.getMatches().subscribe((matches: boolean) => {
+      expect(matches).toBe(true);
+      expect(breakpointObserverMock.observe).toHaveBeenCalledWith([
+        Breakpoints.Handset,
+        Breakpoints.Tablet,
+        Breakpoints.Medium,
+      ]);
+      done();
+    });
+  });
+});

--- a/libs/core/cms-layout/data-access/src/lib/services/layout-observer.service.ts
+++ b/libs/core/cms-layout/data-access/src/lib/services/layout-observer.service.ts
@@ -1,0 +1,19 @@
+import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/layout';
+import { inject, Injectable } from '@angular/core';
+import { map, Observable, shareReplay } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LayoutObserverService {
+  readonly #breakpointObserver = inject(BreakpointObserver);
+
+  getMatches(
+    breakpoints: string[] = [Breakpoints.Handset, Breakpoints.Tablet, Breakpoints.Medium]
+  ): Observable<boolean> {
+    return this.#breakpointObserver.observe(breakpoints).pipe(
+      map((state: BreakpointState) => state.matches),
+      shareReplay(1)
+    );
+  }
+}

--- a/libs/core/cms-layout/feature/src/lib/core-cms-layout-feature/core-cms-layout-feature.component.ts
+++ b/libs/core/cms-layout/feature/src/lib/core-cms-layout-feature/core-cms-layout-feature.component.ts
@@ -1,7 +1,6 @@
 import { AngularSvgIconModule } from 'angular-svg-icon';
-import { map, Subject, takeUntil } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
 
-import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/layout';
 import { DatePipe, NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
@@ -22,7 +21,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { PushPipe } from '@ngrx/component';
-import { LayoutFacade } from '@plastik/core/cms-layout/data-access';
+import { LayoutFacade, LayoutObserverService } from '@plastik/core/cms-layout/data-access';
 import { CoreCmsLayoutUiFooterComponent } from '@plastik/core/cms-layout/footer';
 import { CoreCmsLayoutUiHeaderComponent } from '@plastik/core/cms-layout/header';
 import { CoreCmsLayoutUiSidenavComponent } from '@plastik/core/cms-layout/sidenav';
@@ -57,7 +56,7 @@ import { NotificationUiMatSnackbarDirective } from '@plastik/shared/notification
 export class CoreCmsLayoutFeatureComponent implements OnInit, OnDestroy, AfterViewInit {
   readonly #layoutFacade = inject(LayoutFacade);
   readonly #destroyed$ = new Subject<void>();
-  readonly #breakpointObserver = inject(BreakpointObserver);
+  readonly #layoutObserverService = inject(LayoutObserverService);
   readonly #zone = inject(NgZone);
 
   protected readonly notificationStore = inject(notificationStore);
@@ -74,13 +73,9 @@ export class CoreCmsLayoutFeatureComponent implements OnInit, OnDestroy, AfterVi
   protected readonly headerWidgetsConfig = this.headerConfig?.widgetsConfig;
 
   ngOnInit(): void {
-    // TODO: Isolate breakpoint observer into its own service https://github.com/plastikaweb/plastikspace/issues/68
-    this.#breakpointObserver
-      .observe([Breakpoints.Handset, Breakpoints.Tablet, Breakpoints.Medium])
-      .pipe(
-        takeUntil(this.#destroyed$),
-        map((handset: BreakpointState) => handset.matches)
-      )
+    this.#layoutObserverService
+      .getMatches()
+      .pipe(takeUntil(this.#destroyed$))
       .subscribe((matches: boolean) => {
         if (matches) this.onToggleSidenav(!matches);
         this.onSetIsMobile(matches);
@@ -112,23 +107,23 @@ export class CoreCmsLayoutFeatureComponent implements OnInit, OnDestroy, AfterVi
     this.#zone.runOutsideAngular(() => this.#layoutFacade.setIsMobile(isMobile));
   }
 
-  #createWidgets(): void {
+  async #createWidgets(): Promise<void> {
     if (!this.headerWidgetsConfig) return;
 
     const container = this.widgetsContainer();
     if (container) {
       container.clear();
 
-      this.headerWidgetsConfig?.widgets?.forEach(async widget => {
+      for (const widget of this.headerWidgetsConfig.widgets || []) {
         const component = await widget.component();
         const componentRef = container.createComponent(component);
 
         if (widget.inputs) {
-          Object.keys(widget.inputs ?? {}).map(key => {
-            componentRef?.setInput(key, widget.inputs?.[key]);
+          Object.entries(widget.inputs).forEach(([key, value]) => {
+            componentRef?.setInput(key, value);
           });
         }
-      });
+      }
     }
   }
 }

--- a/libs/eco-store/core/layout/src/layout.component.ts
+++ b/libs/eco-store/core/layout/src/layout.component.ts
@@ -9,20 +9,21 @@ import {
   viewChild,
 } from '@angular/core';
 
-import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { Breakpoints } from '@angular/cdk/layout';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSidenav, MatSidenavContainer, MatSidenavContent } from '@angular/material/sidenav';
 import { NavigationEnd, Router, RouterModule } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
-import { filter, map } from 'rxjs';
+import { filter } from 'rxjs';
 import { FooterComponent } from './footer/footer.component';
 import { HeaderComponent } from './header/header.component';
 import { MenuComponent } from './menu/menu.component';
 import { MobileNavComponent } from './mobile-nav/mobile-nav.component';
 import { TenantLogoComponent } from './tenant-logo/tenant-logo.component';
 
+import { LayoutObserverService } from '@plastik/core/cms-layout/data-access';
 import { appSearchFormConfig } from '@plastik/eco-store/formly';
 import { StoreStatusBannerComponent } from '@plastik/eco-store/status-banner';
 import { ecoStoreTenantStore } from '@plastik/eco-store/tenant';
@@ -56,9 +57,7 @@ export default class LayoutComponent {
   protected readonly hasSidenav = signal(false);
   protected readonly isBannerDismissed = signal(false);
   protected readonly isMobile = toSignal(
-    inject(BreakpointObserver)
-      .observe([Breakpoints.XSmall, Breakpoints.Small]) // XSmall: 0-599.98px, Small: 600-959.98px
-      .pipe(map(result => result.matches))
+    inject(LayoutObserverService).getMatches([Breakpoints.XSmall, Breakpoints.Small])
   );
   private readonly sidenavContent = viewChild<MatSidenavContent>('sidenavContent');
   readonly #destroyRef = inject(DestroyRef);

--- a/libs/eco-store/store-window/src/lib/store-window/store-window.component.ts
+++ b/libs/eco-store/store-window/src/lib/store-window/store-window.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -18,6 +18,7 @@ import { CountdownService } from '@plastik/shared/countdown/util';
   ],
   templateUrl: './store-window.component.html',
   styleUrl: './store-window.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StoreWindowComponent {
   readonly #countdownService = inject(CountdownService);

--- a/libs/nasa-images/faqs/feature/src/lib/nasa-images-faqs-feature/nasa-images-faqs-feature.component.ts
+++ b/libs/nasa-images/faqs/feature/src/lib/nasa-images-faqs-feature/nasa-images-faqs-feature.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { PushPipe } from '@ngrx/component';
@@ -11,6 +11,7 @@ import { NasaImagesFaqsService } from '../nasa-images-faqs.service';
   imports: [MatExpansionModule, MatIconModule, PushPipe],
   templateUrl: './nasa-images-faqs-feature.component.html',
   styleUrl: './nasa-images-faqs-feature.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NasaImagesFaqsFeatureComponent {
   routeInfo$ = inject(NasaImagesFacade).routeInfo$;

--- a/libs/nasa-images/search/ui/no-results/src/lib/nasa-images-search-ui-no-results/nasa-images-search-ui-no-results.component.ts
+++ b/libs/nasa-images/search/ui/no-results/src/lib/nasa-images-search-ui-no-results/nasa-images-search-ui-no-results.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'plastik-nasa-images-search-ui-no-results',
   imports: [MatIconModule],
   templateUrl: './nasa-images-search-ui-no-results.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NasaImagesSearchUiNoResultsComponent {}


### PR DESCRIPTION
Fix race condition in widget creation by replacing forEach loop with for...of loops.

This ensures promises are strictly awaited.

Update READMEs with LayoutObserverService and CoreCmsLayoutHeaderConfig details.

ISSUES CLOSED: #884