### PR TITLE
Extract shared user menu component

### DIFF
--- a/libs/core/cms-layout/feature/src/lib/core-cms-layout-feature/core-cms-layout-feature.component.html
+++ b/libs/core/cms-layout/feature/src/lib/core-cms-layout-feature/core-cms-layout-feature.component.html
@@ -51,8 +51,9 @@
         <ng-container [ngTemplateOutlet]="toggleSidenavButtonTpl"></ng-container>
       }
       @if (headerMenu) {
-        <!-- TODO: Create a shared user menu -->
-        <ng-container [ngTemplateOutlet]="headerMenuTpl"></ng-container>
+        <plastik-core-cms-layout-ui-user-menu
+          [userMenuConfig]="headerMenu"
+          (sendAction)="onSendAction($event)" />
       }
     </div>
   </plastik-core-cms-layout-ui-header>
@@ -111,36 +112,6 @@
     </plastik-core-cms-layout-ui-footer>
   }
 </div>
-
-<ng-template #headerMenuTpl>
-  <button
-    mat-button
-    class="gap-tiny flex"
-    [attr.aria-label]="headerMenu?.label()"
-    [matMenuTriggerFor]="menu">
-    <span class="hidden sm:block">{{ headerMenu?.label() }}</span>
-    <mat-icon class="m-0 size-[30px] p-0 text-[30px]">account_circle</mat-icon>
-  </button>
-  <mat-menu #menu="matMenu" class="px-sub">
-    <span class="p-tiny border-b-gray-10 block w-fit border-b-2 text-balance sm:hidden">{{
-      headerMenu?.label()
-    }}</span>
-
-    @for (item of headerMenu?.config; track item.id) {
-      @if (item && item.route) {
-        <button type="button" mat-menu-item [routerLink]="item.route">
-          <mat-icon>{{ item.icon }}</mat-icon>
-          <span>{{ item.title }}</span>
-        </button>
-      } @else if (item && item.action) {
-        <button type="button" mat-menu-item (click)="onSendAction(item.action)">
-          <mat-icon>{{ item.icon }}</mat-icon>
-          <span>{{ item.title }}</span>
-        </button>
-      }
-    }
-  </mat-menu>
-</ng-template>
 
 <ng-template #h1Tpl>
   <div class="gap-sub flex items-center justify-center">

--- a/libs/core/cms-layout/feature/src/lib/core-cms-layout-feature/core-cms-layout-feature.component.ts
+++ b/libs/core/cms-layout/feature/src/lib/core-cms-layout-feature/core-cms-layout-feature.component.ts
@@ -14,10 +14,8 @@ import {
   viewChild,
   ViewContainerRef,
 } from '@angular/core';
-import { MatButton } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
-import { MatMenuModule } from '@angular/material/menu';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { PushPipe } from '@ngrx/component';
@@ -25,6 +23,7 @@ import { LayoutFacade, LayoutObserverService } from '@plastik/core/cms-layout/da
 import { CoreCmsLayoutUiFooterComponent } from '@plastik/core/cms-layout/footer';
 import { CoreCmsLayoutUiHeaderComponent } from '@plastik/core/cms-layout/header';
 import { CoreCmsLayoutUiSidenavComponent } from '@plastik/core/cms-layout/sidenav';
+import { CoreCmsLayoutUiUserMenuComponent } from '@plastik/core/cms-layout/user-menu';
 import { SharedActivityUiOverlayComponent } from '@plastik/shared/activity/ui';
 import { notificationStore } from '@plastik/shared/notification/data-access';
 import { NotificationUiMatSnackbarDirective } from '@plastik/shared/notification/ui/mat-snackbar';
@@ -41,12 +40,11 @@ import { NotificationUiMatSnackbarDirective } from '@plastik/shared/notification
     MatListModule,
     MatIconModule,
     MatListModule,
-    MatButton,
-    MatMenuModule,
     AngularSvgIconModule,
     CoreCmsLayoutUiFooterComponent,
     CoreCmsLayoutUiHeaderComponent,
     CoreCmsLayoutUiSidenavComponent,
+    CoreCmsLayoutUiUserMenuComponent,
     SharedActivityUiOverlayComponent,
     NotificationUiMatSnackbarDirective,
   ],

--- a/libs/core/cms-layout/ui/user-menu/.eslintrc.json
+++ b/libs/core/cms-layout/ui/user-menu/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "plastik",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "plastik",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/core/cms-layout/ui/user-menu/jest.config.ts
+++ b/libs/core/cms-layout/ui/user-menu/jest.config.ts
@@ -1,0 +1,23 @@
+/* eslint-disable */
+export default {
+  displayName: 'core-cms-layout-ui-user-menu',
+  preset: '../../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {},
+  coverageDirectory: '../../../../../coverage/libs/core/cms-layout/ui/user-menu',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/core/cms-layout/ui/user-menu/project.json
+++ b/libs/core/cms-layout/ui/user-menu/project.json
@@ -1,0 +1,21 @@
+{
+  "name": "core-cms-layout-ui-user-menu",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/core/cms-layout/ui/user-menu/src",
+  "prefix": "plastik",
+  "tags": ["scope:core", "type:ui"],
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/core/cms-layout/ui/user-menu/jest.config.ts",
+        "tsConfig": "libs/core/cms-layout/ui/user-menu/tsconfig.spec.json"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/core/cms-layout/ui/user-menu/src/index.ts
+++ b/libs/core/cms-layout/ui/user-menu/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/core-cms-layout-ui-user-menu.component';

--- a/libs/core/cms-layout/ui/user-menu/src/lib/core-cms-layout-ui-user-menu.component.html
+++ b/libs/core/cms-layout/ui/user-menu/src/lib/core-cms-layout-ui-user-menu.component.html
@@ -1,0 +1,30 @@
+@let headerMenu = userMenuConfig();
+
+<button
+  mat-button
+  class="gap-tiny flex"
+  [attr.aria-label]="headerMenu?.label?.()"
+  [matMenuTriggerFor]="menu">
+  <span class="hidden sm:block">{{ headerMenu?.label?.() }}</span>
+  <mat-icon class="m-0 size-[30px] p-0 text-[30px]">account_circle</mat-icon>
+</button>
+
+<mat-menu #menu="matMenu" class="px-sub">
+  <span class="p-tiny border-b-gray-10 block w-fit border-b-2 text-balance sm:hidden">{{
+    headerMenu?.label?.()
+  }}</span>
+
+  @for (item of headerMenu?.config; track item.id) {
+    @if (item && item.route) {
+      <button type="button" mat-menu-item [routerLink]="item.route">
+        <mat-icon>{{ item.icon }}</mat-icon>
+        <span>{{ item.title }}</span>
+      </button>
+    } @else if (item && item.action) {
+      <button type="button" mat-menu-item (click)="onSendAction(item.action)">
+        <mat-icon>{{ item.icon }}</mat-icon>
+        <span>{{ item.title }}</span>
+      </button>
+    }
+  }
+</mat-menu>

--- a/libs/core/cms-layout/ui/user-menu/src/lib/core-cms-layout-ui-user-menu.component.spec.ts
+++ b/libs/core/cms-layout/ui/user-menu/src/lib/core-cms-layout-ui-user-menu.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { CoreCmsLayoutUiUserMenuComponent } from './core-cms-layout-ui-user-menu.component';
+
+describe('CoreCmsLayoutUiUserMenuComponent', () => {
+  let component: CoreCmsLayoutUiUserMenuComponent;
+  let fixture: ComponentFixture<CoreCmsLayoutUiUserMenuComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CoreCmsLayoutUiUserMenuComponent],
+      providers: [provideZonelessChangeDetection(), provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CoreCmsLayoutUiUserMenuComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('userMenuConfig', {
+      label: signal('label'),
+      position: 'start',
+      config: [],
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/core/cms-layout/ui/user-menu/src/lib/core-cms-layout-ui-user-menu.component.ts
+++ b/libs/core/cms-layout/ui/user-menu/src/lib/core-cms-layout-ui-user-menu.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { MatButton } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { RouterLink } from '@angular/router';
+import { CoreCmsLayoutHeaderConfig } from '@plastik/core/cms-layout/entities';
+
+@Component({
+  selector: 'plastik-core-cms-layout-ui-user-menu',
+  imports: [MatButton, MatIconModule, MatMenuModule, RouterLink],
+  templateUrl: './core-cms-layout-ui-user-menu.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CoreCmsLayoutUiUserMenuComponent {
+  userMenuConfig = input.required<CoreCmsLayoutHeaderConfig['userMenuConfig']>();
+  sendAction = output<() => void>();
+
+  onSendAction(action: () => void): void {
+    this.sendAction.emit(action);
+  }
+}

--- a/libs/core/cms-layout/ui/user-menu/src/test-setup.ts
+++ b/libs/core/cms-layout/ui/user-menu/src/test-setup.ts
@@ -1,0 +1,4 @@
+import { TestBed } from '@angular/core/testing';
+import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
+
+TestBed.initTestEnvironment([BrowserTestingModule], platformBrowserTesting());

--- a/libs/core/cms-layout/ui/user-menu/tsconfig.json
+++ b/libs/core/cms-layout/ui/user-menu/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "lib": ["dom", "es2022"]
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/core/cms-layout/ui/user-menu/tsconfig.lib.json
+++ b/libs/core/cms-layout/ui/user-menu/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true
+  },
+  "exclude": ["src/test-setup.ts", "src/**/*.spec.ts", "jest.config.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts", "../../entities/src/core-cms-layout-header-config.ts"]
+}

--- a/libs/core/cms-layout/ui/user-menu/tsconfig.spec.json
+++ b/libs/core/cms-layout/ui/user-menu/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../dist/out-tsc",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "isolatedModules": true
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/libs/llecoop/entities/tsconfig.lib.json
+++ b/libs/llecoop/entities/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
+    "composite": true,
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,6 +28,7 @@
       "@plastik/core/cms-layout/footer": ["libs/core/cms-layout/ui/footer/src/index.ts"],
       "@plastik/core/cms-layout/header": ["libs/core/cms-layout/ui/header/src/index.ts"],
       "@plastik/core/cms-layout/sidenav": ["libs/core/cms-layout/ui/sidenav/src/index.ts"],
+      "@plastik/core/cms-layout/user-menu": ["libs/core/cms-layout/ui/user-menu/src/index.ts"],
       "@plastik/core/cypress-commands": ["libs/core/util/cypress-commands/src/index.ts"],
       "@plastik/core/detail-edit-view": ["libs/core/detail-item-form/src/index.ts"],
       "@plastik/core/entities": ["libs/core/entities/src/index.ts"],


### PR DESCRIPTION
Extracted the user menu logic from the core CMS layout feature into a new reusable shared UI component. This involved creating a new Nx library for the component, implementing it with modern Angular features (Signals, @let, @if, @for), and integrating it back into the layout feature.

---
*PR created automatically by Jules for task [9660110877259373343](https://jules.google.com/task/9660110877259373343) started by @plastikaweb*