### PR TITLE
fix(eco-store): #901 restore per-product computed signal in cart store

### DIFF
--- a/.agent/skills/commitizen/SKILL.md
+++ b/.agent/skills/commitizen/SKILL.md
@@ -37,7 +37,7 @@ ${type}/${issue-number}-${short-description}
 
 [optional body]
 
-[optional footer: ISSUES CLOSED: #<issue>]
+[optional footer: CLOSED: #<issue>]
 ```
 
 ### Step 1: Determine Type
@@ -100,10 +100,10 @@ To know if the commit closes an issue, in the case we have an issue number, use 
 If the commit closes an issue:
 
 ```
-ISSUES CLOSED: #<issue-number>
+CLOSED: #<issue-number>
 ```
 
-Multiple issues: `ISSUES CLOSED: #31, #34`
+Multiple issues: `CLOSED: #31, #34`
 
 ### Step 7: Add Changelog Entry (prompt)
 
@@ -172,7 +172,7 @@ git add <files>
 Construct the commit message following the structure above:
 
 ```bash
-git commit -m "<type>(<scope>): #<issue> <description>" -m "<body>" -m "ISSUES CLOSED: #<issue>"
+git commit -m "<type>(<scope>): #<issue> <description>" -m "<body>" -m "CLOSED: #<issue>"
 ```
 
 For simple commits without body:
@@ -189,7 +189,7 @@ git commit -m "<type>(<scope>): #<issue> <description>"
 ```bash
 git commit -m "feat(shared-button): #54 add notifications toggle button" \
   -m "Allow users to toggle particular notifications by app section." \
-  -m "ISSUES CLOSED: #54"
+  -m "CLOSED: #54"
 ```
 
 ## Validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-02-20] - API & Firebase Optimizations
+
+### Changed
+
+- Replaced `getFullList` with `getList(1)` in `getOneBySlug` query to reduce PocketBase API overhead ([#900](https://github.com/plastikaweb/plastikspace/issues/900))
+- Replaced quadratic product aggregation logic with a `Map`-based approach in `onChangeUserOrderUpdateOrderListTotal` Firebase trigger, achieving ~29x speedup
+
+---
+
+## [2026-02-20] - Core User Menu Extraction
+
+### Changed
+
+- Extracted header user menu template into a reusable `CoreCmsLayoutUiUserMenuComponent` with signal-based inputs
+
+---
+
+## [2026-02-20] - Test Infrastructure
+
+### Changed
+
+- Added `IntersectionObserver` mock to `test-setup.ts` across all eco-store libs and app to fix CI failures in Jest
+
+---
+
+## [2026-02-20] - Fix Product Grid Reload on Quantity Change
+
+### Fixed
+
+- Restored `getItemCount()` per-product computed signal in cart store to prevent the entire products grid from re-rendering on each quantity control click ([#901](https://github.com/plastikaweb/plastikspace/issues/901))
+
+---
+
 ## [2026-02-20] - Performance Improvements
 
 ### Changed

--- a/libs/eco-store/cart/data-access/src/eco-store-cart.store.spec.ts
+++ b/libs/eco-store/cart/data-access/src/eco-store-cart.store.spec.ts
@@ -1,5 +1,4 @@
 import { LiveAnnouncer } from '@angular/cdk/a11y';
-import { computed } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { pocketBaseUserProfileStore } from '@plastik/auth/pocketbase/data-access';
@@ -142,10 +141,10 @@ describe('ecoStoreCartStore', () => {
     const store = setup();
     store.addToCart(mockProduct, 5);
 
-    const countSignal = computed(() => store.entityMap()['1']?.quantity ?? 0);
+    const countSignal = store.getItemCount('1');
     expect(countSignal()).toBe(5);
 
-    const countSignalEmpty = computed(() => store.entityMap()['2']?.quantity ?? 0);
+    const countSignalEmpty = store.getItemCount('2');
     expect(countSignalEmpty()).toBe(0);
   });
 });

--- a/libs/eco-store/cart/data-access/src/eco-store-cart.store.ts
+++ b/libs/eco-store/cart/data-access/src/eco-store-cart.store.ts
@@ -393,6 +393,12 @@ export const ecoStoreCartStore = signalStore(
     };
 
     return {
+      getItemCount(productId: EcoStoreProductWithCategoryName['id']) {
+        return computed(() => {
+          return store.entityMap()[productId]?.quantity ?? 0;
+        });
+      },
+
       addToCart(product: EcoStoreProductWithCategoryName, quantity = 1) {
         if (!checkStoreStatus()) return;
         const productId = product.id;

--- a/libs/eco-store/products/feature/list/src/lib/eco-store-products-feature.component.html
+++ b/libs/eco-store/products/feature/list/src/lib/eco-store-products-feature.component.html
@@ -31,7 +31,7 @@
         @for (item of productsStore.productsWithTranslatedText(); track item.id; let i = $index) {
           <eco-store-product-card
             [product]="item"
-            [quantity]="cartStore.entityMap()[item.id]?.quantity || 0"
+            [quantity]="cartStore.getItemCount(item.id)()"
             [isFirst]="i < 6"
             [isOpen]="tenantStore.isStoreOpen()"
             (addToCart)="addToCart($event)"


### PR DESCRIPTION
The getItemCount() method was removed during the #895 performance refactor, replacing it with a direct cartStore.entityMap() binding in the @for template. This caused the entire product grid to re-render on every cart change, since entityMap() is a shared signal covering all cart items. Restored getItemCount() as a withMethods computed factory so each product card tracks only its own item's signal in isolation.

CLOSED: #901