### PR TITLE
feat(eco-store): #86c8r2ar3 add order sorting by status and date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-03-17] - Order Sorting and UI Consistency
+
+### Added
+
+- Implemented order sorting by status and update date in the user's order list ([#86c8r2ar3](https://app.clickup.com/t/86c8r2ar3))
+- Added localized sort labels for orders list across English, Spanish, and Catalan.
+
+### Changed
+
+- Updated `EcoStoreOrdersListComponent` to include the `SortSelectorComponent` and unified the sorting navigation logic ([#86c8r2ar3](https://app.clickup.com/t/86c8r2ar3))
+- Renamed `sortProducts` to `sort` in `EcoStoreProductsFeatureComponent` for better consistency across feature components.
+- Enhanced `EcoStoreOrdersStore` with dynamic sorting options for order status.
+- Updated README files for orders and products features to include sorting capabilities.
+
+### Fixed
+
+- Fixed unit tests for `EcoStoreOrdersListComponent` and `EcoStoreProductsFeatureComponent` by adding missing router context and sort method verification.
+- Fixed unit tests for `EcoStoreOrdersStore` to verify the presence of status sort options.
+
 ## [2026-03-16] - Refactoring, Performance, and Linux Support
 
 ### Added

--- a/apps/eco-store/public/i18n/ca.json
+++ b/apps/eco-store/public/i18n/ca.json
@@ -429,7 +429,14 @@
     },
     "filter": {
       "all": "TOTES",
-      "status": "Estat de la comanda"
+      "status": "Estat de la comanda",
+      "sort": {
+        "label": "Ordenar",
+        "statusAsc": "Estat ascendent",
+        "statusDesc": "Estat descendent",
+        "updatedAsc": "Més antigues",
+        "updatedDesc": "Més recents"
+      }
     }
   },
   "users": {

--- a/apps/eco-store/public/i18n/en.json
+++ b/apps/eco-store/public/i18n/en.json
@@ -426,6 +426,17 @@
       "preparing": "Preparing",
       "ready": "Ready",
       "cancelled": "Cancelled"
+    },
+    "filter": {
+      "all": "ALL",
+      "status": "Order status",
+      "sort": {
+        "label": "Sort",
+        "statusAsc": "Status ascending",
+        "statusDesc": "Status descending",
+        "updatedAsc": "Oldest",
+        "updatedDesc": "Most recent"
+      }
     }
   },
   "users": {

--- a/apps/eco-store/public/i18n/es.json
+++ b/apps/eco-store/public/i18n/es.json
@@ -426,6 +426,17 @@
       "preparing": "Preparando",
       "ready": "Preparado",
       "cancelled": "Cancelado"
+    },
+    "filter": {
+      "all": "TODAS",
+      "status": "Estado del pedido",
+      "sort": {
+        "label": "Ordenar",
+        "statusAsc": "Estado ascendente",
+        "statusDesc": "Estado descendente",
+        "updatedAsc": "Más antiguos",
+        "updatedDesc": "Más recientes"
+      }
     }
   },
   "users": {

--- a/libs/eco-store/orders/data-access/src/eco-store-orders.store.spec.ts
+++ b/libs/eco-store/orders/data-access/src/eco-store-orders.store.spec.ts
@@ -117,6 +117,11 @@ describe('ecoStoreOrdersStore', () => {
     expect(store.isLoading()).toBe(false);
   });
 
+  it('should have status in sortOptions', () => {
+    const store = setup();
+    expect(store.sortOptions()).toHaveProperty('status');
+  });
+
   describe('createOrder()', () => {
     let store: ReturnType<typeof setup>;
     let router: Router;

--- a/libs/eco-store/orders/data-access/src/eco-store-orders.store.ts
+++ b/libs/eco-store/orders/data-access/src/eco-store-orders.store.ts
@@ -32,15 +32,15 @@ export const ecoStoreOrdersStore = signalStore(
         page: 1,
         perPage: 10,
       },
-      sort: {
-        active: 'created',
-        direction: 'desc',
-      },
       filter: {
         status: null,
       } as OrdersPocketBaseFilter,
       sortOptions: {
         ...initialGetListState().sortOptions,
+        status: [
+          { id: 3, direction: 'desc', icon: 'arrow_downward' },
+          { id: 3, direction: 'asc', icon: 'arrow_upward' },
+        ],
       },
       apiRequestDebounceTime: 0,
       isLoading: false,

--- a/libs/eco-store/orders/feature/list/README.md
+++ b/libs/eco-store/orders/feature/list/README.md
@@ -19,6 +19,7 @@ It allows users to view their past orders, their status, total price, and delive
 - **Order History Grid**: Displays a list of user orders with essential information at a glance.
 - **Detailed Order Cards**: Individual cards for each order showing status, date, items count, and delivery method.
 - **Order Filtering**: Allows users to filter their order history by status (Pending, Confirmed, etc.).
+- **Order Sorting**: Allows users to sort their order history by status and date.
 - **State Management**: Integrates with `EcoStoreOrdersStore` for reactive data fetching and pagination.
 - **Pagination**: Support for navigating through order history.
 - **Dynamic Status & Icons**: Visual cues for order status (Pending, Confirmed, Ready, etc.) and delivery methods.

--- a/libs/eco-store/orders/feature/list/src/lib/eco-store-orders-list.component.html
+++ b/libs/eco-store/orders/feature/list/src/lib/eco-store-orders-list.component.html
@@ -16,6 +16,14 @@
         {{ 'orders.list.title' | translate }}
       </h2>
     </div>
+
+    <plastik-sort-selector
+      [class.pointer-events-none]="ordersStore.isLoading()"
+      [class.opacity-60]="ordersStore.isLoading()"
+      [options]="ordersStore.sortOptions()"
+      [currentSort]="ordersStore.sort()"
+      [translationPrefix]="'orders.filter.sort'"
+      (sortChange)="sort($event)"></plastik-sort-selector>
   </div>
 </header>
 

--- a/libs/eco-store/orders/feature/list/src/lib/eco-store-orders-list.component.spec.ts
+++ b/libs/eco-store/orders/feature/list/src/lib/eco-store-orders-list.component.spec.ts
@@ -1,6 +1,6 @@
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { ecoStoreOrdersStore } from '@plastik/eco-store/orders/data-access';
 import { axe } from 'vitest-axe';
@@ -15,6 +15,8 @@ describe('EcoStoreOrdersListComponent', () => {
     entities: signal([]),
     count: signal(0),
     filter: signal({ status: null as string | null }),
+    sort: signal({ active: 'created', direction: 'desc' }),
+    sortOptions: signal({}),
     getPagination: () => ({ page: 1, perPage: 10 }),
     paginationSizeOptions: signal([10, 20]),
   };
@@ -74,5 +76,18 @@ describe('EcoStoreOrdersListComponent', () => {
       '.empty-state [description], .empty-state p.max-w-3xl'
     );
     expect(emptyDesc.textContent).toContain('orders.list.emptyDescriptionWithStatus');
+  });
+
+  it('should navigate when sort is called', () => {
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigate');
+    const sortConfig = { active: 'status', direction: 'asc' };
+
+    component.sort(sortConfig as any);
+
+    expect(navigateSpy).toHaveBeenCalledWith([], {
+      queryParams: { ...sortConfig, page: 0 },
+      queryParamsHandling: 'merge',
+    });
   });
 });

--- a/libs/eco-store/orders/feature/list/src/lib/eco-store-orders-list.component.ts
+++ b/libs/eco-store/orders/feature/list/src/lib/eco-store-orders-list.component.ts
@@ -7,6 +7,7 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Router } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
+import { SortConfig } from '@plastik/core/entities';
 import { ORDER_STATUS_LABEL_MAP } from '@plastik/eco-store/entities';
 import { EcoStoreSharedNoResultsComponent } from '@plastik/eco-store/no-results';
 import { ecoStoreOrdersStore } from '@plastik/eco-store/orders/data-access';
@@ -14,12 +15,12 @@ import { PaginationComponent } from '@plastik/pagination/ui';
 import { PocketbasePaginationNavigationDirective } from '@plastik/pagination/util';
 import { SharedFormFeatureModule } from '@plastik/shared/form';
 import { SelectWithIconsFormlyModule } from '@plastik/shared/form/select-with-icons';
+import { SortSelectorComponent } from '@plastik/sort-selector';
 import {
   EcoStoreOrdersFilterData,
   ecoStoreOrdersFilterFormConfig,
 } from './eco-store-orders-filter-form.config';
 import { OrderCardComponent } from './order-card/order-card.component';
-
 @Component({
   selector: 'eco-store-orders-list',
   imports: [
@@ -36,6 +37,7 @@ import { OrderCardComponent } from './order-card/order-card.component';
     SharedFormFeatureModule,
     SelectWithIconsFormlyModule,
     EcoStoreSharedNoResultsComponent,
+    SortSelectorComponent,
   ],
   templateUrl: './eco-store-orders-list.component.html',
   styleUrl: './eco-store-orders-list.component.scss',
@@ -77,6 +79,13 @@ export default class EcoStoreOrdersListComponent {
   onChange(event: EcoStoreOrdersFilterData): void {
     this.#router.navigate([], {
       queryParams: { ...event, page: 0 },
+      queryParamsHandling: 'merge',
+    });
+  }
+
+  sort(sort: SortConfig) {
+    this.#router.navigate([], {
+      queryParams: { ...sort, page: 0 },
       queryParamsHandling: 'merge',
     });
   }

--- a/libs/eco-store/products/feature/list/README.md
+++ b/libs/eco-store/products/feature/list/README.md
@@ -26,6 +26,7 @@ Part of the [**Eco-Store**](../../../../../apps/eco-store/README.md) application
 - **State Management**: Integrates with [NgRx Signal Store](https://ngrx.io/) for reactive state management.
 - **Performance**: Uses `OnPush` change detection and Angular Signals for optimal rendering performance.
 - **Pagination**: Built-in support for paginated data fetching.
+- **Product Sorting**: Allows users to sort products by price, rating, and date.
 - **Store Status Awareness**: Integrates with `ecoStoreTenantStore` to pass the `isOpen` status to product cards, disabling purchase actions when the store is closed.
 - **Modern Architecture**: Built using Angular Standalone Components.
 - **Lazy Loading**: Uses `enableListLoading()` in resolver for efficient data fetching.

--- a/libs/eco-store/products/feature/list/src/lib/eco-store-products-feature.component.html
+++ b/libs/eco-store/products/feature/list/src/lib/eco-store-products-feature.component.html
@@ -17,7 +17,7 @@
       [options]="productsStore.sortOptions()"
       [currentSort]="productsStore.sort()"
       [translationPrefix]="'products.filter.sort'"
-      (sortChange)="sortProducts($event)"></plastik-sort-selector>
+      (sortChange)="sort($event)"></plastik-sort-selector>
   </div>
 </header>
 

--- a/libs/eco-store/products/feature/list/src/lib/eco-store-products-feature.component.spec.ts
+++ b/libs/eco-store/products/feature/list/src/lib/eco-store-products-feature.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
 import { POCKETBASE_INSTANCE } from '@plastik/core/api-pocketbase';
 import { mockPocketBase } from '@plastik/core/api-pocketbase/testing';
@@ -44,4 +44,17 @@ describe('EcoStoreProductsFeature', () => {
     const results = await axe(fixture.nativeElement);
     expect(results).toHaveNoViolations();
   }, 10000);
+
+  it('should navigate when sort is called', () => {
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigate');
+    const sortConfig = { active: 'priceWithIva', direction: 'asc' };
+
+    component.sort(sortConfig as any);
+
+    expect(navigateSpy).toHaveBeenCalledWith([], {
+      queryParams: { ...sortConfig, page: 0 },
+      queryParamsHandling: 'merge',
+    });
+  });
 });

--- a/libs/eco-store/products/feature/list/src/lib/eco-store-products-feature.component.ts
+++ b/libs/eco-store/products/feature/list/src/lib/eco-store-products-feature.component.ts
@@ -108,7 +108,7 @@ export default class EcoStoreProductsFeatureComponent {
    * Navigates to the product list with updated sorting parameters.
    * @param { SortConfig } sort The new sort configuration.
    */
-  sortProducts(sort: SortConfig) {
+  sort(sort: SortConfig) {
     this.#router.navigate([], {
       queryParams: { ...sort, page: 0 },
       queryParamsHandling: 'merge',

--- a/libs/shared/sort-selector/src/lib/sort-selector/sort-selector.component.ts
+++ b/libs/shared/sort-selector/src/lib/sort-selector/sort-selector.component.ts
@@ -10,6 +10,7 @@ type SortSelectorKeyValueFn = (
   a: KeyValue<string, SortMenuItem[]>,
   b: KeyValue<string, SortMenuItem[]>
 ) => number;
+
 @Component({
   selector: 'plastik-sort-selector',
 


### PR DESCRIPTION
Implement sorting functionality in the orders list feature, allowing users to sort their past orders by status and date. Unified sorting logic between orders and products features. Added missing translations and updated specs and READMEs.

CLOSED: #86c8r2ar3