### PR TITLE
fix(eco-store): fix staging data seeding with hook bypass and relatio…

### DIFF
--- a/apps/eco-store/.env-example
+++ b/apps/eco-store/.env-example
@@ -1,0 +1,13 @@
+# PocketBase Configuration
+# By default use environment.staging.ts
+# Changing: export POCKETBASE_ENV=development (o staging, production)
+
+# Credentials for LOCAL PocketBase (development)
+POCKETBASE_DEV_URL=
+POCKETBASE_DEV_ADMIN_EMAIL=
+POCKETBASE_DEV_ADMIN_PASSWORD=
+
+# Credentials for REMOTE PocketBase (staging/production)
+POCKETBASE_STAGING_URL=
+POCKETBASE_STAGING_ADMIN_EMAIL=
+POCKETBASE_STAGING_ADMIN_PASSWORD=

--- a/apps/eco-store/pocketbase/pb_hooks/on_create_order.pb.js
+++ b/apps/eco-store/pocketbase/pb_hooks/on_create_order.pb.js
@@ -4,6 +4,11 @@
 // 1. BEFORE CREATE REQUEST (Assign Cycle and Prevent Duplicates)
 // =================================================================
 onRecordCreateRequest((e) => {
+    // Skip hooks if bypass header is present (used during seeding/import)
+    if (e.httpContext && e.httpContext.request().header.get("x-bypass-hooks") === "true") {
+        return e.next();
+    }
+
     const order = e.record;
     const tenantId = order.get("tenant");
     const userId = order.get("user");

--- a/apps/eco-store/pocketbase/pb_hooks/single_default_address.js
+++ b/apps/eco-store/pocketbase/pb_hooks/single_default_address.js
@@ -1,7 +1,7 @@
 /// <reference path="../pb_data/types.d.ts" />
 
 // Auxiliary function to ensure that only one address can be set as default per user
-function ensureSingleDefaultAddress(record) {
+function ensureSingleDefaultAddress(record, app) {
     // 1. If the address being saved is not "default", do nothing.
     if (!record.getBool('default')) {
         return;
@@ -13,7 +13,7 @@ function ensureSingleDefaultAddress(record) {
     // 2. Search for all other addresses of this user that are 'default'
     // Exclude the one we are touching now (id != currentId)
     try {
-        const otherDefaults = $app.findRecordsByFilter(
+        const otherDefaults = app.findRecordsByFilter(
             "user_addresses",
             `user = {:user} && default = true && id != {:id}`,
             { user: userId, id: currentId }
@@ -22,7 +22,7 @@ function ensureSingleDefaultAddress(record) {
         // 3. Loop through the other defaults and set them to false
         for (const other of otherDefaults) {
             other.set('default', false);
-            $app.save(other); // Save the change without triggering recursive hooks
+            app.save(other); // Save the change without triggering recursive hooks
         }
     } catch (err) {
         // Log error in case of failure
@@ -32,12 +32,22 @@ function ensureSingleDefaultAddress(record) {
 
 // Hook before creating an address
 onRecordCreateRequest((e) => {
-    ensureSingleDefaultAddress(e.record);
+    // Skip hooks if bypass header is present (used during seeding/import)
+    if (e.httpContext && e.httpContext.request().header.get("x-bypass-hooks") === "true") {
+        return e.next();
+    }
+
+    ensureSingleDefaultAddress(e.record, e.app);
     return e.next();
 }, "user_addresses");
 
 // Hook before updating an address
 onRecordUpdateRequest((e) => {
-    ensureSingleDefaultAddress(e.record);
+    // Skip hooks if bypass header is present (used during seeding/import)
+    if (e.httpContext && e.httpContext.request().header.get("x-bypass-hooks") === "true") {
+        return e.next();
+    }
+
+    ensureSingleDefaultAddress(e.record, e.app);
     return e.next();
 }, "user_addresses");

--- a/apps/eco-store/scripts/seed-local.js
+++ b/apps/eco-store/scripts/seed-local.js
@@ -44,6 +44,12 @@ async function pullCollection(collectionName) {
 
     // Get collection info to find file fields
     const collectionInfo = await pbStaging.collections.getOne(collectionName);
+
+    if (collectionInfo.type === 'view') {
+      console.log(`   ⏭️ Skipping ${collectionName} (view collection is read-only).`);
+      return;
+    }
+
     const fileFields = collectionInfo.fields.filter(f => f.type === 'file');
 
     for (const record of records) {
@@ -112,23 +118,44 @@ async function pullCollection(collectionName) {
 
         const payload = hasFiles ? formData : data;
 
+        // If it's an auth collection (like 'users'), we might need to provide a password
+        // because it's required in the schema but not returned by staging API.
+        if (collectionName === 'users' && !exists) {
+          if (!data.password) {
+            data.password = 'seed-password-123';
+            data.passwordConfirm = 'seed-password-123';
+          }
+        }
+
+        const options = {
+          headers: {
+            'x-bypass-hooks': 'true',
+          },
+        };
+
         if (exists) {
           console.log(`   Updating local record ${recordId}...`);
-          await pbLocal.collection(collectionName).update(recordId, payload);
+          await pbLocal.collection(collectionName).update(recordId, payload, options);
         } else {
           console.log(`   Creating local record ${recordId}...`);
-          await pbLocal.collection(collectionName).create(payload);
+          await pbLocal.collection(collectionName).create(payload, options);
         }
       } catch (err) {
         console.error(
           `   ❌ Error processing record ${recordId} in ${collectionName}:`,
           err.message
         );
+        if (err.response?.data) {
+          console.error('      Details:', JSON.stringify(err.response.data, null, 2));
+        }
       }
     }
     console.log(`   ✅ Finished pulling ${collectionName}.`);
   } catch (err) {
     console.error(`   ❌ Failed to fetch from staging collection ${collectionName}:`, err.message);
+    if (err.response?.data) {
+      console.error('      Details:', JSON.stringify(err.response.data, null, 2));
+    }
   }
 }
 
@@ -164,11 +191,11 @@ async function run() {
       'product_categories',
       'tags',
       'products',
+      'users',
       'user_addresses',
       'tenant_addresses',
       'product_categories_stats',
       'order_cycles',
-      'users',
       'carts',
       'orders',
     ];


### PR DESCRIPTION
…n ordering

- Corrected collection pull order to ensure relational integrity (users before user_addresses)
- Implemented x-bypass-hooks header in seed-local.js to prevent interference from PocketBase hooks
- Updated on_create_order.pb.js and single_default_address.js hooks to respect the bypass header
- Added default credentials (password/passwordConfirm) for newly created auth records
- Enhanced error logging with full response details for easier debugging