### PR TITLE
fix(eco-store): add robots.txt to fix lighthouse seo error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-03-24] - Eco-Store: SEO Optimization & PWA Navigation
+
+### Added
+
+- **PWA Standalone Navigation**: Implemented a conditional "Back" button for the login view in PWA standalone mode to ensure iOS users can navigate back to the store.
+- **Centralized PWA Detection**: Created `PwaNavigationService` to reliably detect standalone mode across the application with iOS fallbacks.
+- **Documentation & Testing**: Added README documentation and comprehensive unit tests for `PwaNavigationService` and updated tests for the login component navigation.
+
+### Fixed
+
+- **SEO Robots Configuration**: Added `robots.txt` to properly manage web crawler access and prevent indexing of private routes like cart and orders. Fixed Lighthouse error where `robots.txt` was returning HTML content.
+- **Theme Color Consistency**: Updated `manifest.webmanifest` theme and background colors to match the brand's primary organic aesthetic.
+
 ## [2026-03-24] - Eco-Store: Layout Refinement and Global UX Polish
 
 ### Added

--- a/apps/eco-store/public/manifest.webmanifest
+++ b/apps/eco-store/public/manifest.webmanifest
@@ -42,8 +42,8 @@
       "type": "image/png"
     }
   ],
-  "theme_color": "#FFFEFA",
-  "background_color": "#FFFEFA",
+  "theme_color": "#f8faf0",
+  "background_color": "#f8faf0",
   "display": "standalone",
   "start_url": "/"
 }

--- a/apps/eco-store/public/robots.txt
+++ b/apps/eco-store/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /accedir
+Disallow: /comandes
+Disallow: /cistella
+Allow: /

--- a/libs/eco-store/auth/feature/login/README.md
+++ b/libs/eco-store/auth/feature/login/README.md
@@ -23,8 +23,12 @@ It integrates with the shared authentication infrastructure and provides a user-
 - **Password Visibility**: Includes a toggle to show/hide password text.
 - **Authentication Guards**: Integrated with `pocketBaseIsNotLoggedGuard` to prevent access if already logged in.
 - **Material Design**: Built with Angular Material components (`MatCard`, `MatButton`, etc.).
-- **Internationalization**: Supports translation via `@ngx-translate/core`. The login route uses a `title: 'auth.login.title'` key resolved reactively by `EcoStorePrefixTitleService`.
+- **Internationalization**: Supports translation via `@ngx-translate/core`. The login route uses a
+  `title: 'auth.login.title'` key resolved reactively by `EcoStorePrefixTitleService`.
 - **Tenant Branding**: Dynamically displays the tenant's logo, name, and slogan.
+- **PWA Standalone Navigation**: Includes a conditional "Back" button for iOS users running the app in
+  standalone mode, ensuring they can navigate back to the store even when the browser's native navigation
+  bar is hidden.
 
 ## Installation
 

--- a/libs/eco-store/auth/feature/login/src/lib/eco-store-auth-login/eco-store-auth-login.component.html
+++ b/libs/eco-store/auth/feature/login/src/lib/eco-store-auth-login/eco-store-auth-login.component.html
@@ -3,6 +3,19 @@
   @let tenantName = tenant()?.name;
   @let tenantLogo = tenant()?.logo;
 
+  <!-- PWA Standalone back button -->
+  @if (isStandalone()) {
+    <div class="absolute top-6 left-6 z-50">
+      <button
+        mat-icon-button
+        aria-label="Tornar enrere"
+        class="bg-surface-container/30 hover:bg-surface-container/50 text-on-surface-variant! backdrop-blur-md transition-colors"
+        (click)="goBack()">
+        <mat-icon>arrow_back</mat-icon>
+      </button>
+    </div>
+  }
+
   <mat-card
     appearance="raised"
     class="bg-surface-container-low/80 w-full max-w-[450px] overflow-hidden border-none! shadow-2xl! backdrop-blur-xl"

--- a/libs/eco-store/auth/feature/login/src/lib/eco-store-auth-login/eco-store-auth-login.component.spec.ts
+++ b/libs/eco-store/auth/feature/login/src/lib/eco-store-auth-login/eco-store-auth-login.component.spec.ts
@@ -7,6 +7,8 @@ import { AUTH_FORM_FACADE } from '@plastik/auth/entities';
 import { pocketBaseUserProfileStore } from '@plastik/auth/pocketbase/data-access';
 import { mockPocketBaseUserProfileStore } from '@plastik/auth/pocketbase/data-access/testing';
 import { provideEnvironmentPocketBaseTranslationMock } from '@plastik/core/environments/testing';
+import { NavigationService } from '@plastik/core/router-state';
+import { PwaNavigationService } from '@plastik/eco-store/shared/utils';
 import { ecoStoreTenantStore } from '@plastik/eco-store/tenant';
 import { mockEcoStoreTenantStore } from '@plastik/eco-store/tenant/testing';
 import { EcoStoreAuthLoginComponent } from './eco-store-auth-login.component';
@@ -14,6 +16,7 @@ import { EcoStoreAuthLoginComponent } from './eco-store-auth-login.component';
 describe('EcoStoreAuthLoginComponent', () => {
   let component: EcoStoreAuthLoginComponent;
   let fixture: ComponentFixture<EcoStoreAuthLoginComponent>;
+  let navigationService: NavigationService;
 
   const authFacadeMock = {
     formConfig: {
@@ -22,6 +25,14 @@ describe('EcoStoreAuthLoginComponent', () => {
     },
     extraLinks: signal([]),
     onSubmit: vi.fn(),
+  };
+
+  const navigationServiceMock = {
+    back: vi.fn(),
+  };
+
+  const pwaNavigationServiceMock = {
+    isStandalone: signal(false),
   };
 
   beforeEach(async () => {
@@ -33,16 +44,31 @@ describe('EcoStoreAuthLoginComponent', () => {
         { provide: AUTH_FORM_FACADE, useValue: authFacadeMock },
         { provide: pocketBaseUserProfileStore, useValue: mockPocketBaseUserProfileStore },
         { provide: ecoStoreTenantStore, useValue: mockEcoStoreTenantStore },
+        { provide: NavigationService, useValue: navigationServiceMock },
+        { provide: PwaNavigationService, useValue: pwaNavigationServiceMock },
         { provide: IMAGE_LOADER, useValue: (src: string) => src },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(EcoStoreAuthLoginComponent);
     component = fixture.componentInstance;
+    navigationService = TestBed.inject(NavigationService);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call navigationService.back when goBack is called', () => {
+    // Access protected method via any or by making it public for test
+    (component as any).goBack();
+    expect(navigationService.back).toHaveBeenCalledWith('/botiga');
+  });
+
+  it('should have isStandalone signal reflecting pwaNavigationService', () => {
+    expect(component.isStandalone()).toBe(false);
+    pwaNavigationServiceMock.isStandalone.set(true);
+    expect(component.isStandalone()).toBe(true);
   });
 });

--- a/libs/eco-store/auth/feature/login/src/lib/eco-store-auth-login/eco-store-auth-login.component.ts
+++ b/libs/eco-store/auth/feature/login/src/lib/eco-store-auth-login/eco-store-auth-login.component.ts
@@ -7,7 +7,8 @@ import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { AUTH_FORM_FACADE } from '@plastik/auth/entities';
 import { pocketBaseUserProfileStore } from '@plastik/auth/pocketbase/data-access';
-import { PocketBaseImageUrlPipe } from '@plastik/eco-store/shared/utils';
+import { NavigationService } from '@plastik/core/router-state';
+import { PocketBaseImageUrlPipe, PwaNavigationService } from '@plastik/eco-store/shared/utils';
 import { ecoStoreTenantStore } from '@plastik/eco-store/tenant';
 import { SharedFormFeatureModule } from '@plastik/shared/form';
 import { PasswordWithVisibilityFormlyModule } from '@plastik/shared/form/password';
@@ -36,4 +37,12 @@ export class EcoStoreAuthLoginComponent {
   protected readonly facade = inject(AUTH_FORM_FACADE);
   protected readonly profileStore = inject(pocketBaseUserProfileStore);
   protected readonly tenantStore = inject(ecoStoreTenantStore);
+  protected readonly navigationService = inject(NavigationService);
+  protected readonly pwaNavigationService = inject(PwaNavigationService);
+
+  readonly isStandalone = this.pwaNavigationService.isStandalone;
+
+  protected goBack(): void {
+    this.navigationService.back('/botiga');
+  }
 }

--- a/libs/eco-store/shared/utils/README.md
+++ b/libs/eco-store/shared/utils/README.md
@@ -15,23 +15,49 @@
 
 ## Description
 
-Utility helpers shared across Eco-Store libraries. Currently includes a localized unit formatter pipe for product units.
+Utility helpers shared across Eco-Store libraries. Includes localized unit formatter pipes and PWA
+navigation utilities.
 
 ## Features
 
-- `HumanizeUnitPipe`: Formats numeric values with unit-aware suffixes (`kg`, `g`, `L`, `mL`) based on the `ProductUnitType`.
+- `HumanizeUnitPipe`: Formats numeric values with unit-aware suffixes (`kg`, `g`, `L`, `mL`) based
+  on the `ProductUnitType`.
+- `PocketBaseImageUrlPipe`: Transforms PocketBase image metadata into valid URL fragments.
+- `PwaNavigationService`: Provides reliable detection of PWA standalone mode with fallbacks for iOS devices.
 - Locale-aware number formatting using `Intl.NumberFormat` and the current language from `@ngx-translate/core`.
-- Standalone Angular pipe for easy import in components.
+- Standalone Angular pipes and services for easy import in components.
 
 ## Installation
 
 This library is part of the `@plastik/eco-store` scope and is available via workspace path alias:
 
 ```ts
-import { HumanizeUnitPipe } from '@plastik/eco-store/shared/utils';
+import { HumanizeUnitPipe, PwaNavigationService } from '@plastik/eco-store/shared/utils';
 ```
 
 ## Usage
+
+### PwaNavigationService
+
+Inject the service to detect if the application is running in standalone mode (PWA).
+
+```ts
+import { Component, inject } from '@angular/core';
+import { PwaNavigationService } from '@plastik/eco-store/shared/utils';
+
+@Component({
+  selector: 'demo-pwa-nav',
+  template: `
+    @if (isStandalone()) {
+      <button (click)="goBack()">Back</button>
+    }
+  `,
+})
+export class DemoPwaNavComponent {
+  private pwaNavigationService = inject(PwaNavigationService);
+  readonly isStandalone = this.pwaNavigationService.isStandalone;
+}
+```
 
 ### HumanizeUnitPipe
 
@@ -62,11 +88,13 @@ export class DemoHumanizeUnitComponent {}
 The pipe accepts:
 
 - `value: number | null | undefined`
-- `unitType: ProductUnitType` (`'weight' | 'volume' | 'unit' | 'unitWithFixedWeight' | 'unitWithVariableWeight' | 'unitWithFixedVolume' | 'unitWithVariableVolume'`)
+- `unitType: ProductUnitType` (`'weight' | 'volume' | 'unit' | 'unitWithFixedWeight' |
+'unitWithVariableWeight' | 'unitWithFixedVolume' | 'unitWithVariableVolume'`)
 
 ### PocketBaseImageUrlPipe
 
-Transforms a source object (containing `id` and `collectionId`) and an image filename into a PocketBase URL fragment.
+Transforms a source object (containing `id` and `collectionId`) and an image filename into a
+PocketBase URL fragment.
 
 ```ts
 import { Component, signal } from '@angular/core';

--- a/libs/eco-store/shared/utils/src/index.ts
+++ b/libs/eco-store/shared/utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './humanize-unit.pipe';
 export * from './pocketbase-image-url.pipe';
+export * from './pwa-navigation.service';

--- a/libs/eco-store/shared/utils/src/pwa-navigation.service.spec.ts
+++ b/libs/eco-store/shared/utils/src/pwa-navigation.service.spec.ts
@@ -1,0 +1,91 @@
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { Platform } from '@angular/cdk/platform';
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { PwaNavigationService } from './pwa-navigation.service';
+
+describe('PwaNavigationService', () => {
+  let service: PwaNavigationService;
+  let breakpointObserver: BreakpointObserver;
+  let platform: Platform;
+
+  beforeEach(() => {
+    const breakpointObserverMock = {
+      observe: vi.fn().mockReturnValue(of({ matches: false })),
+    };
+
+    const platformMock = {
+      IOS: false,
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        PwaNavigationService,
+        { provide: BreakpointObserver, useValue: breakpointObserverMock },
+        { provide: Platform, useValue: platformMock },
+      ],
+    });
+
+    service = TestBed.inject(PwaNavigationService);
+    breakpointObserver = TestBed.inject(BreakpointObserver);
+    platform = TestBed.inject(Platform);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return false for isStandalone when not in standalone mode', () => {
+    expect(service.isStandalone()).toBe(false);
+  });
+
+  it('should return true for isStandalone when media query matches', () => {
+    vi.spyOn(breakpointObserver, 'observe').mockReturnValue(of({ matches: true, breakpoints: {} }));
+
+    // Re-inject or re-create service to pick up the new mock if needed,
+    // but since it's a signal based on an observable, it should update.
+    // In this case, toSignal will pick up the initial value of the new observable.
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        PwaNavigationService,
+        {
+          provide: BreakpointObserver,
+          useValue: { observe: () => of({ matches: true, breakpoints: {} }) },
+        },
+        { provide: Platform, useValue: { IOS: false } },
+      ],
+    });
+    service = TestBed.inject(PwaNavigationService);
+
+    expect(service.isStandalone()).toBe(true);
+  });
+
+  it('should return true for isStandalone when on iOS and window.navigator.standalone is true', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        PwaNavigationService,
+        {
+          provide: BreakpointObserver,
+          useValue: { observe: () => of({ matches: false, breakpoints: {} }) },
+        },
+        { provide: Platform, useValue: { IOS: true } },
+      ],
+    });
+
+    // Mock window.navigator.standalone
+    const originalNavigator = window.navigator;
+    const navigatorSpy = vi.spyOn(window, 'navigator', 'get');
+    navigatorSpy.mockReturnValue({
+      ...originalNavigator,
+      standalone: true,
+    } as any);
+
+    service = TestBed.inject(PwaNavigationService);
+
+    expect(service.isStandalone()).toBe(true);
+
+    navigatorSpy.mockRestore();
+  });
+});

--- a/libs/eco-store/shared/utils/src/pwa-navigation.service.ts
+++ b/libs/eco-store/shared/utils/src/pwa-navigation.service.ts
@@ -1,0 +1,31 @@
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { Platform } from '@angular/cdk/platform';
+import { inject, Injectable } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PwaNavigationService {
+  protected readonly breakpointObserver = inject(BreakpointObserver);
+  protected readonly platform = inject(Platform);
+
+  /**
+   * @description Detect if the application is running in standalone mode (PWA).
+   * It also includes a fallback for older iOS versions.
+   */
+  readonly isStandalone = toSignal(
+    this.breakpointObserver.observe('(display-mode: standalone)').pipe(
+      map(result => {
+        const isIosStandalone =
+          this.platform.IOS &&
+          typeof window !== 'undefined' &&
+          'standalone' in window.navigator &&
+          window.navigator['standalone'];
+        return result.matches || isIosStandalone;
+      })
+    ),
+    { initialValue: false }
+  );
+}


### PR DESCRIPTION
Correctly configure robots.txt to prevent indexing of private paths and resolve valid Lighthouse audit failure. Also update manifest.webmanifest theme colors for brand consistency and remove unused tailwind config backup.