### PR TITLE
feat(eco-store): #86c8z1v9g implement reset entities and pocketbase s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-03-27] - Eco-Store: Implement Reset Entities and PocketBase Signal State Improvements
+
+### Added
+
+- **Signal State Reset Library**: Created `@plastik/signal-state/reset` to centralize store state resetting logic ([#86c8z1v9g](https://app.clickup.com/t/86c8z1v9g)).
+  - Features: `withResetEntities` signal store feature for complete state and entity removal.
+
+### Changed
+
+- **PocketBase Store Features**: Updated `withPocketBaseListFeature`, `withPocketBaseCrud`, and `withPocketBaseGet` to support an `autoLoad` parameter (boolean or function) and a `loaded` state flag ([#86c8z1v9g](https://app.clickup.com/t/86c8z1v9g)).
+- **Store Refactoring**:
+  - `ecoStoreCartStore`: Replaced manual reset logic with `withResetEntities`.
+  - `ecoStoreOrdersStore`: Integrated `withPocketBaseCrud` with `autoLoad` based on authentication state.
+- **UI Components**:
+  - `EcoMenuComponent` & `EcoMobileNavComponent`: Improved signal usage for cart data and modernized logout navigation logic.
+  - `useCartBumpAnimation`: Refactored to accept individual signals for better reactivity and reduced dependency on the full store.
+
 ## [2026-03-26] - CSS Compatibility: Fix Styles in Old Systems and Browsers
 
 ### Fixed

--- a/libs/eco-store/auth/feature/login/src/index.ts
+++ b/libs/eco-store/auth/feature/login/src/index.ts
@@ -1,3 +1,2 @@
 export * from './lib/eco-store-auth-feature-login.routes';
-
 export * from './lib/eco-store-auth-login/eco-store-auth-login.component';

--- a/libs/eco-store/cart/data-access/src/eco-store-cart.store.ts
+++ b/libs/eco-store/cart/data-access/src/eco-store-cart.store.ts
@@ -36,6 +36,7 @@ import { EcoStoreProductsApiService } from '@plastik/eco-store/products/data-acc
 import { getPocketBaseImageUrl } from '@plastik/eco-store/shared/utils';
 import { ecoStoreTenantStore } from '@plastik/eco-store/tenant';
 import { StoreNotificationService } from '@plastik/shared/notification/data-access';
+import { withResetEntities } from '@plastik/signal-state/reset';
 import { catchError, firstValueFrom, of, take } from 'rxjs';
 import { EcoStoreCartsApiService } from './eco-store-carts-api.service';
 
@@ -84,10 +85,10 @@ const initialState: EcoStoreCartState = {
 };
 
 export const ecoStoreCartStore = signalStore(
-  { providedIn: 'root' },
   isDevMode() ? withDevtools('cart') : withDevToolsStub('cart'),
   withImmutableState<EcoStoreCartState>(initialState),
   withEntities<EcoStoreCartItem>(),
+  withResetEntities('cart', { isSynced: true }),
   withProps(() => ({
     _userProfileStore: inject(pocketBaseUserProfileStore),
     _cartsService: inject(EcoStoreCartsApiService),
@@ -533,15 +534,6 @@ export const ecoStoreCartStore = signalStore(
           tax: store.tax(),
           total: store.total(),
         };
-      },
-
-      resetCartAfterCheckout() {
-        updateState(
-          store,
-          '[cart] reset after checkout',
-          state => ({ ...state, ...initialState, isSynced: true }),
-          removeAllEntities()
-        );
       },
     };
   }),

--- a/libs/eco-store/cart/data-access/tsconfig.lib.json
+++ b/libs/eco-store/cart/data-access/tsconfig.lib.json
@@ -24,6 +24,9 @@
     },
     {
       "path": "../../core/api/data-access"
+    },
+    {
+      "path": "../../../shared/signal-state/data-reset"
     }
   ],
   "compilerOptions": {

--- a/libs/eco-store/cart/data-access/tsconfig.spec.json
+++ b/libs/eco-store/cart/data-access/tsconfig.spec.json
@@ -44,6 +44,9 @@
     },
     {
       "path": "../../../core/util/environments"
+    },
+    {
+      "path": "../../../shared/signal-state/data-reset"
     }
   ],
   "include": [

--- a/libs/eco-store/core/layout/src/layout.component.spec.ts
+++ b/libs/eco-store/core/layout/src/layout.component.spec.ts
@@ -6,11 +6,15 @@ import { mockPocketBaseUserProfileStore } from '@plastik/auth/pocketbase/data-ac
 import { POCKETBASE_INSTANCE } from '@plastik/core/api-pocketbase';
 import { mockPocketBase } from '@plastik/core/api-pocketbase/testing';
 import { provideEnvironmentPocketBaseTranslationMock } from '@plastik/core/environments/testing';
+import { ecoStoreCartStore } from '@plastik/eco-store/cart/data-access';
+import { mockEcoStoreCartStore } from '@plastik/eco-store/cart/data-access/testing';
 import { EcoStoreFormlyModule } from '@plastik/eco-store/formly';
 import { ecoStoreTenantStore } from '@plastik/eco-store/tenant';
 import { mockEcoStoreTenantStore } from '@plastik/eco-store/tenant/testing';
+import { activityStore } from '@plastik/shared/activity/data-access';
 import { CountdownService } from '@plastik/shared/countdown/util';
 import { LanguageSwitcherService } from '@plastik/shared/translation';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { axe } from 'vitest-axe';
 import { EcoFooterComponent } from './footer/footer.component';
 import { EcoHeaderComponent } from './header/header.component';
@@ -50,9 +54,14 @@ describe('LayoutComponent', () => {
           useValue: mockEcoStoreTenantStore,
         },
         {
+          provide: ecoStoreCartStore,
+          useValue: mockEcoStoreCartStore,
+        },
+        {
           provide: pocketBaseUserProfileStore,
           useValue: mockPocketBaseUserProfileStore,
         },
+        activityStore,
         {
           provide: CountdownService,
           useValue: {

--- a/libs/eco-store/core/layout/src/layout.routes.ts
+++ b/libs/eco-store/core/layout/src/layout.routes.ts
@@ -6,6 +6,8 @@ import { MAT_ICON_DEFAULT_OPTIONS } from '@angular/material/icon';
 import { MatPaginatorIntl } from '@angular/material/paginator';
 import { MatPaginatorIntlService } from '@plastik/core/paginator';
 import { EcoStoreCategoryRouteTitleService } from '@plastik/eco-store/core/router-state';
+import { ecoStoreCartStore } from '@plastik/eco-store/cart/data-access';
+import { ecoStoreOrdersStore } from '@plastik/eco-store/orders/data-access';
 import { BodyBackgroundService } from './body-background.service';
 import { EcoStoreLayoutService } from './eco-store-layout.service';
 import EcoLayoutComponent from './layout.component';
@@ -15,6 +17,8 @@ export const layoutRoutes: Route[] = [
     path: '',
     component: EcoLayoutComponent,
     providers: [
+      ecoStoreCartStore,
+      ecoStoreOrdersStore,
       provideEnvironmentInitializer(() => {
         inject(BodyBackgroundService);
         inject(EcoStoreLayoutService);

--- a/libs/eco-store/core/layout/src/menu/menu.component.spec.ts
+++ b/libs/eco-store/core/layout/src/menu/menu.component.spec.ts
@@ -1,11 +1,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
+import { pocketBaseUserProfileStore } from '@plastik/auth/pocketbase/data-access';
+import { mockPocketBaseUserProfileStore } from '@plastik/auth/pocketbase/data-access/testing';
 import { POCKETBASE_INSTANCE } from '@plastik/core/api-pocketbase';
 import { mockPocketBase } from '@plastik/core/api-pocketbase/testing';
 import { provideEnvironmentPocketBaseTranslationMock } from '@plastik/core/environments/testing';
+import { ecoStoreCartStore } from '@plastik/eco-store/cart/data-access';
+import { mockEcoStoreCartStore } from '@plastik/eco-store/cart/data-access/testing';
 import { ecoStoreTenantStore } from '@plastik/eco-store/tenant';
 import { mockEcoStoreTenantStore } from '@plastik/eco-store/tenant/testing';
+import { describe, expect, it, beforeEach } from 'vitest';
 import { axe } from 'vitest-axe';
 import { EcoMenuComponent } from './menu.component';
 
@@ -27,6 +32,14 @@ describe('MenuComponent', () => {
         {
           provide: ecoStoreTenantStore,
           useValue: mockEcoStoreTenantStore,
+        },
+        {
+          provide: ecoStoreCartStore,
+          useValue: mockEcoStoreCartStore,
+        },
+        {
+          provide: pocketBaseUserProfileStore,
+          useValue: mockPocketBaseUserProfileStore,
         },
       ],
     }).compileComponents();

--- a/libs/eco-store/core/layout/src/menu/menu.component.ts
+++ b/libs/eco-store/core/layout/src/menu/menu.component.ts
@@ -45,20 +45,18 @@ import { useCartBumpAnimation } from '../utils/cart-bump-animation.util';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EcoMenuComponent {
-  readonly router = inject(Router);
-  readonly cartStore = inject(ecoStoreCartStore);
-  readonly profileStore = inject(pocketBaseUserProfileStore);
-  readonly primaryMenu = viewChild.required<TemplateRef<unknown>>('primaryMenu');
-  readonly secondaryMenu = viewChild.required<TemplateRef<unknown>>('secondaryMenu');
-  readonly userMenuComponent = viewChild<EcoUserMenuComponent>('userMenuComponent');
+  readonly #router = inject(Router);
+  protected readonly cartStore = inject(ecoStoreCartStore);
+  protected readonly profileStore = inject(pocketBaseUserProfileStore);
+  protected readonly userMenuComponent = viewChild<EcoUserMenuComponent>('userMenuComponent');
 
   protected readonly currentUrl = toSignal(
-    this.router.events.pipe(
+    this.#router.events.pipe(
       filter(event => event instanceof NavigationEnd),
       map(event => (event as NavigationEnd).urlAfterRedirects),
-      startWith(this.router.url)
+      startWith(this.#router.url)
     ),
-    { initialValue: this.router.url }
+    { initialValue: this.#router.url }
   );
 
   protected readonly roleIcon = computed(() => {
@@ -75,18 +73,22 @@ export class EcoMenuComponent {
     }
   });
 
-  protected readonly bumpAnimation = useCartBumpAnimation(this.cartStore);
+  protected readonly bumpAnimation = useCartBumpAnimation(
+    this.cartStore.subtotal,
+    this.cartStore.tax
+  );
+
+  readonly primaryMenu = viewChild.required<TemplateRef<unknown>>('primaryMenu');
+  readonly secondaryMenu = viewChild.required<TemplateRef<unknown>>('secondaryMenu');
 
   login() {
     if (!this.profileStore.isAuthenticated()) {
-      this.router.navigate(['/accedir']);
+      this.#router.navigate(['/accedir']);
     }
   }
 
   logout() {
     this.profileStore.logout();
-    if (!this.profileStore.isAuthenticated()) {
-      this.router.navigate(['/accedir']);
-    }
+    this.#router.navigate(['/accedir']);
   }
 }

--- a/libs/eco-store/core/layout/src/mobile-nav/mobile-nav.component.html
+++ b/libs/eco-store/core/layout/src/mobile-nav/mobile-nav.component.html
@@ -26,7 +26,7 @@
     >
   </eco-mobile-nav-item>
 
-  <eco-mobile-nav-item routerLink="/favorits" [label]="'store.menu.viewFavorites' | translate">
+  <eco-mobile-nav-item routerLink="/favorits" [label]="'store.menu.favorites' | translate">
     <mat-icon>favorite</mat-icon>
   </eco-mobile-nav-item>
 
@@ -49,4 +49,4 @@
   }
 </nav>
 
-<eco-user-menu #userMenuComponent (logoutEvent)="userProfileStore.logout()" />
+<eco-user-menu #userMenuComponent (logoutEvent)="logout()" />

--- a/libs/eco-store/core/layout/src/mobile-nav/mobile-nav.component.ts
+++ b/libs/eco-store/core/layout/src/mobile-nav/mobile-nav.component.ts
@@ -3,7 +3,7 @@ import { MatBadgeModule } from '@angular/material/badge';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { pocketBaseUserProfileStore } from '@plastik/auth/pocketbase/data-access';
 import { ecoStoreCartStore } from '@plastik/eco-store/cart/data-access';
@@ -36,6 +36,15 @@ import { MobileNavItemComponent } from './mobile-nav-item.component';
 export class EcoMobileNavComponent {
   protected readonly userProfileStore = inject(pocketBaseUserProfileStore);
   protected readonly cartStore = inject(ecoStoreCartStore);
+  readonly #router = inject(Router);
+  protected readonly bumpAnimation = useCartBumpAnimation(
+    this.cartStore.subtotal,
+    this.cartStore.tax
+  );
   readonly userMenuComponent = viewChild.required<EcoUserMenuComponent>('userMenuComponent');
-  protected readonly bumpAnimation = useCartBumpAnimation(this.cartStore);
+
+  logout() {
+    this.userProfileStore.logout();
+    this.#router.navigate(['/accedir']);
+  }
 }

--- a/libs/eco-store/core/layout/src/utils/cart-bump-animation.util.ts
+++ b/libs/eco-store/core/layout/src/utils/cart-bump-animation.util.ts
@@ -2,19 +2,18 @@ import { effect, Signal, signal, WritableSignal } from '@angular/core';
 
 /**
  * @description Trigger a bump animation on the cart when the total changes.
- * @param {object} cartStore - Cart store with subtotal and tax signals.
- * @param {Signal<number>} cartStore.subtotal - Cart subtotal.
- * @param {Signal<number>} cartStore.tax - Cart tax.
+ * @param {Signal<number>} subtotal - Cart subtotal.
+ * @param {Signal<number>} tax - Cart tax.
  * @returns {WritableSignal<boolean>} - Signal that triggers the bump animation.
  */
-export function useCartBumpAnimation(cartStore: {
-  subtotal: Signal<number>;
-  tax: Signal<number>;
-}): WritableSignal<boolean> {
+export function useCartBumpAnimation(
+  subtotal: Signal<number>,
+  tax: Signal<number>
+): WritableSignal<boolean> {
   const bumpAnimation = signal(false);
 
   effect(() => {
-    if (cartStore.subtotal() + cartStore.tax() > 0) {
+    if (subtotal() + tax() > 0) {
       bumpAnimation.set(true);
       const timer = setTimeout(() => {
         bumpAnimation.set(false);

--- a/libs/eco-store/orders/data-access/src/eco-store-orders.store.spec.ts
+++ b/libs/eco-store/orders/data-access/src/eco-store-orders.store.spec.ts
@@ -1,12 +1,16 @@
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
+import { pocketBaseUserProfileStore } from '@plastik/auth/pocketbase/data-access';
+import { mockPocketBaseUserProfileStore } from '@plastik/auth/pocketbase/data-access/testing';
 import { POCKETBASE_INSTANCE } from '@plastik/core/api-pocketbase';
+import { POCKETBASE_ENVIRONMENT } from '@plastik/core/environments';
 import { ecoStoreCartStore } from '@plastik/eco-store/cart/data-access';
 import { EcoStoreOrder } from '@plastik/eco-store/entities';
 import { activityStore } from '@plastik/shared/activity/data-access';
 import { notificationStore } from '@plastik/shared/notification/data-access';
 import { of } from 'rxjs';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { EcoStoreOrdersApiService } from './eco-store-orders-api.service';
 import { ecoStoreOrdersStore } from './eco-store-orders.store';
 
@@ -55,7 +59,7 @@ describe('ecoStoreOrdersStore', () => {
       user: 'user-1',
       items: [],
     }),
-    resetCartAfterCheckout: vi.fn(),
+    reset: vi.fn(),
     isSyncing: signal(false),
     isSynced: signal(false),
   };
@@ -94,6 +98,14 @@ describe('ecoStoreOrdersStore', () => {
         {
           provide: POCKETBASE_INSTANCE,
           useValue: { autoCancellation: vi.fn(), send: vi.fn() },
+        },
+        {
+          provide: pocketBaseUserProfileStore,
+          useValue: mockPocketBaseUserProfileStore,
+        },
+        {
+          provide: POCKETBASE_ENVIRONMENT,
+          useValue: { production: false, environment: 'test' },
         },
         { provide: ecoStoreCartStore, useValue: mockCartStoreValue },
         { provide: activityStore, useValue: mockActivityStoreValue },
@@ -158,7 +170,7 @@ describe('ecoStoreOrdersStore', () => {
 
     it('should reset the cart after a successful order creation', async () => {
       await store.createOrder();
-      expect(mockCartStoreValue.resetCartAfterCheckout).toHaveBeenCalled();
+      expect(mockCartStoreValue.reset).toHaveBeenCalled();
     });
 
     it('should navigate to the order confirmation page with the new order ID', async () => {
@@ -178,7 +190,7 @@ describe('ecoStoreOrdersStore', () => {
 
       await store.createOrder();
 
-      expect(mockCartStoreValue.resetCartAfterCheckout).not.toHaveBeenCalled();
+      expect(mockCartStoreValue.reset).not.toHaveBeenCalled();
       expect(navigateSpy).not.toHaveBeenCalled();
       expect(mockActivityStoreValue.setActivity).toHaveBeenLastCalledWith(false);
     });

--- a/libs/eco-store/orders/data-access/src/eco-store-orders.store.ts
+++ b/libs/eco-store/orders/data-access/src/eco-store-orders.store.ts
@@ -1,32 +1,40 @@
 import { inject } from '@angular/core';
 import { signalStore, withMethods, withProps } from '@ngrx/signals';
-import { initialGetListState, withPocketBaseCrud } from '@plastik/signal-state/pocketbase';
+import {
+  initialGetListState,
+  PocketBaseGetListState,
+  withPocketBaseCrud,
+} from '@plastik/signal-state/pocketbase';
 
 import { Router } from '@angular/router';
-import { DataCrud } from '@plastik/core/api-base';
+import { pocketBaseUserProfileStore } from '@plastik/auth/pocketbase/data-access';
 import { BasePocketBaseEntityFilter } from '@plastik/core/entities';
 import { ecoStoreCartStore } from '@plastik/eco-store/cart/data-access';
 import { EcoStoreOrder } from '@plastik/eco-store/entities';
 import { activityStore } from '@plastik/shared/activity/data-access';
-import { ListResult } from 'pocketbase';
 import { EcoStoreOrdersApiService } from './eco-store-orders-api.service';
 
-export type OrdersPocketBaseCrudState = DataCrud<EcoStoreOrder, ListResult<EcoStoreOrder>>;
-
-/**
- * Filter configuration for orders list.
- * Extends the base PocketBase entity filter with an optional status and product search (items).
- */
 export interface OrdersPocketBaseFilter extends BasePocketBaseEntityFilter {
   status: string | null;
   items: string | null;
 }
 
+export interface OrdersPocketBaseCrudState extends PocketBaseGetListState {
+  filter: OrdersPocketBaseFilter;
+}
+
 export const ecoStoreOrdersStore = signalStore(
-  { providedIn: 'root' },
-  withPocketBaseCrud<EcoStoreOrder, OrdersPocketBaseCrudState>({
+  withProps(() => ({
+    _cartStore: inject(ecoStoreCartStore),
+    _router: inject(Router),
+    _activityStore: inject(activityStore),
+    _profileStore: inject(pocketBaseUserProfileStore),
+  })),
+
+  withPocketBaseCrud<EcoStoreOrder, EcoStoreOrdersApiService>({
     featureName: 'orders',
     dataServiceType: EcoStoreOrdersApiService,
+    autoLoad: () => inject(pocketBaseUserProfileStore).isAuthenticated,
     customInitialState: {
       paginationSizeOptions: [10, 20, 40],
       pagination: {
@@ -46,13 +54,9 @@ export const ecoStoreOrdersStore = signalStore(
       },
       apiRequestDebounceTime: 0,
       isLoading: false,
+      loaded: false,
     },
   }),
-  withProps(() => ({
-    _cartStore: inject(ecoStoreCartStore),
-    _router: inject(Router),
-    _activityStore: inject(activityStore),
-  })),
 
   withMethods(store => {
     return {
@@ -63,7 +67,7 @@ export const ecoStoreOrdersStore = signalStore(
           const newOrder = await store.create(data, {}, { success: false, error: true });
 
           if (newOrder) {
-            store._cartStore.resetCartAfterCheckout();
+            store._cartStore.reset();
             await store._router.navigate(['/comandes', 'nova', newOrder.id]);
           }
         } finally {

--- a/libs/eco-store/product-categories/data-access/src/eco-store-product-categories.store.mock.ts
+++ b/libs/eco-store/product-categories/data-access/src/eco-store-product-categories.store.mock.ts
@@ -17,10 +17,18 @@ export const mockEcoStoreProductCategoriesStore = {
       totalProducts: 10,
     },
   ]),
+  currentLang: signal('ca'),
+  totalProducts: signal(10),
   isLoading: signal(false),
   error: signal(null),
   findCategoryBySlug: vi.fn().mockImplementation((slug: string) => {
     return mockEcoStoreProductCategoriesStore.entities().find(item => item.normalizedName === slug);
+  }),
+  getCategoryBySlug: vi.fn().mockImplementation((slug: string) => {
+    const category = mockEcoStoreProductCategoriesStore
+      .entities()
+      .find(item => item.normalizedName === slug);
+    return category ? { ...category, name: category.name['ca'] } : null;
   }),
   getLocalizedCategoryName: vi.fn().mockImplementation(category => {
     return category.name['ca'];

--- a/libs/eco-store/product-categories/data-access/src/eco-store-product-categories.store.ts
+++ b/libs/eco-store/product-categories/data-access/src/eco-store-product-categories.store.ts
@@ -29,16 +29,18 @@ import { EcoStoreProductCategoriesStatsService } from './eco-store-product-categ
 export interface ProductCategoriesState {
   isLoading: boolean;
   error: string | null;
+  loaded: boolean;
 }
 
 const initialState: ProductCategoriesState = {
   isLoading: false,
   error: null,
+  loaded: false,
 };
 
 export const ecoStoreProductCategoriesStore = signalStore(
   { providedIn: 'root' },
-  isDevMode() ? withDevtools('productsCategories') : withDevToolsStub('productsCategories'),
+  isDevMode() ? withDevtools('product-categories') : withDevToolsStub('product-categories'),
   withImmutableState<ProductCategoriesState>(initialState),
   withEntities<ProductCategoryStats>(),
   withProps(() => ({
@@ -137,6 +139,7 @@ export const ecoStoreProductCategoriesStore = signalStore(
                       }),
                       {
                         isLoading: false,
+                        loaded: true,
                       }
                     );
                   },
@@ -193,7 +196,7 @@ export const ecoStoreProductCategoriesStore = signalStore(
     onInit(store) {
       effect(() => {
         const tenantLoaded = store._tenantStore.loaded();
-        if (tenantLoaded) {
+        if (tenantLoaded && !store.loaded()) {
           untracked(() => store.getStats());
         }
       });

--- a/libs/eco-store/products/data-access/src/eco-store-products.store.ts
+++ b/libs/eco-store/products/data-access/src/eco-store-products.store.ts
@@ -1,6 +1,6 @@
 import { computed, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { signalStore, withComputed, withMethods } from '@ngrx/signals';
+import { signalStore, withComputed, withMethods, withProps } from '@ngrx/signals';
 import { setEntity } from '@ngrx/signals/entities';
 import { TranslateService } from '@ngx-translate/core';
 import { BasePocketBaseEntityFilter, IdType, LocalizedFields } from '@plastik/core/entities';
@@ -19,6 +19,7 @@ import {
 import { firstValueFrom, map } from 'rxjs';
 
 import { updateState } from '@angular-architects/ngrx-toolkit';
+import { ecoStoreTenantStore } from '@plastik/eco-store/tenant';
 import { EcoStoreProductsApiService } from './eco-store-products-api.service';
 
 export interface ProductsPocketBaseFilter extends BasePocketBaseEntityFilter {
@@ -29,31 +30,35 @@ export interface ProductsPocketBaseGetListState extends PocketBaseGetListState {
   filter: ProductsPocketBaseFilter;
 }
 
+const customInitialState: Partial<ProductsPocketBaseGetListState> = {
+  paginationSizeOptions: [10, 20, 40],
+  pagination: {
+    page: 1,
+    perPage: 10,
+  },
+  filter: {
+    category: null,
+  },
+  sortOptions: {
+    ...initialGetListState().sortOptions,
+    priceWithIva: [
+      { id: 3, direction: 'desc', icon: 'arrow_downward' },
+      { id: 4, direction: 'asc', icon: 'arrow_upward' },
+    ],
+  },
+  apiRequestDebounceTime: 0,
+};
+
 export const ecoStoreProductsStore = signalStore(
   { providedIn: 'root' },
-  withPocketBaseGet<EcoStoreProduct, EcoStoreProductsApiService, ProductsPocketBaseGetListState>({
+  withPocketBaseGet<EcoStoreProduct, EcoStoreProductsApiService>({
     featureName: 'products',
     dataServiceType: EcoStoreProductsApiService,
-    autoLoad: false,
-    customInitialState: {
-      paginationSizeOptions: [10, 20, 40],
-      pagination: {
-        page: 1,
-        perPage: 10,
-      },
-      filter: {
-        category: null,
-      },
-      sortOptions: {
-        ...initialGetListState().sortOptions,
-        priceWithIva: [
-          { id: 3, direction: 'desc', icon: 'arrow_downward' },
-          { id: 4, direction: 'asc', icon: 'arrow_upward' },
-        ],
-      },
-      apiRequestDebounceTime: 0,
-    },
+    customInitialState,
   }),
+  withProps(() => ({
+    _tenantStore: inject(ecoStoreTenantStore),
+  })),
 
   withComputed(({ entities }) => {
     const categoriesStore = inject(ecoStoreProductCategoriesStore);

--- a/libs/eco-store/products/feature/detail/src/lib/eco-store-product-feature.component.spec.ts
+++ b/libs/eco-store/products/feature/detail/src/lib/eco-store-product-feature.component.spec.ts
@@ -4,6 +4,8 @@ import { provideTranslateService } from '@ngx-translate/core';
 import { POCKETBASE_INSTANCE } from '@plastik/core/api-pocketbase';
 import { mockPocketBase } from '@plastik/core/api-pocketbase/testing';
 import { provideEnvironmentPocketBaseTranslationMock } from '@plastik/core/environments/testing';
+import { ecoStoreCartStore } from '@plastik/eco-store/cart/data-access';
+import { mockEcoStoreCartStore } from '@plastik/eco-store/cart/data-access/testing';
 import { ecoStoreTenantStore } from '@plastik/eco-store/tenant';
 import { mockEcoStoreTenantStore } from '@plastik/eco-store/tenant/testing';
 import { axe } from 'vitest-axe';
@@ -27,6 +29,10 @@ describe('EcoStoreProductFeatureComponent', () => {
         {
           provide: ecoStoreTenantStore,
           useValue: mockEcoStoreTenantStore,
+        },
+        {
+          provide: ecoStoreCartStore,
+          useValue: mockEcoStoreCartStore,
         },
       ],
     }).compileComponents();

--- a/libs/eco-store/products/feature/list/src/lib/eco-store-products-feature.component.spec.ts
+++ b/libs/eco-store/products/feature/list/src/lib/eco-store-products-feature.component.spec.ts
@@ -4,6 +4,10 @@ import { provideTranslateService } from '@ngx-translate/core';
 import { POCKETBASE_INSTANCE } from '@plastik/core/api-pocketbase';
 import { mockPocketBase } from '@plastik/core/api-pocketbase/testing';
 import { provideEnvironmentPocketBaseTranslationMock } from '@plastik/core/environments/testing';
+import { ecoStoreCartStore } from '@plastik/eco-store/cart/data-access';
+import { mockEcoStoreCartStore } from '@plastik/eco-store/cart/data-access/testing';
+import { ecoStoreProductCategoriesStore } from '@plastik/eco-store/product-categories/data-access';
+import { mockEcoStoreProductCategoriesStore } from '@plastik/eco-store/product-categories/data-access/testing';
 import { ecoStoreTenantStore } from '@plastik/eco-store/tenant';
 import { mockEcoStoreTenantStore } from '@plastik/eco-store/tenant/testing';
 import { axe } from 'vitest-axe';
@@ -27,6 +31,14 @@ describe('EcoStoreProductsFeature', () => {
         {
           provide: ecoStoreTenantStore,
           useValue: mockEcoStoreTenantStore,
+        },
+        {
+          provide: ecoStoreCartStore,
+          useValue: mockEcoStoreCartStore,
+        },
+        {
+          provide: ecoStoreProductCategoriesStore,
+          useValue: mockEcoStoreProductCategoriesStore,
         },
       ],
     }).compileComponents();

--- a/libs/shared/signal-state/data-access-pocketbase/src/lib/pocketbase-store.types.ts
+++ b/libs/shared/signal-state/data-access-pocketbase/src/lib/pocketbase-store.types.ts
@@ -45,6 +45,7 @@ export interface PocketBaseGetListState {
   paginationSizeOptions: number[];
   sortOptions: SortMenuOptions;
   apiRequestDebounceTime: number;
+  loaded: boolean;
 }
 
 export const initialGetListState = (
@@ -71,6 +72,7 @@ export const initialGetListState = (
     ],
   },
   apiRequestDebounceTime: 0,
+  loaded: false,
   ...customInitialState,
 });
 

--- a/libs/shared/signal-state/data-access-pocketbase/src/lib/pocketbase.features.ts
+++ b/libs/shared/signal-state/data-access-pocketbase/src/lib/pocketbase.features.ts
@@ -17,7 +17,7 @@ import { BasePocketBaseEntity, IdType } from '@plastik/core/entities';
 import { StoreNotificationService } from '@plastik/shared/notification/data-access';
 import { areObjectEntriesEqual } from '@plastik/shared/objects';
 import { ClientResponseError, ListResult } from 'pocketbase';
-import { distinctUntilChanged, pipe, switchMap, tap } from 'rxjs';
+import { distinctUntilChanged, filter, pipe, switchMap, tap } from 'rxjs';
 import {
   initialGetListState,
   PocketBaseGetListState,
@@ -44,11 +44,12 @@ export function withPocketBaseListFeature<
   featureName,
   dataServiceType,
   customInitialState = {},
+  autoLoad = true,
 }: {
   featureName: string;
   dataServiceType: Type<S>;
   customInitialState?: Partial<PocketBaseGetListState>;
-  autoLoad?: boolean;
+  autoLoad?: boolean | ((store: unknown) => boolean | (() => boolean));
 }) {
   const defaultState = initialGetListState(customInitialState);
 
@@ -86,8 +87,11 @@ export function withPocketBaseListFeature<
     withMethods(store => {
       return {
         getItemById: (id: IdType<T>) => store.entityMap()[id],
-        getList: rxMethod<{ params: ReturnType<typeof store.formattedParams> }>(
+        getList: rxMethod<{ params: ReturnType<typeof store.formattedParams> } | null>(
           pipe(
+            filter(
+              (val): val is { params: ReturnType<typeof store.formattedParams> } => val !== null
+            ),
             distinctUntilChanged((prev, curr) => {
               return areObjectEntriesEqual(prev.params, curr.params);
             }),
@@ -128,10 +132,17 @@ export function withPocketBaseListFeature<
 
     withHooks({
       onInit: store => {
+        const evalAutoLoad = typeof autoLoad === 'function' ? autoLoad(store) : autoLoad;
+
         store.getList(
-          computed(() => ({
-            params: store.formattedParams(),
-          }))
+          computed(() => {
+            if (evalAutoLoad) {
+              return {
+                params: store.formattedParams(),
+              };
+            }
+            return null;
+          })
         );
       },
     })

--- a/libs/shared/signal-state/data-access-pocketbase/src/lib/stores/with-pocketbase-crud.store.ts
+++ b/libs/shared/signal-state/data-access-pocketbase/src/lib/stores/with-pocketbase-crud.store.ts
@@ -11,12 +11,13 @@ import { withPocketBaseGetOneFeature, withPocketBaseListFeature } from '../pocke
 
 /**
  * @description Store feature for full CRUD operations with PocketBase. Use this when you need complete create, read, update, delete functionality.
- * @template T - The entity type.
- * @template S - The service type.
+ * @template {BasePocketBaseEntity<IdType<T>>} T - The entity type.
+ * @template {DataCrud<T, ListResult<T>, PocketBaseListParams>} S - The service type.
  * @param {object} root0 - Configuration object.
  * @param {string} root0.featureName - The name of the feature for DevTools.
  * @param {Type<S>} root0.dataServiceType - The service type for data operations.
  * @param {Partial<PocketBaseGetListState>} root0.customInitialState - Custom initial state for the store.
+ * @param {boolean | ((store: unknown) => boolean | (() => boolean))} root0.autoLoad - Whether to auto load the data.
  * @returns {SignalStoreFeature} A signal store feature with CRUD operations.
  */
 export function withPocketBaseCrud<
@@ -26,10 +27,12 @@ export function withPocketBaseCrud<
   featureName,
   dataServiceType,
   customInitialState,
+  autoLoad = true,
 }: {
   featureName: string;
   dataServiceType: Type<S>;
   customInitialState?: Partial<PocketBaseGetListState>;
+  autoLoad?: boolean | ((store: unknown) => boolean | (() => boolean));
 }) {
   return signalStoreFeature(
     isDevMode() ? withDevtools(featureName) : withDevToolsStub(featureName),
@@ -37,6 +40,7 @@ export function withPocketBaseCrud<
       featureName,
       dataServiceType,
       customInitialState,
+      autoLoad,
     }),
     withPocketBaseGetOneFeature<T, S>({ featureName }),
 

--- a/libs/shared/signal-state/data-access-pocketbase/src/lib/stores/with-pocketbase-get.store.ts
+++ b/libs/shared/signal-state/data-access-pocketbase/src/lib/stores/with-pocketbase-get.store.ts
@@ -32,7 +32,7 @@ export function withPocketBaseGet<
   featureName: string;
   dataServiceType: Type<S>;
   customInitialState: Partial<STATE>;
-  autoLoad?: boolean;
+  autoLoad?: boolean | ((store: unknown) => boolean | (() => boolean));
 }) {
   return signalStoreFeature(
     isDevMode() ? withDevtools(featureName) : withDevToolsStub(featureName),

--- a/libs/shared/signal-state/data-reset/.eslintrc.json
+++ b/libs/shared/signal-state/data-reset/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "plastik",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "plastik",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/shared/signal-state/data-reset/README.md
+++ b/libs/shared/signal-state/data-reset/README.md
@@ -1,0 +1,7 @@
+# signal-state-data-reset
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test signal-state-data-reset` to execute the unit tests.

--- a/libs/shared/signal-state/data-reset/project.json
+++ b/libs/shared/signal-state/data-reset/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "signal-state-data-reset",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/shared/signal-state/data-reset/src",
+  "prefix": "plastik",
+  "projectType": "library",
+  "tags": ["type:data-access", "scope:shared"],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "reportsDirectory": "../../../../coverage/libs/shared/signal-state/data-reset"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/shared/signal-state/data-reset/src/index.ts
+++ b/libs/shared/signal-state/data-reset/src/index.ts
@@ -1,0 +1,1 @@
+export * from './reset-entities.feature';

--- a/libs/shared/signal-state/data-reset/src/reset-entities.feature.ts
+++ b/libs/shared/signal-state/data-reset/src/reset-entities.feature.ts
@@ -1,0 +1,25 @@
+import { updateState, withReset } from '@angular-architects/ngrx-toolkit';
+import { signalStoreFeature, SignalStoreFeature, withMethods } from '@ngrx/signals';
+import { removeAllEntities } from '@ngrx/signals/entities';
+
+/**
+ * @description Store feature for resetting entities.
+ * @param {string} featureName - The name of the feature for DevTools.
+ * @param {object} partialState - Partial state to reset.
+ * @returns {SignalStoreFeature} A signal store feature with reset functionality.
+ */
+export function withResetEntities(featureName = 'entities', partialState = {}) {
+  return signalStoreFeature(
+    withReset(),
+    withMethods(store => ({
+      reset(): void {
+        store.resetState();
+        updateState(store, `[${featureName}] reset`, state => ({
+          ...state,
+          ...partialState,
+          ...removeAllEntities(),
+        }));
+      },
+    }))
+  );
+}

--- a/libs/shared/signal-state/data-reset/src/test-setup.ts
+++ b/libs/shared/signal-state/data-reset/src/test-setup.ts
@@ -1,0 +1,5 @@
+import '@angular/compiler';
+import '@analogjs/vitest-angular/setup-snapshots';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+setupTestBed({ zoneless: false });

--- a/libs/shared/signal-state/data-reset/tsconfig.json
+++ b/libs/shared/signal-state/data-reset/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "target": "es2022",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "preserve",
+    "composite": true
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/shared/signal-state/data-reset/tsconfig.lib.json
+++ b/libs/shared/signal-state/data-reset/tsconfig.lib.json
@@ -1,0 +1,27 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "composite": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/test-setup.ts"
+  ]
+}

--- a/libs/shared/signal-state/data-reset/tsconfig.spec.json
+++ b/libs/shared/signal-state/data-reset/tsconfig.spec.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ],
+  "files": ["src/test-setup.ts"]
+}

--- a/libs/shared/signal-state/data-reset/vite.config.mts
+++ b/libs/shared/signal-state/data-reset/vite.config.mts
@@ -1,0 +1,28 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import angular from '@analogjs/vite-plugin-angular';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../../../node_modules/.vite/libs/shared/signal-state/data-reset',
+  plugins: [angular(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  // Uncomment this if you are using workers.
+  // worker: {
+  //   plugins: () => [ nxViteTsPaths() ],
+  // },
+  test: {
+    name: 'signal-state-data-reset',
+    watch: false,
+    globals: true,
+    environment: 'jsdom',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    setupFiles: ['src/test-setup.ts'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../../../coverage/libs/shared/signal-state/data-reset',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -274,7 +274,8 @@
       ],
       "@plastik/eco-store/no-results": ["libs/eco-store/shared/no-results/src/index.ts"],
       "@plastik/shared/util/highlight": ["libs/shared/util/highlight/src/index.ts"],
-      "@plastik/shared/translation": ["libs/shared/translation/src/index.ts"]
+      "@plastik/shared/translation": ["libs/shared/translation/src/index.ts"],
+      "@plastik/signal-state/reset": ["libs/shared/signal-state/data-reset/src/index.ts"]
     }
   },
   "angularCompilerOptions": {

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -21,3 +21,17 @@ declare module 'vitest' {
 }
 
 vi.stubGlobal('IntersectionObserver', IntersectionObserverMock);
+
+vi.stubGlobal(
+  'matchMedia',
+  vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+);


### PR DESCRIPTION
…ignal state improvements

- Add signal-state-data-reset library to handle store state resetting.
- Update withPocketBaseListFeature, withPocketBaseCrud, and withPocketBaseGet to support autoLoad and a loaded state flag.
- Refactor ecoStoreCartStore and ecoStoreOrdersStore to use the new reset logic.
- Update EcoMenuComponent and EcoMobileNavComponent to improve signal usage and logout logic.
- Adjust useCartBumpAnimation to take individual signals for better reactivity.

CLOSED: #86c8z1v9g