### PR TITLE
feat(eco-store): #86c93cga0 add trial expired guard to checkout flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-04-05] - Eco-Store: Trial Period Expiration Guard
+
+### Added
+
+- **Trial Expired Guard**: Implemented a new guard to prevent checkout when the user's trial has expired, redirecting them to their profile to formalize membership ([#86c93cga0](https://app.clickup.com/t/86c93cga0)).
+- **Checkout Protection**: Integrated the trial expiration check into shipping and confirmation steps of the cart checkout flow ([#86c93cga0](https://app.clickup.com/t/86c93cga0)).
+
 ## [2026-04-01] - Eco-Store: Authentication Refactoring and Modernization
 
 ### Added

--- a/libs/eco-store/cart/feature/src/lib/eco-store-cart.routes.ts
+++ b/libs/eco-store/cart/feature/src/lib/eco-store-cart.routes.ts
@@ -8,6 +8,7 @@ import { ecoStoreNotLoggedShippingGuard } from './guards/not-logged-shipping.gua
 import { shippingAvailableGuard } from './guards/shipping-available.guard';
 import { shippingInfoGuard } from './guards/shipping-info.guard';
 import { shippingUnavailableGuard } from './guards/shipping-unavailable.guard';
+import { ecoStoreTrialExpiredGuard } from './guards/trial-expired.guard';
 
 export const ecoStoreCartRoutes: Route[] = [
   {
@@ -28,7 +29,12 @@ export const ecoStoreCartRoutes: Route[] = [
       {
         path: 'enviament',
         title: 'cart.shipping.headTitle',
-        canActivate: [ecoStoreNotLoggedShippingGuard, shippingAvailableGuard, isStoreOpenGuard],
+        canActivate: [
+          ecoStoreNotLoggedShippingGuard,
+          shippingAvailableGuard,
+          isStoreOpenGuard,
+          ecoStoreTrialExpiredGuard,
+        ],
         loadComponent: () =>
           import('./eco-store-cart-steps/shipping/cart-shipping.component').then(
             m => m.CartShippingComponent
@@ -42,6 +48,7 @@ export const ecoStoreCartRoutes: Route[] = [
           shippingAvailableGuard,
           isStoreOpenGuard,
           shippingInfoGuard,
+          ecoStoreTrialExpiredGuard,
         ],
         loadComponent: () =>
           import('./eco-store-cart-steps/confirmation/cart-confirmation.component').then(

--- a/libs/eco-store/cart/feature/src/lib/guards/trial-expired.guard.ts
+++ b/libs/eco-store/cart/feature/src/lib/guards/trial-expired.guard.ts
@@ -1,0 +1,39 @@
+import { map, Observable, of, switchMap, take } from 'rxjs';
+
+import { inject } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+import { pocketBaseUserProfileStore } from '@plastik/auth/pocketbase/data-access';
+import { SharedConfirmDialogService } from '@plastik/shared/confirm';
+
+export const ecoStoreTrialExpiredGuard: CanActivateFn = (): Observable<boolean | UrlTree> => {
+  const profileStore = inject(pocketBaseUserProfileStore);
+  const confirmService = inject(SharedConfirmDialogService);
+  const router = inject(Router);
+
+  return toObservable(profileStore.isTrialExpired).pipe(
+    take(1),
+    switchMap(isTrialExpired => {
+      if (isTrialExpired) {
+        return confirmService
+          .confirm(
+            'store.trial.expiredTitle',
+            'store.trial.expiredMessage',
+            'store.trial.expiredSecondary',
+            'store.trial.expiredCta'
+          )
+          .pipe(
+            take(1),
+            map(confirmed => {
+              if (confirmed) {
+                // TODO: Redirect to PRV-06 (sol·licitud d'adhesió)
+                return router.createUrlTree(['/perfil']);
+              }
+              return router.createUrlTree(['/botiga']);
+            })
+          );
+      }
+      return of(true);
+    })
+  );
+};


### PR DESCRIPTION
Implemented a reactive guard that prevents checkout if the user's trial period has expired. This guard is applied to shipping and confirmation routes.

CLOSED: #86c93cga0