### PR TITLE
fix(eco-store): rewrite subdomain URL before passing to AngularAppEngine

### DIFF
--- a/apps/eco-store/src/server.ts
+++ b/apps/eco-store/src/server.ts
@@ -39,10 +39,19 @@ export const reqHandler = createRequestHandler(async request => {
 
   if (url.hostname.endsWith('.9botiga.top') && url.hostname !== '9botiga.top') {
     const headers = new Headers(request.headers);
-    headers.set('host', '9botiga.top'); // We trick the SSR engine
+    headers.set('host', '9botiga.top');
 
-    finalRequest = new Request(request, {
+    // AngularAppEngine validates the hostname from the *request URL*, not the
+    // host header, so we must rewrite the URL too — otherwise the engine still
+    // sees el-llevat.9botiga.top and blocks the request.
+    const rewrittenUrl = new URL(request.url);
+    rewrittenUrl.hostname = '9botiga.top';
+
+    finalRequest = new Request(rewrittenUrl.toString(), {
+      method: request.method,
       headers,
+      body: request.body,
+      redirect: request.redirect,
     });
   }
 


### PR DESCRIPTION
AngularAppEngine validates allowedHosts against the request URL, not the host header. Cloning the request with only a modified header left the original subdomain URL intact, causing "hostname not allowed" errors for *.9botiga.top tenants.