### PR TITLE
perf(eco-store): eliminate SSR trailing-slash redirect and centralise…

### DIFF
--- a/.github/workflows/eco-store-deploy-staging.yml
+++ b/.github/workflows/eco-store-deploy-staging.yml
@@ -77,19 +77,6 @@ jobs:
           yarn nx build-cf eco-store --configuration=staging --skip-nx-cache
         timeout-minutes: 30
 
-      - name: Generate Security Headers
-        if: steps.changes.outputs.has_changes == 'true'
-        run: |
-          cat <<EOF > ./dist/apps/eco-store/browser/_headers
-          /*
-            X-Frame-Options: DENY
-            X-Content-Type-Options: nosniff
-            Referrer-Policy: strict-origin-when-cross-origin
-            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-            Permissions-Policy: camera=(), microphone=(), geolocation=()
-            Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://eco-botiga.pockethost.io; connect-src 'self' https://eco-botiga.pockethost.io https://fonts.gstatic.com https://fonts.googleapis.com; frame-ancestors 'none'; upgrade-insecure-requests;
-          EOF
-
       - name: Set Worker secrets
         if: steps.changes.outputs.has_changes == 'true'
         env:

--- a/apps/eco-store/project.json
+++ b/apps/eco-store/project.json
@@ -142,14 +142,26 @@
       "executor": "nx:run-commands",
       "options": {
         "parallel": false,
-        "commands": ["nx run eco-store:build:production", "node tools/scripts/add-cfasync.cjs"]
+        "commands": [
+          "nx run eco-store:build:production",
+          "node tools/scripts/add-cfasync.cjs",
+          "node apps/eco-store/scripts/generate-cf-headers.cjs"
+        ]
       },
       "configurations": {
         "staging": {
-          "commands": ["nx run eco-store:build:staging", "node tools/scripts/add-cfasync.cjs"]
+          "commands": [
+            "nx run eco-store:build:staging",
+            "node tools/scripts/add-cfasync.cjs",
+            "node apps/eco-store/scripts/generate-cf-headers.cjs"
+          ]
         },
         "production": {
-          "commands": ["nx run eco-store:build:production", "node tools/scripts/add-cfasync.cjs"]
+          "commands": [
+            "nx run eco-store:build:production",
+            "node tools/scripts/add-cfasync.cjs",
+            "node apps/eco-store/scripts/generate-cf-headers.cjs"
+          ]
         }
       },
       "defaultConfiguration": "production"

--- a/apps/eco-store/scripts/.eslintrc.json
+++ b/apps/eco-store/scripts/.eslintrc.json
@@ -18,6 +18,23 @@
         "@typescript-eslint/no-empty-function": "off",
         "no-undef": "error"
       }
+    },
+    {
+      "files": ["*.cjs"],
+      "env": {
+        "node": true,
+        "es2022": true
+      },
+      "parser": "espree",
+      "parserOptions": {
+        "ecmaVersion": 2022,
+        "sourceType": "commonjs"
+      },
+      "rules": {
+        "@typescript-eslint/no-unused-vars": "off",
+        "@typescript-eslint/no-empty-function": "off",
+        "no-undef": "error"
+      }
     }
   ]
 }

--- a/apps/eco-store/scripts/generate-cf-headers.cjs
+++ b/apps/eco-store/scripts/generate-cf-headers.cjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+'use strict';
+
+const { writeFileSync, mkdirSync } = require('fs');
+const { join, dirname } = require('path');
+
+const SECURITY_HEADERS = require('../src/security-headers.json');
+
+const outputPath = join(__dirname, '../../../dist/apps/eco-store/browser/_headers');
+
+mkdirSync(dirname(outputPath), { recursive: true });
+
+const lines = ['/*'];
+for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+  lines.push(`  ${key}: ${value}`);
+}
+
+writeFileSync(outputPath, lines.join('\n') + '\n');
+console.log(`✅ Generated ${outputPath}`);

--- a/apps/eco-store/src/security-headers.json
+++ b/apps/eco-store/src/security-headers.json
@@ -1,0 +1,8 @@
+{
+  "X-Frame-Options": "DENY",
+  "X-Content-Type-Options": "nosniff",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+  "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://eco-botiga.pockethost.io; connect-src 'self' https://eco-botiga.pockethost.io https://fonts.gstatic.com https://fonts.googleapis.com; frame-ancestors 'none'; upgrade-insecure-requests;"
+}

--- a/apps/eco-store/src/server.ts
+++ b/apps/eco-store/src/server.ts
@@ -1,50 +1,48 @@
 /// <reference types="@cloudflare/workers-types" />
-/* eslint-disable no-console */
 import { AngularAppEngine, createRequestHandler } from '@angular/ssr';
+import SECURITY_HEADERS from './security-headers.json' with { type: 'json' };
 
 const engine = new AngularAppEngine({
   allowedHosts: ['9botiga.top', '*.9botiga.top', 'localhost', '127.0.0.1', '*.test'],
 });
 
-const SECURITY_HEADERS: Record<string, string> = {
-  'X-Frame-Options': 'DENY',
-  'X-Content-Type-Options': 'nosniff',
-  'Referrer-Policy': 'strict-origin-when-cross-origin',
-  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
-  'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
-  'Content-Security-Policy':
-    "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://eco-botiga.pockethost.io; connect-src 'self' https://eco-botiga.pockethost.io https://fonts.gstatic.com https://fonts.googleapis.com; frame-ancestors 'none'; upgrade-insecure-requests;",
-};
-
 export const reqHandler = createRequestHandler(async request => {
   const url = new URL(request.url);
-  const response = await engine.handle(request);
+
+  // Normalize URL: add trailing slash before Angular SSR processes it to prevent
+  // a 301 redirect from /path to /path/ that affects Lighthouse and crawlers.
+  // Static assets (paths with a file extension) are excluded from normalization.
+  const normalizedRequest =
+    !url.pathname.endsWith('/') && !/\.[^/]+$/.test(url.pathname)
+      ? new Request(
+          Object.assign(new URL(request.url), { pathname: url.pathname + '/' }).toString(),
+          request
+        )
+      : request;
+
+  const response = await engine.handle(normalizedRequest);
 
   if (!response) {
     return new Response('Not Found', { status: 404 });
   }
 
-  // Add security headers to the response
   const secureResponse = new Response(response.body, response);
 
-  // Detect if we are in local development
   const isLocalDev =
     url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname.endsWith('.test');
 
   for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
     if (isLocalDev) {
-      // Don't send HSTS in local to avoid SSL blocking
-      if (key === 'Strict-Transport-Security') {
-        continue;
-      }
-      // Remove upgrade-insecure-requests from CSP in local
+      if (key === 'Strict-Transport-Security') continue;
       if (key === 'Content-Security-Policy') {
-        const localCsp = value
-          .replace('upgrade-insecure-requests;', '')
-          .replace('connect-src ', 'connect-src http://127.0.0.1:8090 http://localhost:8090 ')
-          .replace('img-src ', 'img-src http://127.0.0.1:8090 http://localhost:8090 ')
-          .trim();
-        secureResponse.headers.set(key, localCsp);
+        secureResponse.headers.set(
+          key,
+          value
+            .replace('upgrade-insecure-requests;', '')
+            .replace('connect-src ', 'connect-src http://127.0.0.1:8090 http://localhost:8090 ')
+            .replace('img-src ', 'img-src http://127.0.0.1:8090 http://localhost:8090 ')
+            .trim()
+        );
         continue;
       }
     }

--- a/apps/eco-store/tsconfig.json
+++ b/apps/eco-store/tsconfig.json
@@ -11,6 +11,7 @@
     "noFallthroughCasesInSwitch": true,
     "module": "preserve",
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "lib": ["dom", "es2024"]
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
… security headers

- Normalise URL in server.ts to prevent 301 /path → /path/ redirect
- Add security-headers.json as single source of truth for all headers
- Add generate-cf-headers.cjs to produce _headers from JSON after build
- Wire script into build-cf target; remove hardcoded CI headers step
- Add *.cjs ESLint override (sourceType: commonjs) for scripts