### PR TITLE
fix(eco-store): fix 301 redirect issue

### DIFF
--- a/apps/eco-store/project.json
+++ b/apps/eco-store/project.json
@@ -149,6 +149,9 @@
         ]
       },
       "configurations": {
+        "local": {
+          "commands": ["nx run eco-store:build:development", "node tools/scripts/add-cfasync.cjs"]
+        },
         "staging": {
           "commands": [
             "nx run eco-store:build:staging",

--- a/apps/eco-store/src/server.ts
+++ b/apps/eco-store/src/server.ts
@@ -6,21 +6,51 @@ const engine = new AngularAppEngine({
   allowedHosts: ['9botiga.top', '*.9botiga.top', 'localhost', '127.0.0.1', '*.test'],
 });
 
+/**
+ * @description Returns a copy of `req` with a trailing slash appended to its pathname.
+ * @param {Request } req The request to append a trailing slash to.
+ * @returns {Request} The request with a trailing slash appended to its pathname.
+ */
+function withTrailingSlash(req: Request): Request {
+  const u = new URL(req.url);
+  u.pathname = u.pathname + '/';
+  return new Request(u.toString(), req);
+}
+
+/**
+ * @description True when the path has no file extension and does not already end with /.
+ * @param {string} pathname The path to check.
+ * @returns {boolean} True when the path has no file extension and does not already end with /.
+ */
+function needsTrailingSlash(pathname: string): boolean {
+  return !pathname.endsWith('/') && !/\.[^/]+$/.test(pathname);
+}
+
 export const reqHandler = createRequestHandler(async request => {
   const url = new URL(request.url);
 
-  // Normalize URL: add trailing slash before Angular SSR processes it to prevent
-  // a 301 redirect from /path to /path/ that affects Lighthouse and crawlers.
-  // Static assets (paths with a file extension) are excluded from normalization.
-  const normalizedRequest =
-    !url.pathname.endsWith('/') && !/\.[^/]+$/.test(url.pathname)
-      ? new Request(
-          Object.assign(new URL(request.url), { pathname: url.pathname + '/' }).toString(),
-          request
-        )
-      : request;
+  // Pre-normalize: add trailing slash so Angular SSR renders directly instead
+  // of issuing a 301 redirect (which hurts Lighthouse and crawlers).
+  const engineRequest = needsTrailingSlash(url.pathname) ? withTrailingSlash(request) : request;
 
-  const response = await engine.handle(normalizedRequest);
+  let response = await engine.handle(engineRequest);
+
+  // Belt-and-suspenders: if Angular SSR still emits a trailing-slash redirect,
+  // follow it internally so the client never sees a 301.
+  if (response?.status === 301 || response?.status === 302) {
+    const location = response.headers.get('Location');
+    if (location) {
+      const redirectUrl = new URL(location, request.url);
+      const isSameOriginTrailingSlash =
+        redirectUrl.origin === url.origin &&
+        redirectUrl.pathname === url.pathname + '/' &&
+        redirectUrl.search === url.search;
+
+      if (isSameOriginTrailingSlash) {
+        response = (await engine.handle(new Request(redirectUrl.toString(), request))) ?? response;
+      }
+    }
+  }
 
   if (!response) {
     return new Response('Not Found', { status: 404 });

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "eco-store:build:staging": "nx run eco-store:build:staging",
     "eco-store:build:prod": "nx run eco-store:build:production",
     "eco-store:build-cf": "nx run eco-store:build-cf",
+    "eco-store:build-cf:local": "nx run eco-store:build-cf:local",
     "eco-store:build-cf:staging": "nx run eco-store:build-cf:staging",
     "eco-store:build-cf:prod": "nx run eco-store:build-cf:production",
     "eco-store:test": "nx run eco-store:test",
@@ -135,7 +136,7 @@
     "eco-store:build:github": "nx run eco-store:build:prod",
     "eco-store:cf:dev": "wrangler dev -c apps/eco-store/wrangler.jsonc",
     "eco-store:cf:deploy": "wrangler deploy -c apps/eco-store/wrangler.jsonc",
-    "eco-store:cf:local": "cp apps/eco-store/.env apps/eco-store/.dev.vars && yarn eco-store:build-cf && npm-run-all --parallel --race eco-store:cf:dev eco-store:watch-scss"
+    "eco-store:cf:local": "cp apps/eco-store/.env apps/eco-store/.dev.vars && yarn eco-store:build-cf:local && npm-run-all --parallel --race eco-store:cf:dev eco-store:watch-scss"
   },
   "resolutions": {
     "sass-embedded": "npm:sass@1.99.0"


### PR DESCRIPTION
Belt-and-suspenders: if Angular SSR still emits a trailing-slash redirect, follow it internally so the client never sees a 301.