### PR TITLE
feat(pwa): #86c9cnwev implement redesigned PWA install prompt for iOS…

### DIFF
--- a/.agent/rules/angular.md
+++ b/.agent/rules/angular.md
@@ -20,6 +20,7 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Use signals for state management
 - Implement lazy loading for feature routes
 - Do NOT use the `@HostBinding` and `@HostListener` decorators. Put host bindings inside the `host` object of the `@Component` or `@Directive` decorator instead
+- **Animations:** Do NOT use `provideAnimations()` or `provideAnimationsAsync()`; both are deprecated as of Angular v20+. Prefer native CSS animations/transitions and the new compiler-supported `animate.enter` and `animate.leave` APIs for element lifecycle animations.
 - Use `NgOptimizedImage` for all static images.
   - `NgOptimizedImage` does not work for inline base64 images.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,6 +16,7 @@ You write maintainable, performant, and accessible code following Angular and Ty
 - Use signals for state management
 - Implement lazy loading for feature routes
 - Do NOT use the `@HostBinding` and `@HostListener` decorators. Put host bindings inside the `host` object of the `@Component` or `@Directive` decorator instead
+- **Animations:** Do NOT use `provideAnimations()` or `provideAnimationsAsync()`; both are deprecated as of Angular v20+. Prefer native CSS animations/transitions and the new compiler-supported `animate.enter` and `animate.leave` APIs for element lifecycle animations.
 - Use `NgOptimizedImage` for all static images.
   - `NgOptimizedImage` does not work for inline base64 images.
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Reusable features and UI components.
 #### UI Components
 
 - [**button**](libs/shared/button/ui/README.md)
+- [**pwa**](libs/shared/pwa/README.md)
 - [**table**](libs/shared/table/ui/README.md)
 - [**form**](libs/shared/form/feature/README.md)
 - [**address-card**](libs/shared/address-card/ui/README.md)

--- a/apps/eco-store/public/i18n/ca.json
+++ b/apps/eco-store/public/i18n/ca.json
@@ -8,7 +8,21 @@
     "cancel": "Cancel·lar",
     "submit": "Enviar",
     "update": "Actualitzar",
-    "save": "Guardar",
+    "pwa": {
+      "title": "Porta l'Eco al teu mòbil",
+      "description": "Aquest lloc té funcionalitats d'aplicació. Instal·la'l al teu dispositiu per a una àmplia experiència i fàcil accés.",
+      "howToInstall": "Com instal·lar-la",
+      "iosInstructionsStep1": "Toca la icona de 'Compartir' a la barra inferior.",
+      "iosInstructionsStep1Old": "Toca el menú de 'Compartir'.",
+      "iosInstructionsStep2": "Desplaça't cap avall fins a trobar l'opció.",
+      "iosInstructionsStep3": "Selecciona 'Afegeix a la pantalla d'inici'.",
+      "iosSafariRequired": "Per instal·lar l'app a iOS, has d'obrir aquesta pàgina amb el navegador Safari.",
+      "androidInstructionsStep1": "Toca la icona de menú del navegador",
+      "androidInstructionsStep2": "Selecciona 'Instal·lar aplicació' o 'Afegeix a la pantalla d'inici'.",
+      "install": "Instal·lar",
+      "later": "Més tard",
+      "close": "Entès, tancar"
+    },
     "delete": "Eliminar",
     "navigation": {
       "previous": "Tornar a la pàgina anterior",

--- a/apps/eco-store/public/i18n/en.json
+++ b/apps/eco-store/public/i18n/en.json
@@ -8,7 +8,21 @@
     "cancel": "Cancel",
     "submit": "Submit",
     "update": "Update",
-    "save": "Save",
+    "pwa": {
+      "title": "Bring Eco to your mobile",
+      "description": "Install our app for a faster, more secure experience with offline access to your orders.",
+      "howToInstall": "How to install",
+      "iosInstructionsStep1": "Tap the 'Share' icon in the bottom bar.",
+      "iosInstructionsStep1Old": "Tap the 'Share' menu.",
+      "iosInstructionsStep2": "Scroll down until you find the option.",
+      "iosInstructionsStep3": "Select 'Add to Home Screen'.",
+      "iosSafariRequired": "To install the app on iOS, you must open this page with the Safari browser.",
+      "androidInstructionsStep1": "Tap the browser menu icon",
+      "androidInstructionsStep2": "Select 'Install app' or 'Add to home screen'.",
+      "install": "Install",
+      "later": "Later",
+      "close": "Got it, close"
+    },
     "delete": "Delete",
     "navigation": {
       "previous": "Go to previous page",
@@ -553,7 +567,7 @@
       "delivered": "DELIVERED",
       "cancelled": "CANCELLED",
       "pending": "PENDING",
-      "confirmed": "CONFIRMED",
+      "confirmed": "CONFIRMADA",
       "preparing": "PREPARING",
       "ready": "READY"
     },
@@ -595,7 +609,7 @@
     "phone": "Phone",
     "submitButton": "Save changes",
     "navigation": "Profile navigation",
-    "memberSince": "[en] Membre des del {date}",
+    "memberSince": "Member since {date}",
     "personalData": {
       "title": "Personal details",
       "description": "Manage your personal details."

--- a/apps/eco-store/public/i18n/es.json
+++ b/apps/eco-store/public/i18n/es.json
@@ -8,7 +8,21 @@
     "cancel": "Cancelar",
     "submit": "Enviar",
     "update": "Actualizar",
-    "save": "Guardar",
+    "pwa": {
+      "title": "Lleva lo Eco en tu móvil",
+      "description": "Instala nuestra app para una experiencia más rápida, segura y con acceso a tus pedidos sin conexión.",
+      "howToInstall": "Cómo instalarla",
+      "iosInstructionsStep1": "Pulsa el icono de 'Compartir' en la barra inferior.",
+      "iosInstructionsStep1Old": "Pulsa el menú de 'Compartir'.",
+      "iosInstructionsStep2": "Desplázate hacia abajo hasta encontrar la opción.",
+      "iosInstructionsStep3": "Selecciona 'Añadir a la pantalla de inicio'.",
+      "iosSafariRequired": "Para instalar la app en iOS, debes abrir esta página en el navegador Safari.",
+      "androidInstructionsStep1": "Pulsa el icono de menú del navegador",
+      "androidInstructionsStep2": "Selecciona 'Instalar aplicación' o 'Añadir a la pantalla de inicio'.",
+      "install": "Instalar",
+      "later": "Más tarde",
+      "close": "Entendido, cerrar"
+    },
     "delete": "Eliminar",
     "navigation": {
       "previous": "Volver a la página anterior",
@@ -37,7 +51,7 @@
     },
     "form": {
       "error": {
-        "email": "El format del correu electrònic no és correcte",
+        "email": "El formato del correo electrónico no es correcto",
         "required": "El campo es obligatorio",
         "minLength": "El campo debe tener al menos {value} caracteres",
         "maxLength": "El campo debe tener más de {value} caracteres",
@@ -381,7 +395,7 @@
         "subtitle": "Elige cómo quieres pagar tu pedido."
       },
       "confirmation": {
-        "title": "Confirmación",
+        "title": "Confirmation",
         "subtitle": "Elige cómo quieres recibir tu pedido."
       }
     },
@@ -561,7 +575,7 @@
       "all": "TODAS",
       "status": "Estado del pedido",
       "productSearch": "Producto",
-      "productSearchPlaceholder": "Escribe el nombre del producto (mínimo 2 caracteres)",
+      "productSearchPlaceholder": "Escribe el nombre del producto (mínim 2 caracteres)",
       "sort": {
         "label": "Ordenar",
         "statusAsc": "Estado ascendente",

--- a/apps/eco-store/public/manifest.webmanifest
+++ b/apps/eco-store/public/manifest.webmanifest
@@ -2,23 +2,8 @@
   "$schema": "https://json.schemastore.org/web-manifest.json",
   "name": "Botiga Eco",
   "short_name": "Eco",
-  "description": "La teva cooperativa de productes ecològics",
+  "description": "La teva botiga en línia de productes ecològics",
   "icons": [
-    {
-      "src": "/icons/favicon.ico",
-      "sizes": "32x32",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "/icons/favicon-16x16.png",
-      "sizes": "16x16",
-      "type": "image/png"
-    },
-    {
-      "src": "/icons/favicon-32x32.png",
-      "sizes": "32x32",
-      "type": "image/png"
-    },
     {
       "src": "/icons/android-chrome-192x192.png",
       "sizes": "192x192",

--- a/apps/eco-store/src/app/app.component.ts
+++ b/apps/eco-store/src/app/app.component.ts
@@ -18,6 +18,7 @@ import { activityStore } from '@plastik/shared/activity/data-access';
 import { SharedActivityUiOverlayComponent } from '@plastik/shared/activity/ui';
 import { notificationStore } from '@plastik/shared/notification/data-access';
 import { SharedNotificationUiHotToastComponent } from '@plastik/shared/notification/ui/hot-toast';
+import { PwaInstallService } from '@plastik/shared/pwa';
 import { SkipLinkComponent } from '@plastik/shared/skip-link';
 
 @Component({
@@ -47,13 +48,15 @@ export class AppComponent implements OnInit {
   readonly #renderer = inject(Renderer2);
   readonly #meta = inject(Meta);
 
-  readonly matIconRegistry = inject(MatIconRegistry);
-  readonly domSanitizer = inject(DomSanitizer);
+  readonly #matIconRegistry = inject(MatIconRegistry);
+  readonly #domSanitizer = inject(DomSanitizer);
+  readonly #pwaInstallService = inject(PwaInstallService);
 
   constructor() {
     this.#translate.addLangs(this.#environment.languages);
     this.#addPreconnectLink();
-    this.#addSvgIcon();
+    this.#addEcoLogoIcon();
+    this.#addIosSafariIcon();
 
     effect(() => {
       const description = this.#tenantStore.tenantDescriptionTranslated();
@@ -71,6 +74,15 @@ export class AppComponent implements OnInit {
         this.#renderer.removeClass(this.#document.body, 'is-keyboard-active');
       }
     });
+
+    // Delay showing the PWA prompt to avoid interrupting first paint.
+    // On iOS Safari, we trigger the prompt manually if it should be shown.
+    // On Android, the service auto-triggers on beforeinstallprompt event.
+    setTimeout(() => {
+      if (this.#pwaInstallService.isIos() && this.#pwaInstallService.shouldShowPrompt()) {
+        this.#pwaInstallService.showPrompt();
+      }
+    }, 5000);
   }
 
   #addPreconnectLink(): void {
@@ -86,12 +98,24 @@ export class AppComponent implements OnInit {
     this.#document.head.appendChild(appLink);
   }
 
-  #addSvgIcon(): void {
-    this.matIconRegistry.addSvgIconLiteral(
+  #addEcoLogoIcon(): void {
+    this.#matIconRegistry.addSvgIconLiteral(
       'eco_logo',
-      this.domSanitizer.bypassSecurityTrustHtml(`
+      this.#domSanitizer.bypassSecurityTrustHtml(`
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%">
-          <path d="M17,8C8,10 5.9,16.17 3.82,21.34L5.71,22L6.66,19.7C7.14,19.87 7.64,20 8,20C19,20 22,3 22,3C21,5 14,5.25 9,6.25C4,7.25 2,11.5 2,13.5C2,15.5 3.75,17.25 3.75,17.25C7,8 17,8 17,8Z"/>
+          <path fill="currentColor" d="M17,8C8,10 5.9,16.17 3.82,21.34L5.71,22L6.66,19.7C7.14,19.87 7.64,20 8,20C19,20 22,3 22,3C21,5 14,5.25 9,6.25C4,7.25 2,11.5 2,13.5C2,15.5 3.75,17.25 3.75,17.25C7,8 17,8 17,8Z"/>
+        </svg>
+      `)
+    );
+  }
+
+  #addIosSafariIcon(): void {
+    this.#matIconRegistry.addSvgIconLiteral(
+      'safari',
+      this.#domSanitizer.bypassSecurityTrustHtml(`
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="10"></circle>
+          <polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"></polygon>
         </svg>
       `)
     );

--- a/apps/eco-store/src/app/app.config.ts
+++ b/apps/eco-store/src/app/app.config.ts
@@ -34,9 +34,11 @@ import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 import { POCKETBASE_INSTANCE, pocketBaseFactory } from '@plastik/core/api-pocketbase';
 import { providePocketBaseWithTranslationsEnv } from '@plastik/core/environments';
 import { EcoStorePrefixTitleService } from '@plastik/eco-store/core/router-state';
+import { getPocketBaseImageUrl } from '@plastik/eco-store/shared/utils';
 import { ecoStoreTenantStore, provideEcoStoreTenant } from '@plastik/eco-store/tenant';
 import { activityStore } from '@plastik/shared/activity/data-access';
 import { ErrorHandlerService } from '@plastik/shared/notification/data-access';
+import { PWA_APP_DATA_FN, PwaInstallService, PwaManifestService } from '@plastik/shared/pwa';
 import { pocketBaseStorageLoader } from '@plastik/storage/data-access';
 import { TranslateFormatJsCompiler } from 'ngx-translate-formatjs-compiler';
 import { firstValueFrom } from 'rxjs';
@@ -91,10 +93,13 @@ export const appConfig: ApplicationConfig = {
     }),
     provideEcoStoreTenant,
     provideAppInitializer(async () => {
-      // Totes les injeccions han d'anar abans de qualsevol codi asíncron (await)
+      // All injections must be done before any async code
       const translate = inject(TranslateService);
       const activity = inject(activityStore);
       const tenantStore = inject(ecoStoreTenantStore);
+      inject(PwaInstallService);
+      const pwaManifest = inject(PwaManifestService);
+      const getAppData = inject(PWA_APP_DATA_FN);
 
       const defaultLang = environment.defaultLanguage || 'ca';
       const browserLang =
@@ -114,6 +119,7 @@ export const appConfig: ApplicationConfig = {
 
       activity.setActivity(true);
       await tenantStore.getTenant();
+      await pwaManifest.applyBranding(getAppData());
     }),
     { provide: LOCALE_ID, useValue: 'ca' },
     { provide: ErrorHandler, useClass: ErrorHandlerService },
@@ -125,6 +131,19 @@ export const appConfig: ApplicationConfig = {
     {
       provide: IMAGE_LOADER,
       useValue: pocketBaseStorageLoader(environment.baseApiUrl),
+    },
+    {
+      provide: PWA_APP_DATA_FN,
+      useFactory: () => {
+        const store = inject(ecoStoreTenantStore);
+
+        return () => {
+          const tenant = store.tenant();
+          const logoPath = getPocketBaseImageUrl(tenant, tenant?.logo);
+          const logo = logoPath ? `${environment.baseApiUrl}api/files/${logoPath}` : undefined;
+          return { name: tenant?.name, logo, defaultLogo: 'eco_logo' };
+        };
+      },
     },
   ],
 };

--- a/apps/eco-store/src/index.html
+++ b/apps/eco-store/src/index.html
@@ -34,9 +34,13 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
+    <link
+      id="apple-touch-icon"
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/icons/apple-touch-icon.png" />
 
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link id="app-manifest" rel="manifest" href="/manifest.webmanifest" />
 
     <script>
       (function () {
@@ -63,7 +67,7 @@
 
     <link
       rel="preload"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block&icon_names=access_time,account_cancel,account_circle,add,add_home,admin_panel_settings,arrow_back,arrow_downward,arrow_forward,arrow_upward,auto_awesome,badge,balance,bento,box,calendar_month,check,check_circle,chevron_right,cleaning_services,clear,clock_loader_10,close,cookie,counter_1,counter_2,counter_3,dark_mode,delete,delete_outline,desktop_mac,done,eco,eco_logo,edit,egg,error,expand_more,favorite,gps_fixed,grain,grocery,help_outline,history,history_toggle_off,home,hourglass_top,how_to_reg,image,image_not_supported,info,keyboard_arrow_down,keyboard_arrow_up,language,light_mode,lightbulb,liquor,list_alt,local_cafe,local_offer,local_shipping,location_on,lock,lock_clock,lock_reset,logout,manage_accounts,menu,nature,nutrition,order_approve,package_2,pause,payments,pending,person,phone,photo_camera,priority,public,receipt,receipt_long,remove,restaurant,rice_bowl,search,security,sentiment_very_dissatisfied,shopping_basket,shopping_cart,spa,star,store,storefront,takeout_dining,thumb_up,timer,trending_down,trending_up,upload,verified,visibility,visibility_off,warning,water_drop,zoom_in,zoom_out"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block&icon_names=access_time,account_cancel,account_circle,add,add_home,admin_panel_settings,arrow_back,arrow_downward,arrow_forward,arrow_upward,auto_awesome,badge,balance,bento,box,calendar_month,check,check_circle,chevron_right,cleaning_services,clear,clock_loader_10,close,cookie,counter_1,counter_2,counter_3,dark_mode,delete,delete_outline,desktop_mac,done,eco,eco_logo,edit,egg,error,expand_more,favorite,gps_fixed,grain,grocery,help_outline,history,history_toggle_off,home,hourglass_top,how_to_reg,image,image_not_supported,info,ios_share,keyboard_arrow_down,keyboard_arrow_up,language,light_mode,lightbulb,liquor,list_alt,local_cafe,local_offer,local_shipping,location_on,lock,lock_clock,lock_reset,logout,manage_accounts,menu,more_vert,nature,nutrition,order_approve,package_2,pause,payments,pending,person,phone,photo_camera,priority,public,receipt,receipt_long,remove,restaurant,rice_bowl,search,security,sentiment_very_dissatisfied,shopping_basket,shopping_cart,spa,star,store,storefront,takeout_dining,thumb_up,timer,trending_down,trending_up,upload,verified,visibility,visibility_off,warning,water_drop,zoom_in,zoom_out"
       as="style"
       type="text/css"
       onload="
@@ -73,7 +77,7 @@
     <noscript>
       <link
         rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block&icon_names=access_time,account_cancel,account_circle,add,add_home,admin_panel_settings,arrow_back,arrow_downward,arrow_forward,arrow_upward,auto_awesome,badge,balance,bento,box,calendar_month,check,check_circle,chevron_right,cleaning_services,clear,clock_loader_10,close,cookie,counter_1,counter_2,counter_3,dark_mode,delete,delete_outline,desktop_mac,done,eco,eco_logo,edit,egg,error,expand_more,favorite,gps_fixed,grain,grocery,help_outline,history,history_toggle_off,home,hourglass_top,how_to_reg,image,image_not_supported,info,keyboard_arrow_down,keyboard_arrow_up,language,light_mode,lightbulb,liquor,list_alt,local_cafe,local_offer,local_shipping,location_on,lock,lock_clock,lock_reset,logout,manage_accounts,menu,nature,nutrition,order_approve,package_2,pause,payments,pending,person,phone,photo_camera,priority,public,receipt,receipt_long,remove,restaurant,rice_bowl,search,security,sentiment_very_dissatisfied,shopping_basket,shopping_cart,spa,star,store,storefront,takeout_dining,thumb_up,timer,trending_down,trending_up,upload,verified,visibility,visibility_off,warning,water_drop,zoom_in,zoom_out" />
+        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block&icon_names=access_time,account_cancel,account_circle,add,add_home,admin_panel_settings,arrow_back,arrow_downward,arrow_forward,arrow_upward,auto_awesome,badge,balance,bento,box,calendar_month,check,check_circle,chevron_right,cleaning_services,clear,clock_loader_10,close,cookie,counter_1,counter_2,counter_3,dark_mode,delete,delete_outline,desktop_mac,done,eco,eco_logo,edit,egg,error,expand_more,favorite,gps_fixed,grain,grocery,help_outline,history,history_toggle_off,home,hourglass_top,how_to_reg,image,image_not_supported,info,ios_share,keyboard_arrow_down,keyboard_arrow_up,language,light_mode,lightbulb,liquor,list_alt,local_cafe,local_offer,local_shipping,location_on,lock,lock_clock,lock_reset,logout,manage_accounts,menu,more_vert,nature,nutrition,order_approve,package_2,pause,payments,pending,person,phone,photo_camera,priority,public,receipt,receipt_long,remove,restaurant,rice_bowl,search,security,sentiment_very_dissatisfied,shopping_basket,shopping_cart,spa,star,store,storefront,takeout_dining,thumb_up,timer,trending_down,trending_up,upload,verified,visibility,visibility_off,warning,water_drop,zoom_in,zoom_out" />
     </noscript>
 
     <style>

--- a/apps/eco-store/src/security-headers.json
+++ b/apps/eco-store/src/security-headers.json
@@ -4,5 +4,5 @@
   "Referrer-Policy": "strict-origin-when-cross-origin",
   "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
   "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
-  "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://eco-botiga.pockethost.io; connect-src 'self' https://eco-botiga.pockethost.io https://fonts.gstatic.com https://fonts.googleapis.com; frame-ancestors 'none'; upgrade-insecure-requests;"
+  "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://eco-botiga.pockethost.io; connect-src 'self' https://eco-botiga.pockethost.io https://fonts.gstatic.com https://fonts.googleapis.com; manifest-src 'self' blob:; frame-ancestors 'none'; upgrade-insecure-requests;"
 }

--- a/apps/eco-store/src/styles/_components.scss
+++ b/apps/eco-store/src/styles/_components.scss
@@ -144,6 +144,19 @@
       font-size: 1.1rem;
     }
   }
+
+  /* Bottom sheet — rounded top corners + blurred backdrop */
+  @include mat.bottom-sheet-overrides(
+    (
+      container-shape: var(--app-main-border-radius),
+    )
+  );
+
+  .pwa-backdrop.cdk-overlay-backdrop {
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    background-color: color-mix(in srgb, var(--primary-900), transparent 80%);
+  }
 }
 
 .input--eco {

--- a/libs/shared/pwa/.eslintrc.json
+++ b/libs/shared/pwa/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "plastik",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "plastik",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/shared/pwa/README.md
+++ b/libs/shared/pwa/README.md
@@ -1,0 +1,127 @@
+# shared/pwa
+
+Shared library providing a PWA install prompt for Angular apps. Handles the
+`beforeinstallprompt` browser event, persists dismiss state, and shows a
+Material bottom sheet with install / dismiss CTAs.
+
+## Architecture
+
+```bash
+PwaInstallService        — singleton service (providedIn: 'root')
+PwaManifestService       — optional singleton service (providedIn: 'root')
+PwaPromptComponent       — bottom sheet UI component (lazily loaded)
+PWA_APP_DATA_FN          — injection token to supply app identity (name/logo)
+```
+
+The library has **no dependency on any app-scoped code**. App identity data is
+injected via `PWA_APP_DATA_FN` so each consuming app wires up its own source.
+
+## Setup
+
+### 1. Provide app identity data
+
+In your `app.config.ts`:
+
+```typescript
+import { inject } from '@angular/core';
+import { PWA_APP_DATA_FN } from '@plastik/shared/pwa';
+import { myTenantStore } from '@my-app/tenant';
+
+{
+  provide: PWA_APP_DATA_FN,
+  useFactory: () => {
+    const store = inject(myTenantStore);
+    return () => {
+      const tenant = store.tenant();
+      return { name: tenant?.name, logo: tenant?.logo };
+    };
+  },
+},
+```
+
+### 2. Trigger the install service
+
+Inject `PwaInstallService` in your root `AppComponent` so browser event
+listeners are registered. On iOS, trigger the prompt manually after a short
+delay (iOS does not fire `beforeinstallprompt`):
+
+```typescript
+constructor() {
+  const pwa = inject(PwaInstallService);
+
+  // Android: handled automatically via beforeinstallprompt event.
+  // iOS Safari: trigger manually after first paint.
+  setTimeout(() => {
+    if (pwa.isIos() && pwa.shouldShowPrompt()) pwa.showPrompt();
+  }, 5000);
+}
+```
+
+The service automatically:
+
+- Skips initialization when running in standalone (already-installed) mode.
+- Skips initialization during SSR.
+- Checks the dismiss / installed state before showing the prompt.
+- Shows the prompt again after `DISMISS_DAYS` (15) days.
+
+### 3. Apply dynamic branding (optional)
+
+Inject `PwaManifestService` and call `applyBranding()` once tenant data is
+available to patch the web app manifest and `apple-touch-icon` with the
+tenant's name and logo:
+
+```typescript
+const manifest = inject(PwaManifestService);
+
+effect(() => {
+  const tenant = tenantStore.tenant();
+  if (tenant?.logo) {
+    manifest.applyBranding({ name: tenant.name, logo: tenant.logo });
+  }
+});
+```
+
+`applyBranding` is a no-op on the server (SSR-safe). It fetches the static
+`/manifest.webmanifest`, patches the icons and name, and replaces the manifest
+`<link>` with a Blob URL. The Blob URL is revoked automatically on destroy.
+
+## Dismiss / install state
+
+| localStorage key    | Meaning                                   |
+| ------------------- | ----------------------------------------- |
+| `eco_pwa_dismissed` | Unix timestamp of last dismissal          |
+| `eco_pwa_installed` | `"1"` when the user accepted installation |
+
+## Testing in DevTools (Chrome)
+
+1. Open DevTools → **Application** tab → **Manifest**.
+2. Scroll to **Add to homescreen** and click **Add to homescreen** to
+   simulate the `beforeinstallprompt` event.
+3. To reset state: open **Application → Storage → Clear site data** (clears
+   `localStorage` entries above).
+4. To test iOS instructions: in DevTools → **Sensors**, set **User agent** to
+   `Mobile Safari` on an iPhone/iPad UA string.
+
+## Translations
+
+All UI strings are keyed under `common.pwa.*` in the app's i18n JSON files:
+
+| Key                                  | Used when                        |
+| ------------------------------------ | -------------------------------- |
+| `common.pwa.title`                   | Always                           |
+| `common.pwa.description`             | Always                           |
+| `common.pwa.install`                 | Android / Chrome install button  |
+| `common.pwa.later`                   | Android / Chrome defer button    |
+| `common.pwa.close`                   | iOS and non-Safari close button  |
+| `common.pwa.howToInstall`            | iOS Safari step list eyebrow     |
+| `common.pwa.iosInstructionsStep1`    | iOS ≥ 17 (Share button location) |
+| `common.pwa.iosInstructionsStep1Old` | iOS < 17 (Share button location) |
+| `common.pwa.iosInstructionsStep2`    | iOS: "Add to Home Screen" scroll |
+| `common.pwa.iosInstructionsStep3`    | iOS: confirm add                 |
+| `common.pwa.iosSafariRequired`       | iOS with non-Safari browser      |
+
+## Running unit tests
+
+```bash
+yarn nx test pwa
+```

--- a/libs/shared/pwa/project.json
+++ b/libs/shared/pwa/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "pwa",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/shared/pwa/src",
+  "prefix": "lib",
+  "projectType": "library",
+  "tags": ["scope:shared", "type:feature"],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "reportsDirectory": "../../../coverage/libs/shared/pwa"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/shared/pwa/src/index.ts
+++ b/libs/shared/pwa/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/services/pwa-install.service';
+export * from './lib/services/pwa-manifest.service';

--- a/libs/shared/pwa/src/lib/components/pwa-prompt/pwa-prompt.component.html
+++ b/libs/shared/pwa/src/lib/components/pwa-prompt/pwa-prompt.component.html
@@ -1,0 +1,119 @@
+<div
+  role="dialog"
+  class="flex flex-col gap-5 p-6 pb-12"
+  [attr.aria-label]="'common.pwa.title' | translate">
+  <!-- Drag handle -->
+  <div class="mx-auto h-1 w-10 rounded-full bg-[var(--mat-sys-outline-variant)] opacity-60"></div>
+
+  <!-- Identity: icon · name · tagline -->
+  <div class="flex items-center gap-4">
+    @if (data.logo) {
+      <plastik-img-container
+        class="h-12 w-12 shrink-0 object-cover"
+        [src]="data.logo"
+        [title]="data.name"
+        [lcpImage]="true"
+        [dimensions]="{ height: 50, width: 50 }" />
+    } @else if (data.defaultLogo) {
+      <span
+        class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-[var(--mat-sys-primary-container)] text-[var(--mat-sys-on-primary-container)] shadow-md">
+        <mat-icon class="scale-125" [svgIcon]="data.defaultLogo"></mat-icon>
+      </span>
+    }
+    <div class="min-w-0 flex-1">
+      <h2 class="text-xl leading-tight font-bold tracking-tight text-[var(--mat-sys-on-surface)]">
+        {{ data.name || ('common.pwa.title' | translate) }}
+      </h2>
+      <p class="mt-1 text-sm leading-snug text-[var(--mat-sys-on-surface-variant)]">
+        {{ 'common.pwa.description' | translate }}
+      </p>
+    </div>
+  </div>
+
+  <!-- Content card -->
+  <div class="flex flex-col gap-4 bg-[var(--mat-sys-surface-container-low)] p-5">
+    @if (pwa.isIosAndNotSafari()) {
+      <!-- iOS not Safari: nudge to open in Safari -->
+      <div class="flex flex-col items-center gap-4 py-2 text-center">
+        <div
+          class="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--mat-sys-primary-container)] text-[var(--mat-sys-on-primary-container)]">
+          <mat-icon svgIcon="safari" class="!h-6 !w-6"></mat-icon>
+        </div>
+        <p class="text-sm font-medium text-[var(--mat-sys-on-surface)]">
+          {{ 'common.pwa.iosSafariRequired' | translate }}
+        </p>
+        <button mat-flat-button class="w-full" (click)="close()">
+          {{ 'common.pwa.close' | translate }}
+        </button>
+      </div>
+    } @else {
+      @if (pwa.isIos()) {
+        <!-- iOS Safari: eyebrow + 3 connected steps -->
+        <p
+          class="text-[0.625rem] font-semibold tracking-[0.12em] text-[var(--mat-sys-primary)] uppercase">
+          {{ 'common.pwa.howToInstall' | translate }}
+        </p>
+        <ol class="flex flex-col">
+          <li class="relative flex items-center justify-start gap-3 pb-5">
+            <div
+              class="connector absolute top-6 bottom-0 left-3 w-px bg-[var(--mat-sys-outline-variant)]"></div>
+            <span
+              class="pwa-step-badge relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--mat-sys-primary)] text-xs font-bold text-[var(--mat-sys-on-primary)]"
+              >1</span
+            >
+            <p
+              class="grid grid-cols-[auto_1fr] items-center gap-1.5 pt-0.5 text-sm leading-none text-[var(--mat-sys-on-surface-variant)]">
+              @if (pwa.isOldIos()) {
+                {{ 'common.pwa.iosInstructionsStep1Old' | translate }}
+              } @else {
+                {{ 'common.pwa.iosInstructionsStep1' | translate }}
+              }
+              <mat-icon class="text-[var(--mat-sys-primary)]">ios_share</mat-icon>
+            </p>
+          </li>
+          <li class="relative flex items-center justify-start gap-3 pb-5">
+            <div
+              class="connector absolute top-6 bottom-0 left-3 w-px bg-[var(--mat-sys-outline-variant)]"></div>
+            <span
+              class="pwa-step-badge relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--mat-sys-primary)] text-xs font-bold text-[var(--mat-sys-on-primary)]"
+              >2</span
+            >
+            <p class="pt-0.5 text-sm text-[var(--mat-sys-on-surface-variant)]">
+              {{ 'common.pwa.iosInstructionsStep2' | translate }}
+            </p>
+          </li>
+          <li class="relative flex items-center justify-start gap-3">
+            <span
+              class="pwa-step-badge relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--mat-sys-primary)] text-xs font-bold text-[var(--mat-sys-on-primary)]"
+              >3</span
+            >
+            <p class="pt-0.5 text-sm text-[var(--mat-sys-on-surface-variant)]">
+              {{ 'common.pwa.iosInstructionsStep3' | translate }}
+            </p>
+          </li>
+        </ol>
+        <button matButton="filled" class="w-full" (click)="close()">
+          {{ 'common.pwa.close' | translate }}
+        </button>
+      } @else {
+        <!-- Android / Chrome: native prompt available — one tap to install -->
+        <div class="flex flex-row justify-end gap-4">
+          <button
+            matButton="filled"
+            class="w-full lg:w-auto"
+            [attr.aria-label]="'common.pwa.install' | translate"
+            (click)="install()">
+            {{ 'common.pwa.install' | translate }}
+          </button>
+          <button
+            matButton="outlined"
+            class="w-full lg:w-auto"
+            [attr.aria-label]="'common.pwa.later' | translate"
+            (click)="later()">
+            {{ 'common.pwa.later' | translate }}
+          </button>
+        </div>
+      }
+    }
+  </div>
+</div>

--- a/libs/shared/pwa/src/lib/components/pwa-prompt/pwa-prompt.component.spec.ts
+++ b/libs/shared/pwa/src/lib/components/pwa-prompt/pwa-prompt.component.spec.ts
@@ -1,0 +1,248 @@
+import { provideHttpClient } from '@angular/common/http';
+import { ChangeDetectorRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_BOTTOM_SHEET_DATA, MatBottomSheetRef } from '@angular/material/bottom-sheet';
+import { MatIcon, MatIconModule, MatIconRegistry } from '@angular/material/icon';
+import { By } from '@angular/platform-browser';
+import { TranslateModule } from '@ngx-translate/core';
+import { of, Subject } from 'rxjs';
+import { PwaInstallService } from '../../services/pwa-install.service';
+import { PwaPromptComponent } from './pwa-prompt.component';
+
+describe('PwaPromptComponent', () => {
+  let component: PwaPromptComponent;
+  let fixture: ComponentFixture<PwaPromptComponent>;
+  let cdr: ChangeDetectorRef;
+  let dismissedSubject: Subject<void>;
+
+  const mockPwaService = {
+    isIos: vi.fn().mockReturnValue(false),
+    isIosAndNotSafari: vi.fn().mockReturnValue(false),
+    isOldIos: vi.fn().mockReturnValue(false),
+    installPwa: vi.fn().mockResolvedValue('accepted'),
+    dismissForLater: vi.fn(),
+  };
+
+  const mockBottomSheetRef = { dismiss: vi.fn(), afterDismissed: vi.fn() };
+
+  const mockData = {
+    name: 'Eco Shop',
+    logo: 'shop.png',
+    defaultLogo: 'eco_logo',
+  };
+
+  const mockMatIconRegistry = {
+    getNamedSvgIcon: vi
+      .fn()
+      .mockReturnValue(of(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))),
+    addSvgIconLiteral: vi.fn(),
+    getDefaultFontSetClass: vi.fn().mockReturnValue(['material-icons']),
+    getGroupConfig: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Fresh subject per test so subjects don't bleed across tests.
+    dismissedSubject = new Subject<void>();
+    mockBottomSheetRef.dismiss.mockImplementation(() => dismissedSubject.next());
+    mockBottomSheetRef.afterDismissed.mockReturnValue(dismissedSubject.asObservable());
+
+    mockPwaService.isIos.mockReturnValue(false);
+    mockPwaService.isIosAndNotSafari.mockReturnValue(false);
+    mockPwaService.isOldIos.mockReturnValue(false);
+    mockPwaService.installPwa.mockResolvedValue('accepted');
+
+    await TestBed.configureTestingModule({
+      imports: [PwaPromptComponent, MatIconModule, TranslateModule.forRoot()],
+      providers: [
+        { provide: PwaInstallService, useValue: mockPwaService },
+        { provide: MatBottomSheetRef, useValue: mockBottomSheetRef },
+        { provide: MAT_BOTTOM_SHEET_DATA, useValue: mockData },
+        { provide: MatIconRegistry, useValue: mockMatIconRegistry },
+        provideHttpClient(),
+      ],
+    }).compileComponents();
+  });
+
+  /**
+   * Creates a new test component fixture.
+   */
+  function createComponent() {
+    fixture = TestBed.createComponent(PwaPromptComponent);
+    component = fixture.componentInstance;
+    cdr = fixture.componentRef.injector.get(ChangeDetectorRef);
+    fixture.detectChanges();
+  }
+
+  it('should create', () => {
+    createComponent();
+    expect(component).toBeTruthy();
+  });
+
+  describe('Identity rendering', () => {
+    it('renders the custom logo when provided', () => {
+      createComponent();
+      const img = fixture.debugElement.query(By.css('plastik-img-container'));
+      expect(img).toBeTruthy();
+      expect(img.componentInstance.src()).toBe(mockData.logo);
+    });
+
+    it('renders the default icon when logo is missing', () => {
+      TestBed.overrideProvider(MAT_BOTTOM_SHEET_DATA, {
+        useValue: { ...mockData, logo: undefined },
+      });
+      createComponent();
+      const iconDebug = fixture.debugElement.query(By.directive(MatIcon));
+      expect(iconDebug).toBeTruthy();
+      expect(iconDebug.componentInstance.svgIcon).toBe(mockData.defaultLogo);
+    });
+
+    it('uses data.name in the heading', () => {
+      createComponent();
+      const h2 = fixture.nativeElement.querySelector('h2');
+      expect(h2.textContent).toContain(mockData.name);
+    });
+
+    it('falls back to translated title if data.name is missing', () => {
+      TestBed.overrideProvider(MAT_BOTTOM_SHEET_DATA, { useValue: { ...mockData, name: '' } });
+      createComponent();
+      const h2 = fixture.nativeElement.querySelector('h2');
+      expect(h2.textContent).toContain('common.pwa.title');
+    });
+  });
+
+  describe('install()', () => {
+    beforeEach(() => createComponent());
+
+    it('calls installPwa() and dismisses the sheet on completion', async () => {
+      component.install();
+      await fixture.whenStable();
+      expect(mockPwaService.installPwa).toHaveBeenCalled();
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalled();
+    });
+
+    it('does not call dismissForLater — installPwa() manages its own state', async () => {
+      component.install();
+      await fixture.whenStable();
+      expect(mockPwaService.dismissForLater).not.toHaveBeenCalled();
+    });
+
+    it('dismisses even when installPwa returns dismissed', async () => {
+      mockPwaService.installPwa.mockResolvedValueOnce('dismissed');
+      component.install();
+      await fixture.whenStable();
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalled();
+    });
+  });
+
+  describe('later()', () => {
+    it('dismisses the sheet and calls dismissForLater via afterDismissed', () => {
+      createComponent();
+      component.later();
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalled();
+      expect(mockPwaService.dismissForLater).toHaveBeenCalled();
+    });
+  });
+
+  describe('close()', () => {
+    it('dismisses the sheet and calls dismissForLater via afterDismissed', () => {
+      createComponent();
+      component.close();
+      expect(mockBottomSheetRef.dismiss).toHaveBeenCalled();
+      expect(mockPwaService.dismissForLater).toHaveBeenCalled();
+      expect(mockPwaService.installPwa).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('backdrop / external dismiss', () => {
+    it('calls dismissForLater when the sheet is dismissed without an explicit action', () => {
+      createComponent();
+      dismissedSubject.next(); // simulate backdrop tap or swipe-to-dismiss
+      expect(mockPwaService.dismissForLater).toHaveBeenCalled();
+    });
+
+    it('does not call dismissForLater a second time when install preceded the dismiss', async () => {
+      createComponent();
+      component.install();
+      await fixture.whenStable(); // dismiss() fires → dismissedSubject.next()
+      expect(mockPwaService.dismissForLater).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('template — Android (default)', () => {
+    beforeEach(() => createComponent());
+
+    it('renders an install and a later button', () => {
+      const buttons = fixture.nativeElement.querySelectorAll('button');
+      expect(buttons.length).toBe(2);
+      expect(buttons[0].textContent).toContain('common.pwa.install');
+      expect(buttons[1].textContent).toContain('common.pwa.later');
+    });
+
+    it('does not render the iOS step list', () => {
+      expect(fixture.nativeElement.querySelector('ol')).toBeNull();
+    });
+  });
+
+  describe('template — iOS Safari', () => {
+    beforeEach(() => {
+      mockPwaService.isIos.mockReturnValue(true);
+      mockPwaService.isIosAndNotSafari.mockReturnValue(false);
+      createComponent();
+    });
+
+    it('renders three installation steps', () => {
+      const steps = fixture.nativeElement.querySelectorAll('ol li');
+      expect(steps.length).toBe(3);
+    });
+
+    it('renders step 1 for modern iOS by default', () => {
+      const step1 = fixture.nativeElement.querySelector('ol li');
+      expect(step1.textContent).toContain('common.pwa.iosInstructionsStep1');
+    });
+
+    it('renders step 1 for old iOS when isOldIos is true', () => {
+      mockPwaService.isOldIos.mockReturnValue(true);
+      cdr.markForCheck();
+      fixture.detectChanges();
+      const step1 = fixture.nativeElement.querySelector('ol li');
+      expect(step1.textContent).toContain('common.pwa.iosInstructionsStep1Old');
+    });
+
+    it('renders a single close button (no install button)', () => {
+      const buttons = fixture.nativeElement.querySelectorAll('button');
+      expect(buttons.length).toBe(1);
+      expect(buttons[0].textContent).toContain('common.pwa.close');
+    });
+  });
+
+  describe('template — iOS non-Safari', () => {
+    beforeEach(() => {
+      mockPwaService.isIosAndNotSafari.mockReturnValue(true);
+      createComponent();
+    });
+
+    it('shows the Safari required message', () => {
+      expect(fixture.nativeElement.textContent).toContain('common.pwa.iosSafariRequired');
+    });
+
+    it('does not render the iOS step list', () => {
+      expect(fixture.nativeElement.querySelector('ol')).toBeNull();
+    });
+
+    it('renders a single close button', () => {
+      const buttons = fixture.nativeElement.querySelectorAll('button');
+      expect(buttons.length).toBe(1);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has a dialog role and proper aria-label', () => {
+      createComponent();
+      const container = fixture.nativeElement.querySelector('div[role="dialog"]');
+      expect(container).toBeTruthy();
+      expect(container.getAttribute('aria-label')).toBe('common.pwa.title');
+    });
+  });
+});

--- a/libs/shared/pwa/src/lib/components/pwa-prompt/pwa-prompt.component.ts
+++ b/libs/shared/pwa/src/lib/components/pwa-prompt/pwa-prompt.component.ts
@@ -1,0 +1,52 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MAT_BOTTOM_SHEET_DATA, MatBottomSheetRef } from '@angular/material/bottom-sheet';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { TranslateModule } from '@ngx-translate/core';
+import { SharedImgContainerComponent } from '@plastik/shared/img-container';
+import { PwaInstallService } from '../../services/pwa-install.service';
+
+@Component({
+  selector: 'plastik-pwa-prompt',
+  imports: [MatButtonModule, MatIconModule, TranslateModule, SharedImgContainerComponent],
+  templateUrl: './pwa-prompt.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'block',
+  },
+})
+export class PwaPromptComponent {
+  protected readonly pwa = inject(PwaInstallService);
+  protected readonly data = inject<{ name: string; logo: string; defaultLogo?: string }>(
+    MAT_BOTTOM_SHEET_DATA
+  );
+  readonly #bottomSheetRef = inject(MatBottomSheetRef<PwaPromptComponent>);
+  #installAttempted = false;
+
+  constructor() {
+    // Covers all dismiss paths: close button, later button, backdrop tap, swipe-to-dismiss.
+    // installPwa() manages its own state, so we skip it via the flag.
+    this.#bottomSheetRef
+      .afterDismissed()
+      .pipe(takeUntilDestroyed())
+      .subscribe(() => {
+        if (!this.#installAttempted) {
+          this.pwa.dismissForLater();
+        }
+      });
+  }
+
+  install(): void {
+    this.#installAttempted = true;
+    this.pwa.installPwa().then(() => this.#bottomSheetRef.dismiss());
+  }
+
+  later(): void {
+    this.#bottomSheetRef.dismiss();
+  }
+
+  close(): void {
+    this.#bottomSheetRef.dismiss();
+  }
+}

--- a/libs/shared/pwa/src/lib/services/pwa-install.service.spec.ts
+++ b/libs/shared/pwa/src/lib/services/pwa-install.service.spec.ts
@@ -1,0 +1,287 @@
+import { Platform } from '@angular/cdk/platform';
+import { TestBed } from '@angular/core/testing';
+import { MatBottomSheet } from '@angular/material/bottom-sheet';
+import { PWA_APP_DATA_FN, PwaInstallService } from './pwa-install.service';
+
+// Stub PwaPromptComponent so showPrompt()'s dynamic import resolves immediately
+// without triggering Angular template compilation, making tests deterministic.
+vi.mock('../components/pwa-prompt/pwa-prompt.component', () => ({
+  PwaPromptComponent: class PwaPromptComponent {},
+}));
+
+const DISMISS_KEY = 'eco_pwa_dismissed';
+const INSTALLED_KEY = 'eco_pwa_installed';
+const DISMISS_DAYS_MS = 15 * 24 * 60 * 60 * 1000;
+
+/**
+ * Creates a mock beforeinstallprompt event.
+ * @param {'accepted' | 'dismissed'} outcome - The simulated user choice outcome.
+ * @returns {Event} The event instance.
+ */
+function makeInstallEvent(outcome: 'accepted' | 'dismissed' = 'accepted'): Event {
+  const e = new Event('beforeinstallprompt');
+  Object.assign(e, {
+    preventDefault: vi.fn(),
+    prompt: vi.fn().mockResolvedValue(undefined),
+    userChoice: Promise.resolve({ outcome, platform: '' }),
+  });
+  return e;
+}
+
+describe('PwaInstallService', () => {
+  let service: PwaInstallService;
+  let bottomSheetOpen: ReturnType<typeof vi.fn>;
+  const mockPlatform = { IOS: false, ANDROID: false, SAFARI: false };
+
+  // Pre-warm @angular/material/bottom-sheet so showPrompt()'s Promise.all
+  // resolves instantly in tests rather than racing against first-load latency.
+  beforeAll(async () => {
+    await import('@angular/material/bottom-sheet');
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    mockPlatform.IOS = false;
+    mockPlatform.ANDROID = false;
+    mockPlatform.SAFARI = false;
+    bottomSheetOpen = vi.fn();
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockReturnValue({ matches: false }),
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        PwaInstallService,
+        { provide: MatBottomSheet, useValue: { open: bottomSheetOpen } },
+        { provide: PWA_APP_DATA_FN, useValue: () => ({ name: 'Eco Shop', logo: '' }) },
+        { provide: Platform, useValue: mockPlatform },
+      ],
+    });
+
+    service = TestBed.inject(PwaInstallService);
+  });
+
+  it('should create', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('beforeinstallprompt', () => {
+    it('sets promptAvailable to true', () => {
+      expect(service.promptAvailable()).toBe(false);
+      window.dispatchEvent(makeInstallEvent());
+      expect(service.promptAvailable()).toBe(true);
+    });
+
+    it('opens the bottom sheet when not previously dismissed', async () => {
+      window.dispatchEvent(makeInstallEvent());
+      await vi.waitFor(() => expect(bottomSheetOpen).toHaveBeenCalled(), { timeout: 2000 });
+    });
+
+    it('does not open a second sheet when the event fires again in the same session', async () => {
+      window.dispatchEvent(makeInstallEvent());
+      await vi.waitFor(() => expect(bottomSheetOpen).toHaveBeenCalledTimes(1), { timeout: 2000 });
+      window.dispatchEvent(makeInstallEvent());
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(bottomSheetOpen).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not open the sheet when dismissed within DISMISS_DAYS', async () => {
+      localStorage.setItem(DISMISS_KEY, String(Date.now()));
+      window.dispatchEvent(makeInstallEvent());
+      // Wait a bit to ensure it doesn't open
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(bottomSheetOpen).not.toHaveBeenCalled();
+    });
+
+    it('opens the sheet when dismissal is older than DISMISS_DAYS', async () => {
+      localStorage.setItem(DISMISS_KEY, String(Date.now() - DISMISS_DAYS_MS - 1000));
+      window.dispatchEvent(makeInstallEvent());
+      await vi.waitFor(() => expect(bottomSheetOpen).toHaveBeenCalled(), { timeout: 2000 });
+    });
+
+    it('does not open the sheet when already installed', async () => {
+      localStorage.setItem(INSTALLED_KEY, '1');
+      window.dispatchEvent(makeInstallEvent());
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(bottomSheetOpen).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('appinstalled', () => {
+    it('clears promptAvailable and marks installed in localStorage', () => {
+      service.promptAvailable.set(true);
+      window.dispatchEvent(new Event('appinstalled'));
+      expect(service.promptAvailable()).toBe(false);
+      expect(localStorage.getItem(INSTALLED_KEY)).toBe('1');
+      expect(localStorage.getItem(DISMISS_KEY)).toBeNull();
+    });
+  });
+
+  describe('isIos()', () => {
+    it('returns true when platform is iOS and not standalone', () => {
+      mockPlatform.IOS = true;
+      expect(service.isIos()).toBe(true);
+    });
+
+    it('returns false when already in standalone mode', () => {
+      mockPlatform.IOS = true;
+      vi.spyOn(service, 'isStandalone').mockReturnValue(true);
+      expect(service.isIos()).toBe(false);
+    });
+  });
+
+  describe('isIosAndNotSafari()', () => {
+    beforeEach(() => {
+      mockPlatform.IOS = true;
+    });
+
+    it('returns false when not on iOS', () => {
+      mockPlatform.IOS = false;
+      expect(service.isIosAndNotSafari()).toBe(false);
+    });
+
+    it('returns false when in standalone mode', () => {
+      vi.spyOn(service, 'isStandalone').mockReturnValue(true);
+      expect(service.isIosAndNotSafari()).toBe(false);
+    });
+
+    it('returns false for a standard Safari UA', () => {
+      vi.stubGlobal('navigator', {
+        userAgent:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 Version/17.4.1 Mobile/15E148 Safari/604.1',
+      });
+      expect(service.isIosAndNotSafari()).toBe(false);
+    });
+
+    it.each([
+      [
+        'Chrome (CriOS)',
+        'Mozilla/5.0 (iPhone) AppleWebKit/605.1.15 CriOS/123.0 Mobile/15E148 Safari/604.1',
+      ],
+      [
+        'Edge (EdgiOS)',
+        'Mozilla/5.0 (iPhone) AppleWebKit/605.1.15 EdgiOS/123.0 Mobile/15E148 Safari/604.1',
+      ], // cspell:ignore EdgiOS
+      [
+        'Firefox (FxiOS)',
+        'Mozilla/5.0 (iPhone) AppleWebKit/605.1.15 FxiOS/123.0 Mobile/15E148 Safari/604.1',
+      ],
+      [
+        'Opera (OPiOS)',
+        'Mozilla/5.0 (iPhone) AppleWebKit/605.1.15 OPiOS/18.0 Mobile/15E148 Safari/604.1',
+      ],
+    ])('returns true for iOS %s', (_, ua) => {
+      vi.stubGlobal('navigator', { userAgent: ua });
+      expect(service.isIosAndNotSafari()).toBe(true);
+    });
+  });
+
+  describe('isOldIos()', () => {
+    it('identifies iOS version < 17', () => {
+      mockPlatform.IOS = true;
+      vi.stubGlobal('navigator', {
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X)',
+      });
+      expect(service.isOldIos()).toBe(true);
+    });
+
+    it('identifies iOS version >= 17', () => {
+      mockPlatform.IOS = true;
+      vi.stubGlobal('navigator', {
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X)',
+      });
+      expect(service.isOldIos()).toBe(false);
+    });
+
+    it('returns false if not iOS', () => {
+      mockPlatform.IOS = false;
+      expect(service.isOldIos()).toBe(false);
+    });
+  });
+
+  describe('isStandalone()', () => {
+    it('returns false when matchMedia does not match', () => {
+      expect(service.isStandalone()).toBe(false);
+    });
+
+    it('returns true when matchMedia matches standalone', () => {
+      (window.matchMedia as ReturnType<typeof vi.fn>).mockReturnValue({ matches: true });
+      expect(service.isStandalone()).toBe(true);
+    });
+  });
+
+  describe('shouldShowPrompt()', () => {
+    it('returns true when never dismissed or installed', () => {
+      expect(service.shouldShowPrompt()).toBe(true);
+    });
+
+    it('returns false when already installed', () => {
+      localStorage.setItem(INSTALLED_KEY, '1');
+      expect(service.shouldShowPrompt()).toBe(false);
+    });
+
+    it('returns false when dismissed within DISMISS_DAYS', () => {
+      localStorage.setItem(DISMISS_KEY, String(Date.now()));
+      expect(service.shouldShowPrompt()).toBe(false);
+    });
+
+    it('returns true when dismissed more than DISMISS_DAYS ago', () => {
+      localStorage.setItem(DISMISS_KEY, String(Date.now() - DISMISS_DAYS_MS - 1000));
+      expect(service.shouldShowPrompt()).toBe(true);
+    });
+  });
+
+  describe('dismissForLater()', () => {
+    it('stores a timestamp and sets promptAvailable to false', () => {
+      service.promptAvailable.set(true);
+      service.dismissForLater();
+      expect(localStorage.getItem(DISMISS_KEY)).toBeTruthy();
+      expect(service.promptAvailable()).toBe(false);
+    });
+  });
+
+  describe('installPwa()', () => {
+    it('returns no-prompt when no deferred prompt is stored', async () => {
+      const result = await service.installPwa();
+      expect(result).toBe('no-prompt');
+    });
+
+    it('returns accepted and marks installed when user accepts', async () => {
+      localStorage.setItem(INSTALLED_KEY, '1');
+      window.dispatchEvent(makeInstallEvent('accepted'));
+      const result = await service.installPwa();
+      expect(result).toBe('accepted');
+      expect(localStorage.getItem(INSTALLED_KEY)).toBe('1');
+      expect(service.promptAvailable()).toBe(false);
+    });
+
+    it('returns dismissed and stores dismiss timestamp when user dismisses', async () => {
+      localStorage.setItem(INSTALLED_KEY, '1');
+      window.dispatchEvent(makeInstallEvent('dismissed'));
+      const result = await service.installPwa();
+      expect(result).toBe('dismissed');
+      expect(localStorage.getItem(DISMISS_KEY)).toBeTruthy();
+    });
+
+    it('returns no-prompt when prompt() times out', async () => {
+      vi.useFakeTimers();
+      localStorage.setItem(INSTALLED_KEY, '1');
+      const event = new Event('beforeinstallprompt');
+      Object.assign(event, {
+        preventDefault: vi.fn(),
+        prompt: vi.fn().mockReturnValue(new Promise(() => {})),
+        userChoice: Promise.resolve({ outcome: 'accepted', platform: '' }),
+      });
+      window.dispatchEvent(event);
+
+      const resultPromise = service.installPwa();
+      await vi.advanceTimersByTimeAsync(10_001);
+      const result = await resultPromise;
+      expect(result).toBe('no-prompt');
+      vi.useRealTimers();
+    });
+  });
+});

--- a/libs/shared/pwa/src/lib/services/pwa-install.service.ts
+++ b/libs/shared/pwa/src/lib/services/pwa-install.service.ts
@@ -1,0 +1,213 @@
+import { Platform } from '@angular/cdk/platform';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import {
+  DestroyRef,
+  inject,
+  Injectable,
+  InjectionToken,
+  Injector,
+  PLATFORM_ID,
+  runInInjectionContext,
+  signal,
+} from '@angular/core';
+
+const DISMISS_KEY = 'eco_pwa_dismissed';
+const INSTALLED_KEY = 'eco_pwa_installed';
+const DISMISS_DAYS = 15;
+const PROMPT_TIMEOUT_MS = 10_000;
+
+/**
+ * @description Interface for the beforeinstallprompt event.
+ */
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{
+    outcome: 'accepted' | 'dismissed';
+    platform: string;
+  }>;
+  prompt(): Promise<void>;
+}
+
+/**
+ * @description Interface for the PWA app data.
+ */
+export interface PwaAppData {
+  name?: string;
+  logo?: string;
+  defaultLogo?: string;
+}
+
+/** Provide a factory function that returns current app identity data for the install prompt. */
+export const PWA_APP_DATA_FN = new InjectionToken<() => PwaAppData>('PWA_APP_DATA_FN', {
+  providedIn: 'root',
+  factory: () => () => ({}),
+});
+
+@Injectable({ providedIn: 'root' })
+/**
+ * @description Service for managing PWA installation, native install prompts, and tenant branding.
+ */
+export class PwaInstallService {
+  readonly #document = inject(DOCUMENT);
+  readonly #injector = inject(Injector);
+  readonly #getAppData = inject(PWA_APP_DATA_FN);
+  readonly #destroyRef = inject(DestroyRef);
+  readonly #platform = inject(Platform);
+  readonly #platformId = inject(PLATFORM_ID);
+  readonly #window = signal(this.#document?.defaultView);
+
+  #deferredPrompt: BeforeInstallPromptEvent | null = null;
+  #promptShown = false;
+  readonly promptAvailable = signal(false);
+
+  constructor() {
+    if (!isPlatformBrowser(this.#platformId) || this.isStandalone()) return;
+
+    const controller = new AbortController();
+
+    this.#window()?.addEventListener(
+      'beforeinstallprompt',
+      e => {
+        e.preventDefault();
+        this.#deferredPrompt = e as BeforeInstallPromptEvent;
+        this.promptAvailable.set(true);
+        if (this.shouldShowPrompt()) {
+          this.showPrompt();
+        }
+      },
+      { signal: controller.signal }
+    );
+
+    this.#window()?.addEventListener(
+      'appinstalled',
+      () => {
+        this.#deferredPrompt = null;
+        this.promptAvailable.set(false);
+        localStorage.setItem(INSTALLED_KEY, '1');
+        localStorage.removeItem(DISMISS_KEY);
+      },
+      { signal: controller.signal }
+    );
+
+    this.#destroyRef.onDestroy(() => controller.abort());
+  }
+
+  /**
+   * @description Opens the PWA install prompt bottom sheet.
+   * MatBottomSheet and PwaPromptComponent are lazily imported to keep them out of the initial bundle.
+   */
+  showPrompt(): void {
+    if (!isPlatformBrowser(this.#platformId) || this.#promptShown) return;
+    this.#promptShown = true;
+    const data = this.#getAppData();
+    const injector = this.#injector;
+    Promise.all([
+      import('@angular/material/bottom-sheet'),
+      import('../components/pwa-prompt/pwa-prompt.component'),
+    ]).then(([{ MatBottomSheet }, { PwaPromptComponent }]) => {
+      runInInjectionContext(injector, () =>
+        inject(MatBottomSheet).open(PwaPromptComponent, {
+          data,
+          backdropClass: 'pwa-backdrop',
+        })
+      );
+    });
+  }
+
+  /**
+   * @description Returns true if the app is running on iOS and not already installed.
+   * @returns {boolean} True on iOS outside of standalone mode.
+   */
+  isIos(): boolean {
+    return this.#platform.IOS && !this.isStandalone();
+  }
+
+  /**
+   * @description Returns true if running on iOS with a non-Safari browser.
+   * CDK Platform.SAFARI is unreliable on iOS because all iOS browsers share Apple's
+   * WebKit/vendor, so this uses User Agent sniffing to detect Chromium (CriOS),
+   * Edge (EdgiOS), Firefox (FxiOS) and Opera (OPiOS) specifically.
+   * @returns {boolean} True when iOS + non-Safari browser detected.
+   */
+  isIosAndNotSafari(): boolean {
+    if (!this.#platform.IOS || this.isStandalone()) return false;
+    const ua = this.#window()?.navigator.userAgent ?? '';
+    return /CriOS|EdgiOS|FxiOS|OPiOS/.test(ua); // cspell:ignore EdgiOS OPiOS
+  }
+
+  /**
+   * @description Returns true if the current iOS version is older than 17.
+   * On iOS < 17 the Share button is in a different location.
+   * @returns {boolean} True for iOS < 17.
+   */
+  isOldIos(): boolean {
+    if (!this.#platform.IOS || !this.#window()?.navigator) return false;
+    const match = this.#window()?.navigator.userAgent.match(/OS (\d+)_/);
+    if (match?.[1]) {
+      return parseInt(match[1], 10) < 17;
+    }
+    return false;
+  }
+
+  /**
+   * @description Returns true if the app is running in standalone (installed PWA) mode.
+   * @returns {boolean} True in standalone display mode.
+   */
+  isStandalone(): boolean {
+    const win = this.#window();
+    if (!win || typeof win.matchMedia !== 'function') return false;
+    return win.matchMedia('(display-mode: standalone)').matches;
+  }
+
+  /**
+   * @description Triggers the native browser install prompt.
+   * @returns {Promise<'accepted' | 'dismissed' | 'no-prompt'>} The result of the installation attempt.
+   */
+  async installPwa(): Promise<'accepted' | 'dismissed' | 'no-prompt'> {
+    const deferred = this.#deferredPrompt;
+    if (!deferred) return 'no-prompt';
+    try {
+      // Browsers may hang on prompt() in simulated/unsupported environments — time out after 10 s.
+      await Promise.race([
+        deferred.prompt(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('timeout')), PROMPT_TIMEOUT_MS)
+        ),
+      ]);
+      const choice = await deferred.userChoice;
+      if (choice?.outcome === 'accepted') {
+        this.#window()?.localStorage.setItem(INSTALLED_KEY, '1');
+        this.#window()?.localStorage.removeItem(DISMISS_KEY);
+        this.#deferredPrompt = null;
+        this.promptAvailable.set(false);
+        return 'accepted';
+      }
+      this.dismissForLater();
+      return 'dismissed';
+    } catch {
+      this.#deferredPrompt = null;
+      this.promptAvailable.set(false);
+      return 'no-prompt';
+    }
+  }
+
+  /**
+   * @description Suppresses the install prompt for DISMISS_DAYS days.
+   */
+  dismissForLater(): void {
+    this.#window()?.localStorage.setItem(DISMISS_KEY, String(Date.now()));
+    this.promptAvailable.set(false);
+  }
+
+  /**
+   * @description Returns true if the install prompt should be shown based on installation status and dismissal history.
+   * @returns {boolean} True if prompt should be shown.
+   */
+  shouldShowPrompt(): boolean {
+    if (this.#window()?.localStorage.getItem(INSTALLED_KEY)) return false;
+    const dismissed = this.#window()?.localStorage.getItem(DISMISS_KEY);
+    if (!dismissed) return true;
+    const daysSince = (Date.now() - Number(dismissed)) / (1000 * 60 * 60 * 24);
+    return daysSince >= DISMISS_DAYS;
+  }
+}

--- a/libs/shared/pwa/src/lib/services/pwa-manifest.service.spec.ts
+++ b/libs/shared/pwa/src/lib/services/pwa-manifest.service.spec.ts
@@ -1,0 +1,168 @@
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { PwaManifestService } from './pwa-manifest.service';
+
+describe('PwaManifestService', () => {
+  let service: PwaManifestService;
+  let manifestLink: HTMLLinkElement;
+  let appleIcon: HTMLLinkElement;
+  let createObjectURL: ReturnType<typeof vi.spyOn>;
+  let revokeObjectURL: ReturnType<typeof vi.spyOn>;
+
+  const mockData = { name: 'Eco Shop', logo: 'https://example.com/logo.png' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    manifestLink = document.createElement('link');
+    manifestLink.id = 'app-manifest';
+    document.head.appendChild(manifestLink);
+
+    appleIcon = document.createElement('link');
+    appleIcon.id = 'apple-touch-icon';
+    document.head.appendChild(appleIcon);
+
+    createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url');
+    revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ theme_color: '#fff', display: 'standalone' }),
+      })
+    );
+
+    TestBed.configureTestingModule({ providers: [PwaManifestService] });
+    service = TestBed.inject(PwaManifestService);
+  });
+
+  afterEach(() => {
+    manifestLink.remove();
+    appleIcon.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('should create', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('applyBranding()', () => {
+    it('does nothing when no logo is provided', async () => {
+      await service.applyBranding({ name: 'No Logo' });
+      expect(createObjectURL).not.toHaveBeenCalled();
+    });
+
+    it('fetches the static manifest as the base', async () => {
+      await service.applyBranding(mockData);
+      expect(fetch).toHaveBeenCalledWith('/manifest.webmanifest');
+    });
+
+    it('sets the manifest link href to the generated blob URL', async () => {
+      await service.applyBranding(mockData);
+      expect(manifestLink.getAttribute('href')).toBe('blob:mock-url');
+    });
+
+    it('patches name and short_name when name is provided', async () => {
+      let manifest: Record<string, unknown> = {};
+      createObjectURL.mockImplementation((blob: Blob) => {
+        blob.text().then(t => (manifest = JSON.parse(t)));
+        return 'blob:mock-url';
+      });
+      await service.applyBranding(mockData);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(manifest['name']).toBe('Eco Shop');
+      expect(manifest['short_name']).toBe('Eco Shop');
+    });
+
+    it('omits name and short_name when name is absent', async () => {
+      let manifest: Record<string, unknown> = {};
+      createObjectURL.mockImplementation((blob: Blob) => {
+        blob.text().then(t => (manifest = JSON.parse(t)));
+        return 'blob:mock-url';
+      });
+      await service.applyBranding({ logo: mockData.logo });
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(manifest['name']).toBeUndefined();
+    });
+
+    it('includes two icon entries pointing to the logo URL', async () => {
+      let manifest: Record<string, unknown> = {};
+      createObjectURL.mockImplementation((blob: Blob) => {
+        blob.text().then(t => (manifest = JSON.parse(t)));
+        return 'blob:mock-url';
+      });
+      await service.applyBranding(mockData);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      const icons = manifest['icons'] as Array<{ src: string }>;
+      expect(icons).toHaveLength(2);
+      expect(icons.every(i => i.src === mockData.logo)).toBe(true);
+    });
+
+    it('preserves base manifest fields from the static file', async () => {
+      let manifest: Record<string, unknown> = {};
+      createObjectURL.mockImplementation((blob: Blob) => {
+        blob.text().then(t => (manifest = JSON.parse(t)));
+        return 'blob:mock-url';
+      });
+      await service.applyBranding(mockData);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(manifest['theme_color']).toBe('#fff');
+      expect(manifest['display']).toBe('standalone');
+    });
+
+    it('proceeds with an empty base when fetch throws', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+      await service.applyBranding(mockData);
+      expect(createObjectURL).toHaveBeenCalled();
+    });
+
+    it('proceeds with an empty base when fetch returns a non-ok response', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+      await service.applyBranding(mockData);
+      expect(createObjectURL).toHaveBeenCalled();
+    });
+
+    it('does not throw when the manifest link element is absent', async () => {
+      manifestLink.remove();
+      await expect(service.applyBranding(mockData)).resolves.not.toThrow();
+    });
+
+    it('updates the apple-touch-icon href', async () => {
+      await service.applyBranding(mockData);
+      expect(appleIcon.getAttribute('href')).toBe(mockData.logo);
+    });
+
+    it('does not throw when the apple-touch-icon element is absent', async () => {
+      appleIcon.remove();
+      await expect(service.applyBranding(mockData)).resolves.not.toThrow();
+    });
+
+    it('revokes the previous blob URL on a subsequent call', async () => {
+      await service.applyBranding(mockData);
+      await service.applyBranding(mockData);
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    });
+  });
+
+  describe('SSR guard', () => {
+    it('applyBranding() does nothing when not running in a browser', async () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [PwaManifestService, { provide: PLATFORM_ID, useValue: 'server' }],
+      });
+      const ssrService = TestBed.inject(PwaManifestService);
+      await ssrService.applyBranding(mockData);
+      expect(createObjectURL).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup on destroy', () => {
+    it('revokes the blob URL when the service is destroyed', async () => {
+      await service.applyBranding(mockData);
+      TestBed.resetTestingModule();
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    });
+  });
+});

--- a/libs/shared/pwa/src/lib/services/pwa-manifest.service.ts
+++ b/libs/shared/pwa/src/lib/services/pwa-manifest.service.ts
@@ -1,0 +1,89 @@
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { DestroyRef, inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
+import { PwaAppData } from './pwa-install.service';
+
+@Injectable({ providedIn: 'root' })
+/**
+ * @description Optional service that patches the web app manifest and apple-touch-icon with dynamic branding.
+ */
+export class PwaManifestService {
+  readonly #document = inject(DOCUMENT);
+  readonly #platformId = inject(PLATFORM_ID);
+  readonly #window = signal(this.#document?.defaultView);
+
+  #manifestBlobUrl: string | null = null;
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => this.#revokeBlobUrl());
+  }
+
+  /**
+   * @description Fetches the static manifest, patches name and icons with the provided data, and applies it as a Blob URL.
+   * @param {PwaAppData} data - App identity data; logo must be an absolute URL.
+   * @returns {Promise<void>}
+   */
+  async applyBranding(data: PwaAppData): Promise<void> {
+    if (!isPlatformBrowser(this.#platformId) || !data.logo) return;
+    await this.#updateManifest(data);
+    this.#updateAppleTouchIcon(data);
+  }
+
+  /**
+   * @description Fetches the current static manifest, merges dynamic branding, and replaces the manifest link with a Blob URL.
+   * @param {PwaAppData} data - App identity data with an absolute logo URL.
+   * @returns {Promise<void>}
+   */
+  async #updateManifest(data: PwaAppData): Promise<void> {
+    const manifestLink = this.#document.getElementById('app-manifest') as HTMLLinkElement | null;
+    if (!manifestLink || !data.logo) return;
+
+    let base: Record<string, unknown> = {};
+    try {
+      const res = await fetch('/manifest.webmanifest');
+      if (res.ok) {
+        base = await res.json();
+      }
+    } catch {
+      // Proceed with empty base if the static manifest is unreachable.
+    }
+
+    this.#revokeBlobUrl();
+
+    const origin = this.#window()?.location.origin ?? '';
+    const patch: Record<string, unknown> = {
+      icons: [
+        { src: data.logo, sizes: '512x512', purpose: 'any' },
+        { src: data.logo, sizes: '512x512', purpose: 'maskable' },
+      ],
+      start_url: `${origin}/`,
+    };
+
+    if (data.name) {
+      patch['name'] = data.name;
+      patch['short_name'] = data.name.substring(0, 12);
+    }
+
+    const manifest = { ...base, ...patch };
+    const blob = new Blob([JSON.stringify(manifest)], { type: 'application/manifest+json' });
+    this.#manifestBlobUrl = URL.createObjectURL(blob);
+    manifestLink.setAttribute('href', this.#manifestBlobUrl);
+  }
+
+  /**
+   * @description Updates the apple-touch-icon href for iOS Add to Home Screen.
+   * @param {PwaAppData} data - App identity data with an absolute logo URL.
+   */
+  #updateAppleTouchIcon(data: PwaAppData): void {
+    if (!data.logo) return;
+    const appleIcon = this.#document.getElementById('apple-touch-icon') as HTMLLinkElement | null;
+    appleIcon?.setAttribute('href', data.logo);
+  }
+
+  /** Revokes the current manifest blob URL to prevent memory leaks. */
+  #revokeBlobUrl(): void {
+    if (this.#manifestBlobUrl) {
+      URL.revokeObjectURL(this.#manifestBlobUrl);
+      this.#manifestBlobUrl = null;
+    }
+  }
+}

--- a/libs/shared/pwa/src/test-setup.ts
+++ b/libs/shared/pwa/src/test-setup.ts
@@ -1,0 +1,7 @@
+import '@angular/compiler';
+import '@analogjs/vitest-angular/setup-zone';
+
+import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
+import { getTestBed } from '@angular/core/testing';
+
+getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting());

--- a/libs/shared/pwa/tsconfig.json
+++ b/libs/shared/pwa/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "target": "es2022",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "preserve"
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/shared/pwa/tsconfig.lib.json
+++ b/libs/shared/pwa/tsconfig.lib.json
@@ -1,0 +1,26 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/test-setup.ts"
+  ]
+}

--- a/libs/shared/pwa/tsconfig.spec.json
+++ b/libs/shared/pwa/tsconfig.spec.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ],
+  "files": ["src/test-setup.ts"]
+}

--- a/libs/shared/pwa/vite.config.mts
+++ b/libs/shared/pwa/vite.config.mts
@@ -1,0 +1,28 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import angular from '@analogjs/vite-plugin-angular';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../../node_modules/.vite/libs/shared/pwa',
+  plugins: [angular(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  // Uncomment this if you are using workers.
+  // worker: {
+  //   plugins: () => [ nxViteTsPaths() ],
+  // },
+  test: {
+    name: 'pwa',
+    watch: false,
+    globals: true,
+    environment: 'jsdom',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    setupFiles: ['src/test-setup.ts'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../../coverage/libs/shared/pwa',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "@nx/vitest": "^22.5.4",
     "@nx/web": "22.5.4",
     "@nx/workspace": "22.5.4",
+    "@oxc-project/runtime": "^0.115.0",
     "@schematics/angular": "21.1.2",
     "@simondotm/nx-firebase": "^22.3.3",
     "@swc-node/register": "1.11.1",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -292,7 +292,8 @@
       "@plastik/shared/img-cropper": ["libs/shared/img-cropper/ui/src/index.ts"],
       "@plastik/eco-store/profile/avatar": ["libs/eco-store/profile/avatar/src/index.ts"],
       "@plastik/eco-store/profile/addresses": ["libs/eco-store/profile/addresses/src/index.ts"],
-      "@plastik/shared/alert/ui": ["libs/shared/alert/ui/src/index.ts"]
+      "@plastik/shared/alert/ui": ["libs/shared/alert/ui/src/index.ts"],
+      "@plastik/shared/pwa": ["libs/shared/pwa/src/index.ts"]
     }
   },
   "angularCompilerOptions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10187,6 +10187,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/runtime@npm:^0.115.0":
+  version: 0.115.0
+  resolution: "@oxc-project/runtime@npm:0.115.0"
+  checksum: 10c0/88905181724fcad06d2852969e706a25a7b6c4fadac22dd6aece24b882a947eda7487451e0824781c9dc87b40b2c6ee582790e47fec5a9ba5d27c6e8c6c35bc1
+  languageName: node
+  linkType: hard
+
 "@oxc-project/types@npm:=0.113.0":
   version: 0.113.0
   resolution: "@oxc-project/types@npm:0.113.0"
@@ -29733,6 +29740,7 @@ __metadata:
     "@nx/vitest": "npm:^22.5.4"
     "@nx/web": "npm:22.5.4"
     "@nx/workspace": "npm:22.5.4"
+    "@oxc-project/runtime": "npm:^0.115.0"
     "@schematics/angular": "npm:21.1.2"
     "@simondotm/nx-firebase": "npm:^22.3.3"
     "@swc-node/register": "npm:1.11.1"


### PR DESCRIPTION
…/Android

- Redesign PWA install prompt to match eco-store visual guidelines.
- Add theme-aware styling with Tailwind CSS v4 and light/dark mode support.
- Refactor iOS/Android installation logic in PwaInstallService.
- Update I18n translations (ca/en/es) for the new prompt content.
- Link PWA library to root workspace.

CLOSED: #86c9cnwev