### PR TITLE
feat(eco-store): #86c9hv1mf optimize store window responsive accessib…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2026-04-28] - Eco-Store: Breadcrumb Navigation Library
+## [2026-04-28] - Eco-Store: Breadcrumb Navigation Library & UI Accessibility
 
 ### Added
 
 - **Breadcrumbs Library**: Created `@plastik/eco-store/breadcrumbs` (`libs/eco-store/shared/breadcrumbs`) — a new shared UI library providing a responsive, accessible breadcrumb navigation bar with integrated back button, skeleton loading states, optional Material icons, and full i18n support via `ngx-translate` ([#86c9hdff3](https://app.clickup.com/t/86c9hdff3)).
 - **Order Detail Breadcrumbs**: Integrated `EcoStoreBreadcrumbsComponent` into `EcoStoreOrdersDetailComponent` with a two-level trail (orders list → order detail) and a reactive `breadcrumbItems` computed signal ([#86c9hdff3](https://app.clickup.com/t/86c9hdff3)).
 - **Product Detail Breadcrumbs**: Integrated `EcoStoreBreadcrumbsComponent` into `EcoStoreProductFeatureComponent` with a three-level trail (store → category → product) and skeleton placeholders while data loads ([#86c9hdff3](https://app.clickup.com/t/86c9hdff3)).
+
+### Changed
+
+- **Responsive Accessibility Optimization**: Refined `StoreWindowComponent` and `SharedCountdownUiComponent` to hide labels and prefixes on mobile and tablet (`lg` breakpoint) to maximize space for primary countdown content. Implementation uses a separate `sr-only` span for screen readers and `aria-hidden` visual labels, ensuring full accessibility without layout compromises ([#86c9hv1mf](https://app.clickup.com/t/86c9hv1mf)).
+
+### Fixed
+
+- **Store Status Visibility**: Standardized status chip label responsive behavior across all store views, ensuring the primary state is always available to assistive technologies regardless of visual layout ([#86c9hv1mf](https://app.clickup.com/t/86c9hv1mf)).
 
 ## [2026-04-27] - Eco-Store: Hero Spacing Standardization & UI Modernization
 

--- a/libs/eco-store/store-window/README.md
+++ b/libs/eco-store/store-window/README.md
@@ -18,6 +18,8 @@ A feature library containing the `StoreWindowComponent`, which displays the curr
 ## Features
 
 - **Dynamic Status**: Visualizes store status with icons, colors, and labels.
+- **Responsive Accessibility**: Status labels are visually hidden on mobile and tablet using `hidden lg:flex` to
+  prioritize space for the countdown, while remaining fully accessible to screen readers via a dedicated `sr-only` span.
 - **Closing Soon Urgency**: High-visibility state with a pulsing indicator to encourage last-minute orders.
 - **Countdown Integration**: Displays a countdown timer when the store is closed, opening soon, or closing soon.
 - **Shared Chip Integration**: Uses `SharedChipComponent` (`<plastik-shared-chip>`) from `@plastik/shared/chip/ui` for a modern, accessible, and semantically colored UI.

--- a/libs/eco-store/store-window/src/lib/store-window/store-window.component.html
+++ b/libs/eco-store/store-window/src/lib/store-window/store-window.component.html
@@ -4,11 +4,15 @@
     [matTooltip]="closedReason() || (config.label | translate)">
     <plastik-shared-chip [type]="config.type || 'neutral'" [icon]="config.icon">
       <div class="flex items-center gap-2">
+        <!-- Screen Reader Only Label -->
+        <span class="sr-only">{{ config.label | translate }}</span>
+
+        <!-- Visual Label (Hidden on mobile and tablet) -->
         <span
-          [class]="`flex items-center font-bold tracking-wide whitespace-nowrap uppercase ${config.countdownSegments?.length ? 'border-tertiary-200 border-r pr-2' : ''}`">
+          aria-hidden="true"
+          [class]="`hidden items-center font-bold tracking-wide whitespace-nowrap uppercase lg:flex ${config.countdownSegments?.length ? 'border-tertiary-200 border-r pr-2' : ''}`">
           @if (config.class === 'closing') {
             <span
-              aria-hidden="true"
               class="bg-warning-800 dark:bg-warning-200 mr-2 inline-block h-[12px] w-[12px] animate-pulse rounded-full"></span>
           }
           {{ config.label | translate }}

--- a/libs/eco-store/store-window/src/lib/store-window/store-window.component.spec.ts
+++ b/libs/eco-store/store-window/src/lib/store-window/store-window.component.spec.ts
@@ -46,14 +46,22 @@ describe('StoreWindowComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render OPEN status correctly', () => {
+  it('should render OPEN status correctly with sr-only for screen readers and hidden for visual users on mobile/tablet', () => {
     fixture.componentRef.setInput('status', 'OPEN');
     fixture.detectChanges();
 
     const chip = fixture.nativeElement.querySelector('.status-chip');
     expect(chip).toBeTruthy();
     expect(chip.classList).toContain('open');
-    expect(chip.textContent).toContain('store.status.open');
+
+    const srOnly = fixture.nativeElement.querySelector('.sr-only');
+    const visual = fixture.nativeElement.querySelector('span[aria-hidden="true"]');
+
+    expect(srOnly.textContent).toContain('store.status.open');
+    expect(visual.textContent).toContain('store.status.open');
+
+    expect(visual.classList).toContain('hidden');
+    expect(visual.classList).toContain('lg:flex');
   });
 
   it('should render CLOSED status correctly', () => {

--- a/libs/shared/countdown/ui/README.md
+++ b/libs/shared/countdown/ui/README.md
@@ -18,6 +18,9 @@ A reusable Angular component for displaying countdowns with a customizable prefi
 
 - **Segmented Display**: Renders countdowns as a series of time segments (e.g., `12m`, `30s`).
 - **Animated Separators**: Supports custom separators with optional pulsing animations.
+- **Responsive Accessibility**: Prefix labels are visually hidden on mobile and tablet using `hidden lg:block` to
+  prioritize space for the countdown segments, while remaining fully accessible to screen readers via a dedicated
+  `sr-only` span.
 - **Translatable**: Integrated with `ngx-translate` for localized prefixes.
 - **Customizable**: Accepts custom CSS classes for flexible styling.
 

--- a/libs/shared/countdown/ui/src/lib/shared-countdown-ui/shared-countdown-ui.component.html
+++ b/libs/shared/countdown/ui/src/lib/shared-countdown-ui/shared-countdown-ui.component.html
@@ -1,6 +1,7 @@
 <p [class]="`chip-countdown flex flex-row items-center ${class()}`">
   @if (prefix()) {
-    {{ prefix() | translate }}
+    <span class="sr-only">{{ prefix() | translate }}</span>
+    <span aria-hidden="true" class="hidden lg:block">{{ prefix() | translate }}</span>
   }
   @for (segment of segments(); track $index) {
     @if (segment === ':') {

--- a/libs/shared/countdown/ui/src/lib/shared-countdown-ui/shared-countdown-ui.component.scss
+++ b/libs/shared/countdown/ui/src/lib/shared-countdown-ui/shared-countdown-ui.component.scss
@@ -1,3 +1,0 @@
-:host {
-  display: inline-flex;
-}

--- a/libs/shared/countdown/ui/src/lib/shared-countdown-ui/shared-countdown-ui.component.spec.ts
+++ b/libs/shared/countdown/ui/src/lib/shared-countdown-ui/shared-countdown-ui.component.spec.ts
@@ -21,11 +21,23 @@ describe('SharedCountdownUiComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display prefix if provided', () => {
+  it('should display prefix with sr-only for screen readers and hidden for visual users', () => {
     fixture.componentRef.setInput('prefix', 'Starts in');
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.textContent).toContain('Starts in');
+    const srOnly = compiled.querySelector('.sr-only');
+    const visual = compiled.querySelector('[aria-hidden="true"]');
+
+    expect(srOnly?.textContent).toContain('Starts in');
+    expect(visual?.textContent).toContain('Starts in');
+    expect(visual?.classList).toContain('hidden');
+    expect(visual?.classList).toContain('lg:block');
+  });
+
+  it('should have timer role and aria-live attribute', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.getAttribute('role')).toBe('timer');
+    expect(compiled.getAttribute('aria-live')).toBe('polite');
   });
 
   it('should render segments correctly', () => {

--- a/libs/shared/countdown/ui/src/lib/shared-countdown-ui/shared-countdown-ui.component.ts
+++ b/libs/shared/countdown/ui/src/lib/shared-countdown-ui/shared-countdown-ui.component.ts
@@ -5,8 +5,12 @@ import { TranslatePipe } from '@ngx-translate/core';
   selector: 'plastik-countdown',
   imports: [TranslatePipe],
   templateUrl: './shared-countdown-ui.component.html',
-  styleUrl: './shared-countdown-ui.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    role: 'timer',
+    'aria-live': 'polite',
+    class: 'inline-flex',
+  },
 })
 export class SharedCountdownUiComponent {
   readonly segments = input<string[]>([]);


### PR DESCRIPTION
…ility

Optimize StoreWindowComponent and SharedCountdownUiComponent for mobile and tablet by hiding labels and prefixes while maintaining full screen reader accessibility.

Key changes:
- Implement separate sr-only spans for screen reader accessibility.
- Hide visual labels on screens smaller than the 'lg' breakpoint (mobile/tablet) to provide more room for countdown content.
- Update READMEs and spec files to reflect and verify these responsive accessibility improvements.

CLOSED: #86c9hv1mf