### PR TITLE
fix(eco-store): #86c9kwk3x address impeccable UI audit findings on pr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-02] - Eco-Store: Impeccable UI Audit Fixes on Products Page
+
+### Changed
+
+- **Sidenav Category Icons Toned Down**: Replaced raw `[style.color]` with a `color-mix(... in oklch ...)` blend on `.category-icon` so vivid hues (e.g. purple) render as soft, organic accents instead of the "AI palette" pattern flagged by the audit ([#86c9kwk3x](https://app.clickup.com/t/86c9kwk3x)).
+- **Header Toolbar Visual Weight**: Removed the redundant `box-shadow` and `border-bottom` from `mat-toolbar`; the visual weight already lives on the `<eco-header>` wrapper, eliminating the "card-in-card" tell ([#86c9kwk3x](https://app.clickup.com/t/86c9kwk3x)).
+- **Product Quantity Stepper Styling**: Removed the heavy `border-2 / bg-surface-variant / rounded-2xl` wrapper around the +/- controls and switched the add-button icon to the `--mat-sys-on-primary` token; the round icon buttons themselves provide the visual grouping in both light and dark mode ([#86c9kwk3x](https://app.clickup.com/t/86c9kwk3x)).
+- **Favorite Button Animation & Color**: Replaced the elastic `cubic-bezier(0.175, 0.885, 0.32, 1.275)` heart-pop easing with the M3 standard `cubic-bezier(0.22, 1, 0.36, 1)`, softened the keyframes (1.4 → 1.25, 1.1 → 1.05) and wrapped `icon-color` with `light-dark()` so the icon stays legible on dark surfaces ([#86c9kwk3x](https://app.clickup.com/t/86c9kwk3x)).
+- **Cart Button Disabled Icon Contrast**: Scoped the bright `--primary-50` icon color to `:not(:disabled)` and added a fallback to the M3 disabled on-surface token, fixing the 1.1:1 contrast when the cart is empty ([#86c9kwk3x](https://app.clickup.com/t/86c9kwk3x)).
+- **Shared Chip Vertical Padding**: Bumped chip padding from `py-1` to `py-2.5` so it clears the 8px floor in the project's Tailwind spacing scale ([#86c9kwk3x](https://app.clickup.com/t/86c9kwk3x)).
+- **Sidenav Nav-Line Letter Spacing**: Reset Material's wide list-line tracking (`--mat-list-list-item-label-text-tracking: normal`) so category names no longer trip the "wide letter spacing on body text" heuristic ([#86c9kwk3x](https://app.clickup.com/t/86c9kwk3x)).
+- **Activity Overlay Loading Text**: Removed `uppercase` and oversized tracking, switched to `text-sm font-semibold tracking-wide` with `py-2.5`, fixing both the "all-caps body text" and "cramped padding" findings ([#86c9kwk3x](https://app.clickup.com/t/86c9kwk3x)).
+- **Sidenav Layout Animation Hint**: Added `ng-animate-disabled` on `<mat-sidenav-container>` and a desktop `mat-drawer-content { transition: none }` reset so Material's layout-property transition (`margin-left, margin-right`) does not animate in our `over`/`side` configuration ([#86c9kwk3x](https://app.clickup.com/t/86c9kwk3x)).
+
 ## [2026-05-01] - Code Quality Refinements: Jules Review & Convention Alignment
 
 ### Added

--- a/apps/eco-store/src/app/app.component.html
+++ b/apps/eco-store/src/app/app.component.html
@@ -40,7 +40,7 @@
 
         <!-- Loading text -->
         <p
-          class="text-primary-900 dark:text-primary-100 bg-surface-container-high animate-pulse rounded-full px-4 py-2 text-center text-xs font-bold tracking-[0.2em] uppercase">
+          class="text-primary-900 dark:text-primary-100 bg-surface-container-high animate-pulse rounded-full px-4 py-2.5 text-center text-sm font-semibold tracking-wide">
           {{ activityStore.message() | translate }}
         </p>
       </div>

--- a/libs/eco-store/core/layout/src/header/header.component.scss
+++ b/libs/eco-store/core/layout/src/header/header.component.scss
@@ -17,13 +17,14 @@
       )
     );
 
-    border-bottom: 1px solid
-      light-dark(
-        color-mix(in srgb, var(--mat-sys-primary), transparent 90%),
-        rgba(255, 255, 255, 0.05)
-      );
-    box-shadow: 0 4px 20px -2px rgba(0, 0, 0, 0.05) !important;
-    transition: all 0.3s ease;
+    /* Visual weight (border + shadow) lives on the parent <eco-header>
+       wrapper. Keeping them here too made the toolbar read as a card
+       nested inside another card. */
+    border-bottom: none;
+    box-shadow: none !important;
+    transition:
+      background-color 0.3s ease,
+      color 0.3s ease;
   }
 
   .header-icon {

--- a/libs/eco-store/core/layout/src/layout.component.html
+++ b/libs/eco-store/core/layout/src/layout.component.html
@@ -3,7 +3,9 @@
     <ng-container *ngTemplateOutlet="headerContent"></ng-container>
   }
 
-  <mat-sidenav-container class="content-container flex-1" [class.z-10]="isMobile()">
+  <mat-sidenav-container
+    class="content-container ng-animate-disabled flex-1"
+    [class.z-10]="isMobile()">
     @if (hasSidenav()) {
       <mat-sidenav
         #sidenav

--- a/libs/eco-store/core/layout/src/layout.component.scss
+++ b/libs/eco-store/core/layout/src/layout.component.scss
@@ -27,6 +27,13 @@
     background: var(--transparent);
   }
 
+  /* Avoid animating layout properties (margin-left/right) on the content
+     pane: in `over` mode (mobile) the content does not shift, and in `side`
+     mode (desktop) we suppress drawer transitions altogether below. */
+  .mat-drawer-content {
+    transition: none !important;
+  }
+
   .mat-drawer.mat-drawer-over {
     transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1) !important;
     visibility: visible !important;

--- a/libs/eco-store/core/layout/src/menu/menu.component.scss
+++ b/libs/eco-store/core/layout/src/menu/menu.component.scss
@@ -53,17 +53,27 @@
   );
 
   mat-icon {
-    color: light-dark(var(--primary-50), var(--primary-950));
     font-variation-settings: 'FILL' 1;
     transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
   }
 
-  &:hover mat-icon {
+  &:not(:disabled) mat-icon {
+    color: light-dark(var(--primary-50), var(--primary-950));
+  }
+
+  &:hover:not(:disabled) mat-icon {
     transform: scale(1.1) rotate(-5deg);
   }
 
   &:disabled {
     cursor: not-allowed;
+
+    /* Don't keep the bright primary-50 icon when the button background
+       collapses to a disabled near-white surface. Use the M3 disabled
+       on-surface token so contrast stays legible. */
+    mat-icon {
+      color: color-mix(in srgb, var(--mat-sys-on-surface), transparent 62%);
+    }
 
     @include mat.badge-overrides(
       (

--- a/libs/eco-store/products/feature/list/src/lib/eco-store-products-sidenav-feature.component.html
+++ b/libs/eco-store/products/feature/list/src/lib/eco-store-products-sidenav-feature.component.html
@@ -46,14 +46,16 @@
               <div class="flex w-full items-center gap-2">
                 <mat-icon
                   aria-hidden="true"
-                  class="scale-90 transition-all dark:brightness-150 dark:saturate-75"
-                  [style.color]="category.color"
+                  class="category-icon scale-90 transition-all dark:brightness-150 dark:saturate-75"
+                  [style.--category-color]="category.color"
                   >{{ category.icon }}</mat-icon
                 >
-                <span matListItemTitle class="flex-1 truncate text-sm">{{
+                <span matListItemTitle class="flex-1 truncate text-sm tracking-normal">{{
                   category.translatedName
                 }}</span>
-                <span matListItemLine class="ml-2 text-xs">({{ category.productCount }})</span>
+                <span matListItemLine class="ml-2 text-xs tracking-normal"
+                  >({{ category.productCount }})</span
+                >
               </div>
             </mat-list-item>
           }

--- a/libs/eco-store/products/feature/list/src/lib/eco-store-products-sidenav-feature.component.scss
+++ b/libs/eco-store/products/feature/list/src/lib/eco-store-products-sidenav-feature.component.scss
@@ -24,7 +24,16 @@
   }
 
   mat-list-item {
-    --mat-list-list-item-label-text-tracking: 0.05rem;
+    --mat-list-list-item-label-text-tracking: normal;
+
+    /* Category color icons: tone down saturation/lightness so vivid hues
+       (e.g. purple) read as soft, organic accents instead of "AI palette". */
+    .category-icon {
+      color: light-dark(
+        color-mix(in oklch, var(--category-color, currentColor) 70%, var(--neutral-700)),
+        color-mix(in oklch, var(--category-color, currentColor) 80%, white)
+      );
+    }
 
     &.active {
       --mat-list-list-item-container-color: light-dark(var(--secondary-200), var(--secondary-800));

--- a/libs/eco-store/shared/favorite-button/src/lib/eco-store-shared-favorite-button/eco-store-shared-favorite-button.component.scss
+++ b/libs/eco-store/shared/favorite-button/src/lib/eco-store-shared-favorite-button/eco-store-shared-favorite-button.component.scss
@@ -4,7 +4,6 @@
   display: block;
 
   .favorite-button {
-    // Default (sm)
     --button-size: 38px;
     --icon-size: 20px;
 
@@ -39,7 +38,7 @@
       (
         icon-size: var(--icon-size),
         state-layer-size: var(--button-size),
-        icon-color: var(--neutral-800),
+        icon-color: light-dark(var(--neutral-800), var(--neutral-100)),
       )
     );
 
@@ -60,7 +59,7 @@
       );
 
       .mat-icon {
-        animation: heart-pop 0.45s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+        animation: heart-pop 0.4s cubic-bezier(0.22, 1, 0.36, 1);
         filter: drop-shadow(0 0 6px color-mix(in srgb, var(--error-500), transparent 60%));
       }
 
@@ -74,10 +73,10 @@
         transform: scale(1);
       }
       50% {
-        transform: scale(1.4);
+        transform: scale(1.25);
       }
       100% {
-        transform: scale(1.1);
+        transform: scale(1.05);
       }
     }
 

--- a/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.html
+++ b/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.html
@@ -10,7 +10,7 @@
 } @else {
   <div class="flex w-full items-center" [class.gap-4]="mode() === 'detail'">
     <div
-      class="border-outline bg-surface-variant flex items-center justify-between gap-1 rounded-2xl border-2 py-1 pr-1 pl-1 transition-all"
+      class="flex items-center justify-between gap-1 py-1 pr-1 pl-1 transition-all"
       role="group"
       [class.w-full]="mode() === 'card'"
       [class.w-auto]="mode() === 'detail'"

--- a/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.scss
+++ b/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.scss
@@ -24,9 +24,12 @@
       }
 
       &:not(:disabled) {
+        /* Use the M3 on-primary token so the icon reads as proper foreground
+           text on the green primary surface (was a low-contrast neutral grey
+           on coloured background). */
         @include mat.icon-overrides(
           (
-            color: light-dark(var(--neutral-100), var(--neutral-500)),
+            color: var(--mat-sys-on-primary),
           )
         );
       }

--- a/libs/shared/chip/ui/src/lib/shared-chip.component.ts
+++ b/libs/shared/chip/ui/src/lib/shared-chip.component.ts
@@ -43,7 +43,7 @@ export class SharedChipComponent {
 
   protected readonly computedClass = computed(() => {
     const baseClass =
-      'flex justify-center items-center gap-1.5 rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wide inset border transition-colors';
+      'flex justify-center items-center gap-1.5 rounded-full px-3 py-2.5 text-xs font-bold uppercase tracking-wide inset border transition-colors';
     const typeClasses: Record<SharedChipType, string> = {
       primary:
         'chip-primary bg-primary-50 text-primary-800 border-primary-400 dark:bg-primary-700 dark:text-primary-50 dark:border-primary-600',


### PR DESCRIPTION
…oducts page

Light: tone down sidenav category icons, drop redundant header toolbar shadow, simplify quantity stepper, fix cart-disabled icon contrast, normalize chip padding and nav-line tracking, replace elastic favorite-button easing.
Dark: switch favorite-button icon color via light-dark(), drop nested-card chrome from quantity stepper.
Activity overlay: remove all-caps body text and bump padding past 8px floor.
Sidenav: opt out of Material's margin-left/right layout-property transition.

CLOSED: #86c9kwk3x