### PR TITLE
fix(eco-store): #86c9kwwjg fix confirm dialog nesting and trial badge…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-02] - Eco-Store: Confirm Dialog & Header Trial Badge
+
+### Changed
+
+- **Shared Confirm Dialog Sectioning**: Removed the distinct `bg-surface-container-low` / `bg-surface-container-lowest` backgrounds from the dialog's `<header>` and `<mat-dialog-actions>`; kept the `border-b` / `border-t` separators so the dialog stops reading as a card-in-card while preserving visual hierarchy ([#86c9kwwjg](https://app.clickup.com/t/86c9kwwjg)).
+- **Header Trial Badge Typography**: Bumped the trial-status pill from `text-xs / py-1` to `text-sm / py-1.5` so the warning text clears the 12px body-text floor and the pill stays comfortably tappable ([#86c9kwwjg](https://app.clickup.com/t/86c9kwwjg)).
+
 ## [2026-05-02] - Eco-Store: Auth Container Footer Typography
 
 ### Changed

--- a/libs/eco-store/core/layout/src/header/header.component.html
+++ b/libs/eco-store/core/layout/src/header/header.component.html
@@ -27,7 +27,7 @@
 
       @if (isTrial() && !isTrialExpired()) {
         <div
-          class="bg-tertiary-container text-on-tertiary-container hidden items-center gap-1 rounded-full px-3 py-1 text-xs font-medium lg:flex"
+          class="bg-tertiary-container text-on-tertiary-container hidden items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium lg:flex"
           [attr.aria-label]="
             'store.trial.badge.nearlyExpired' | translate: { days: trialDaysLeft() }
           ">
@@ -38,7 +38,7 @@
         </div>
       } @else if (isTrial() && isTrialExpired()) {
         <div
-          class="bg-tertiary-container text-on-tertiary-container hidden items-center gap-1 rounded-full px-3 py-1 text-xs font-medium lg:flex"
+          class="bg-tertiary-container text-on-tertiary-container hidden items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium lg:flex"
           [attr.aria-label]="'store.trial.badge.expired' | translate">
           <mat-icon class="scale-80">timer</mat-icon>
           <span>{{ 'store.trial.badge.expired' | translate }}</span>

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.html
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.html
@@ -6,7 +6,7 @@
   <div class="relative z-0">
     <!-- Header with Icon and Title -->
     <header
-      class="bg-surface-container-low border-outline-variant grid grid-cols-[32px_1fr] items-center gap-4 border-b px-6 py-5 pl-8">
+      class="border-outline-variant grid grid-cols-[32px_1fr] items-center gap-4 border-b px-6 py-5 pl-8">
       <mat-icon
         class="text-sys-primary top-0! size-10! overflow-visible! text-[40px]"
         aria-hidden="true">
@@ -28,7 +28,7 @@
 
     <!-- Actions -->
     <mat-dialog-actions
-      class="bg-surface-container-lowest border-outline-variant flex min-h-auto flex-col-reverse gap-3 border-t px-6 py-5 pl-8! sm:flex-row sm:justify-end sm:gap-4">
+      class="border-outline-variant flex min-h-auto flex-col-reverse gap-3 border-t px-6 py-5 pl-8! sm:flex-row sm:justify-end sm:gap-4">
       @if (data.ko.route) {
         <button
           matButton


### PR DESCRIPTION
… tiny text

Drop distinct backgrounds on the shared confirm dialog header/footer so the dialog stops reading as a card-in-card; keep the border separators. Bump the header trial badge from text-xs/py-1 to text-sm/py-1.5 to clear the 12px body-text floor.

CLOSED: #86c9kwwjg