### PR TITLE
Refactor Angular 21 Modernization Fixes (PR #1060)

### DIFF
--- a/libs/shared/storage/data-access/src/firebase/firebase-storage.service.ts
+++ b/libs/shared/storage/data-access/src/firebase/firebase-storage.service.ts
@@ -53,7 +53,7 @@ export class FirebaseStorageService extends StorageService implements StorageSer
       this.fileUrl.set(await getDownloadURL(snapshot.ref));
       this.progress.set(0);
     } catch (error) {
-      this.progress.set(0);
+      this.reset();
       throw error;
     }
   }

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
@@ -36,7 +36,6 @@ import { RouterLink } from '@angular/router';
 import { EntityId } from '@ngrx/signals/entities';
 import { BaseEntity } from '@plastik/core/entities';
 import {
-  DataFormatFactoryService,
   FormattingTypes,
   SafeFormattedPipe,
   SharedUtilFormattersModule,
@@ -279,14 +278,25 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
       };
     }
 
-    if (this.sort()) {
+    effect(() => {
       const matSortInstance = this.matSort();
+      const sortConfig = this.sort();
+
       if (matSortInstance) {
-        matSortInstance.active = this.sort()?.[0] || '';
-        matSortInstance.direction = this.sort()?.[1] || 'asc';
+        if (sortConfig) {
+          matSortInstance.active = sortConfig[0] || '';
+          matSortInstance.direction = sortConfig[1] || 'asc';
+        }
         this.dataSource.sort = matSortInstance;
       }
-    }
+    });
+
+    effect(() => {
+      const matPaginatorInstance = this.matPaginator();
+      if (matPaginatorInstance) {
+        this.dataSource.paginator = matPaginatorInstance;
+      }
+    });
   }
 
   /**

--- a/libs/shared/util/formatters/src/lib/services/data-format-factory.service.ts
+++ b/libs/shared/util/formatters/src/lib/services/data-format-factory.service.ts
@@ -32,13 +32,21 @@ export class DataFormatFactoryService<T extends FormattingInput<keyof T> & BaseE
    * @param {unknown } extraConfig Extra configuration object to format values specially when using custom formatters.
    * @returns { PropertyFormatting } The valid types to be returned after formatting a value.
    */
+  /**
+   * @description Gets the formatted value from an item property.
+   * @param { T } item The object to extract value from.
+   * @param { PropertyFormatting } param The configuration to format the object property value.
+   * @param { number } [index] Optional index for the item.
+   * @param { unknown } [extraConfig] Optional extra configuration.
+   * @returns { SafeHtml | string | FormattingComponentOutput } The formatted value.
+   */
   getFormattedValue(
     item: T extends BaseEntity ? T : never,
     { pathToKey, formatting }: PropertyFormatting<T, FormattingTypes>,
     index?: number,
     extraConfig?: unknown
   ): SafeHtml | string | FormattingComponentOutput {
-    const value = this.getValueFromRow(pathToKey, item);
+    const value = this.#getValueFromRow(pathToKey, item);
     const { type, extras } = formatting;
 
     switch (type) {
@@ -86,10 +94,13 @@ export class DataFormatFactoryService<T extends FormattingInput<keyof T> & BaseE
     }
   }
 
-  private getValueFromRow(
-    property: string,
-    item: T extends BaseEntity ? T : never
-  ): FormattingOutput {
+  /**
+   * @description Extracts a value from a row using a dot-notated property path.
+   * @param { string } property The dot-notated property path.
+   * @param { T } item The item to extract the value from.
+   * @returns { FormattingOutput } The extracted value.
+   */
+  #getValueFromRow(property: string, item: T extends BaseEntity ? T : never): FormattingOutput {
     return property.split('.').reduce((accObject: unknown, currentProp: string) => {
       const object = (accObject as T)[currentProp as keyof T];
       return isNil(object) ? '' : (object as FormattingOutput);

--- a/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
+++ b/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
@@ -196,6 +196,14 @@ export class SharedUtilFormattersService {
     return formatNumber(Number(value), format.locale, format.numberDigitsInfo) || '';
   }
 
+  /**
+   * Formats a quantity value with optional prefix and suffix.
+   * @template T - The type of the item.
+   * @param {number} value - The numeric value to format.
+   * @param {T} item - The item object.
+   * @param {(item: T) => Partial<Pick<FormattingExtras<'QUANTITY'>, 'numberDigitsInfo' | 'locale' | 'suffix' | 'prefix'>>} [extras] - Optional formatting extras.
+   * @returns {string} The formatted quantity string.
+   */
   quantityFormatter<T extends BaseEntity>(
     value: number,
     item: T,
@@ -217,11 +225,7 @@ export class SharedUtilFormattersService {
         ...extras(item),
       };
     }
-    return `
-    ${format.prefix ? format.prefix : ''}
-    ${formatNumber(Number(value), format.locale, format.numberDigitsInfo)}
-    ${format.suffix ? format.suffix : ''}
-    `;
+    return `${format.prefix}${formatNumber(Number(value), format.locale, format.numberDigitsInfo)}${format.suffix}`;
   }
 
   /**

--- a/libs/shared/util/objects/src/util-objects.ts
+++ b/libs/shared/util/objects/src/util-objects.ts
@@ -135,12 +135,13 @@ export function setEmptyStringPropertiesToNull(
 
 /**
  * Returns a boolean after comparing the object entries.
+ * It performs an order-independent shallow comparison of the object keys and values.
  * @param prev - First object.
  * @param curr - Current object.
  * @returns A boolean indicating if the object entries are equal.
  */
 export function areObjectEntriesEqual(prev: object, curr: object): boolean {
-  if (!prev && !curr) {
+  if (prev === curr) {
     return true;
   }
 
@@ -148,17 +149,17 @@ export function areObjectEntriesEqual(prev: object, curr: object): boolean {
     return false;
   }
 
-  const prevEntries = Object.entries(prev);
-  const currEntries = Object.entries(curr);
+  const prevKeys = Object.keys(prev);
+  const currKeys = Object.keys(curr);
 
-  if (prevEntries.length !== currEntries.length) {
+  if (prevKeys.length !== currKeys.length) {
     return false;
   }
 
-  return prevEntries.every(([key, value]) => {
+  return prevKeys.every(key => {
     return (
       Object.prototype.hasOwnProperty.call(curr, key) &&
-      (curr as Record<string, unknown>)[key] === value
+      (curr as Record<string, unknown>)[key] === (prev as Record<string, unknown>)[key]
     );
   });
 }


### PR DESCRIPTION
This PR addresses critical architectural violations and modernization refinements identified during the review of PR #1060 for "Plastikspace".

### Key Changes:
1.  **ES6 Private Fields**: Strictly enforced `#` syntax in `DataFormatFactoryService`.
2.  **State Consistency**: Ensured `FirebaseStorageService` resets its signals (`progress`, `fileUrl`) in the `catch` block of the `upload` method.
3.  **Lean Architecture**: Removed an unused import of `DataFormatFactoryService` in `SharedTableUiComponent`.
4.  **@defer Compatibility**: Moved the initialization of `matSort` and `matPaginator` in `SharedTableUiComponent` into `effect()` blocks. This ensures they are correctly populated after the deferred `mat-table` content renders.
5.  **UI Formatting**: Refactored `quantityFormatter` to use a single-line template literal, preventing unwanted whitespace in the rendered output.
6.  **Utility Optimization**: Improved `areObjectEntriesEqual` to perform order-independent shallow equality checks.
7.  **Documentation**: Updated JSDoc to follow the "Capital letter and period" rule.

All changes comply with Angular 21, Signals API, and Tailwind 4.0 project standards.

---
*PR created automatically by Jules for task [9205625084860657838](https://jules.google.com/task/9205625084860657838) started by @plastikaweb*