### PR TITLE
fix(eco-store): #86c9kwxm4 fix profile views alert side-tab and chip …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-02] - Eco-Store: Profile Views Alert & Chip Audit Fixes
+
+### Changed
+
+- **Shared Alert Border**: Replaced the asymmetric `border-left: 4px` (the "side-tab accent" AI tell) on `plastik-shared-alert` with a soft full-perimeter `1px` border using `color-mix(... 35%, transparent)`. The variant signal still flows through the tinted background and coloured icon ([#86c9kwxm4](https://app.clickup.com/t/86c9kwxm4)).
+- **Profile Avatar Hint Text**: Replaced the `text-[11px] font-bold tracking-widest uppercase` "recommended" hint with `text-sm font-medium tracking-normal italic`, fixing both the all-caps body-text and tiny-text findings ([#86c9kwxm4](https://app.clickup.com/t/86c9kwxm4)).
+- **Shared Chip Optional Uppercase**: Added an `uppercase` input on `SharedChipComponent` (default `true` to preserve existing visuals across all consumers); set `[uppercase]="false"` on the profile-feature role chip whose label is long enough to read as body text ([#86c9kwxm4](https://app.clickup.com/t/86c9kwxm4)).
+
 ## [2026-05-02] - Eco-Store: Confirm Dialog & Header Trial Badge
 
 ### Changed

--- a/libs/eco-store/profile/avatar/src/lib/eco-store-profile-avatar-feature/eco-store-profile-avatar-feature.component.html
+++ b/libs/eco-store/profile/avatar/src/lib/eco-store-profile-avatar-feature/eco-store-profile-avatar-feature.component.html
@@ -39,7 +39,7 @@
               {{ 'profile.avatar.description' | translate }}
             </p>
           </div>
-          <p class="text-on-surface/50 text-[11px] font-bold tracking-widest uppercase">
+          <p class="text-on-surface/60 text-sm font-medium tracking-normal italic">
             {{ 'profile.avatar.recommended' | translate }}
           </p>
 

--- a/libs/eco-store/profile/feature/src/lib/eco-store-profile-feature/eco-store-profile-feature.component.html
+++ b/libs/eco-store/profile/feature/src/lib/eco-store-profile-feature/eco-store-profile-feature.component.html
@@ -14,7 +14,9 @@
         class="text-sys-on-surface items-cener flex flex-col flex-wrap gap-3 text-3xl font-black tracking-tight sm:text-4xl lg:text-5xl">
         <span>{{ user.name }}</span>
         <div class="flex flex-row items-center gap-2">
-          <plastik-shared-chip class="text-sys-primary flex items-center gap-2 text-sm font-bold">
+          <plastik-shared-chip
+            class="text-sys-primary flex items-center gap-2 text-sm font-bold"
+            [uppercase]="false">
             <mat-icon class="scale-[0.8]" aria-hidden="true">{{ roleIcon() }}</mat-icon>
             {{ `users.role.${user?.role}` | translate }}
           </plastik-shared-chip>

--- a/libs/shared/alert/ui/src/lib/shared-alert-ui/shared-alert-ui.component.scss
+++ b/libs/shared/alert/ui/src/lib/shared-alert-ui/shared-alert-ui.component.scss
@@ -1,7 +1,11 @@
 @use '@angular/material' as mat;
 
 :host {
-  border-left: 4px solid;
+  /* Subtle full border instead of an asymmetric chunky left border.
+     The variant colour still flows through `border-color` + the tinted
+     background + icon colour, so the alert reads as colour-coded without
+     the "side-tab accent" pattern flagged by AI-tell audits. */
+  border: 1px solid;
 
   &.plastik-alert--info {
     background-color: color-mix(
@@ -9,7 +13,7 @@
       light-dark(var(--info-700), var(--info-100)) 12%,
       transparent
     );
-    border-left-color: light-dark(var(--info-700), var(--info-300));
+    border-color: color-mix(in srgb, light-dark(var(--info-700), var(--info-300)) 35%, transparent);
     color: var(--mat-sys-on-surface);
 
     .plastik-alert__icon {
@@ -27,7 +31,11 @@
       light-dark(var(--warning-700), var(--warning-300)) 14%,
       transparent
     );
-    border-left-color: light-dark(var(--warning-700), var(--warning-300));
+    border-color: color-mix(
+      in srgb,
+      light-dark(var(--warning-700), var(--warning-300)) 35%,
+      transparent
+    );
     color: var(--mat-sys-on-surface);
 
     .plastik-alert__icon {
@@ -41,7 +49,11 @@
       light-dark(var(--success-700), var(--success-300)) 12%,
       transparent
     );
-    border-left-color: light-dark(var(--success-700), var(--success-300));
+    border-color: color-mix(
+      in srgb,
+      light-dark(var(--success-700), var(--success-300)) 35%,
+      transparent
+    );
     color: var(--mat-sys-on-surface);
 
     .plastik-alert__icon {
@@ -51,7 +63,11 @@
 
   &.plastik-alert--error {
     background: color-mix(in srgb, light-dark(var(--error-700), var(--error-300)) 12%, transparent);
-    border-left-color: light-dark(var(--error-700), var(--error-300));
+    border-color: color-mix(
+      in srgb,
+      light-dark(var(--error-700), var(--error-300)) 35%,
+      transparent
+    );
     color: var(--mat-sys-on-error-container);
 
     .plastik-alert__icon {

--- a/libs/shared/chip/ui/src/lib/shared-chip.component.ts
+++ b/libs/shared/chip/ui/src/lib/shared-chip.component.ts
@@ -41,9 +41,16 @@ export class SharedChipComponent {
    */
   ariaLabel = input<string>();
 
+  /**
+   * Whether to render the chip label in uppercase. Defaults to true to keep
+   * the historical chip look. Set to false on chips whose label is long
+   * enough to read as body text (avoids the "all-caps body text" audit).
+   */
+  uppercase = input<boolean>(true);
+
   protected readonly computedClass = computed(() => {
-    const baseClass =
-      'flex justify-center items-center gap-1.5 rounded-full px-3 py-2.5 text-xs font-bold uppercase tracking-wide inset border transition-colors';
+    const caseClass = this.uppercase() ? 'uppercase' : 'normal-case';
+    const baseClass = `flex justify-center items-center gap-1.5 rounded-full px-3 py-2.5 text-xs font-bold ${caseClass} tracking-wide inset border transition-colors`;
     const typeClasses: Record<SharedChipType, string> = {
       primary:
         'chip-primary bg-primary-50 text-primary-800 border-primary-400 dark:bg-primary-700 dark:text-primary-50 dark:border-primary-600',


### PR DESCRIPTION
…uppercase

Replace shared-alert's chunky border-left with a soft full-perimeter border to drop the side-tab accent AI tell. Soften the profile avatar recommended hint (no uppercase, text-sm). Add an opt-out uppercase input on plastik-shared-chip and apply it to the profile role chip whose label is long enough to read as body text.

CLOSED: #86c9kwxm4