### PR TITLE
fix(eco-store): #86c9kxfya flatten cart shipping status strip and rem…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-02] - Eco-Store: Cart Shipping Progress & Status Strip
+
+### Changed
+
+- **Shipping Status Box Flattened**: Removed the gradient background, `1px` border, `box-shadow`, and `translateY(-1px)` hover lift on `.cart-order-price-slots__shipping`; replaced with a flat `color-mix(... 12%, transparent)` tinted strip so it no longer reads as a card-in-card inside the price-summary `mat-card` ([#86c9kxfya](https://app.clickup.com/t/86c9kxfya)).
+- **Shipping Status Icon Animations Removed**: Dropped the Tailwind `animate-bounce` from the "info" icon and `animate-pulse` from the "check_circle" icon, eliminating the bounce/elastic-easing AI-tell on the cart shipping summary ([#86c9kxfya](https://app.clickup.com/t/86c9kxfya)).
+- **Shipping Status Body Text**: Bumped the wrapper from `text-xs` (12px) to `text-sm` (14px) so the remaining-for-free / free-achieved message clears the body-text minimum-size floor ([#86c9kxfya](https://app.clickup.com/t/86c9kxfya)).
+
 ## [2026-05-02] - Eco-Store: Orders Detail Typography & Missing Icon
 
 ### Changed

--- a/libs/eco-store/cart/feature/src/lib/ui/cart-order-price-slots/cart-order-price-slots.component.html
+++ b/libs/eco-store/cart/feature/src/lib/ui/cart-order-price-slots/cart-order-price-slots.component.html
@@ -45,14 +45,14 @@
   </div>
 
   <div
-    class="cart-order-price-slots__shipping flex items-center gap-2 rounded-xl border p-2 text-xs font-semibold"
+    class="cart-order-price-slots__shipping flex items-center gap-2 rounded-lg p-2 text-sm font-semibold"
     [class.free]="isFree()"
     [class.not-free]="!isFree()">
     @if (isFree()) {
-      <mat-icon class="animate-pulse">check_circle</mat-icon>
+      <mat-icon aria-hidden="true">check_circle</mat-icon>
       <span>{{ 'cart.shipping.freeAchieved' | translate }}</span>
     } @else {
-      <mat-icon class="flex-shrink-0 animate-bounce">info</mat-icon>
+      <mat-icon class="flex-shrink-0" aria-hidden="true">info</mat-icon>
       <span
         >{{
           'cart.shipping.remainingForFree' | translate: { amount: remainingForFree() | currency }

--- a/libs/eco-store/cart/feature/src/lib/ui/cart-order-price-slots/cart-order-price-slots.component.scss
+++ b/libs/eco-store/cart/feature/src/lib/ui/cart-order-price-slots/cart-order-price-slots.component.scss
@@ -3,7 +3,7 @@
 :host {
   display: block;
 
-  // Tier Visualization Styles
+  /* Tier Visualization Styles */
   .tier-label {
     transform: translateX(-50%);
     transition: transform 0.3s ease;
@@ -35,7 +35,7 @@
     }
   }
 
-  // Shipping Cost Labels
+  /* Shipping Cost Labels */
   .shipping-cost-label {
     transform: translateX(-50%);
     transition: transform 0.3s ease;
@@ -50,56 +50,40 @@
     }
   }
 
-  // Shipping Status Box
+  /* Shipping Status Box — flat tinted strip (no card-in-card, no shadow, no hover lift). */
   .cart-order-price-slots__shipping {
     transition:
-      transform 0.4s cubic-bezier(0.4, 0, 0.2, 1),
-      box-shadow 0.4s cubic-bezier(0.4, 0, 0.2, 1),
-      background-color 0.4s cubic-bezier(0.4, 0, 0.2, 1),
-      border-color 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      background-color 0.3s ease,
+      color 0.3s ease;
 
     &.free {
-      background: linear-gradient(
-        135deg,
-        light-dark(var(--primary-50), var(--primary-800)) 0%,
-        light-dark(var(--primary-100), var(--primary-700)) 100%
+      background-color: color-mix(
+        in srgb,
+        light-dark(var(--primary-700), var(--primary-300)) 12%,
+        transparent
       );
-      border-color: light-dark(var(--primary-300), var(--primary-500));
       color: light-dark(var(--primary-700), var(--primary-200));
 
       @include mat.icon-overrides(
         (
-          color: light-dark(var(--primary-500), var(--primary-200)),
+          color: light-dark(var(--primary-700), var(--primary-200)),
         )
       );
     }
 
     &.not-free {
-      background: linear-gradient(
-        135deg,
-        light-dark(var(--error-50), var(--error-800)) 0%,
-        light-dark(var(--error-100), var(--error-700)) 100%
+      background-color: color-mix(
+        in srgb,
+        light-dark(var(--error-700), var(--error-300)) 12%,
+        transparent
       );
-      border-color: light-dark(var(--error-300), var(--error-500));
       color: light-dark(var(--error-700), var(--error-200));
 
       @include mat.icon-overrides(
         (
-          color: light-dark(var(--error-500), var(--error-200)),
+          color: light-dark(var(--error-700), var(--error-200)),
         )
       );
-    }
-
-    mat-icon {
-      transition:
-        color 0.3s ease,
-        transform 0.3s ease;
-    }
-
-    &:hover {
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-      transform: translateY(-1px);
     }
   }
 }


### PR DESCRIPTION
…ove icon bounce

Replace the gradient + border + box-shadow + hover-lift treatment on the shipping status box with a flat tinted strip so it stops reading as a card-in-card inside the price-summary mat-card. Drop the animate-bounce and animate-pulse icon animations and bump the wrapper from 12px to 14px text to clear the body-text size floor.