### PR TITLE
refactor(shared): apply jules modernization fixes from PR #1062

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-02] - Shared: Jules Modernization Fixes (PR #1062)
+
+### Changed
+
+- **Firebase Storage Reset on Upload Failure**: Replaced the partial `this.progress.set(0)` in `FirebaseStorageService.upload`'s `catch` block with `this.reset()` so the `fileUrl` signal is also cleared when an upload throws, keeping signal state consistent on error ([#1062](https://github.com/plastikaweb/plastikspace/pull/1062)).
+- **Shared Table Lean Architecture**: Removed the unused `DataFormatFactoryService` import and its dead `protected dataFormatFactoryService` injection from `SharedTableUiComponent` ([#1062](https://github.com/plastikaweb/plastikspace/pull/1062)).
+
 ## [2026-05-02] - Eco-Store: Cart Shipping Progress & Status Strip
 
 ### Changed

--- a/libs/shared/storage/data-access/src/firebase/firebase-storage.service.ts
+++ b/libs/shared/storage/data-access/src/firebase/firebase-storage.service.ts
@@ -53,7 +53,7 @@ export class FirebaseStorageService extends StorageService implements StorageSer
       this.fileUrl.set(await getDownloadURL(snapshot.ref));
       this.progress.set(0);
     } catch (error) {
-      this.progress.set(0);
+      this.reset();
       throw error;
     }
   }

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
@@ -37,7 +37,6 @@ import { RouterLink } from '@angular/router';
 import { EntityId } from '@ngrx/signals/entities';
 import { BaseEntity, SortConfig } from '@plastik/core/entities';
 import {
-  DataFormatFactoryService,
   FormattingTypes,
   SafeFormattedPipe,
   SharedUtilFormattersModule,
@@ -93,7 +92,6 @@ import { OrderTableActionsElementsPipe } from '../utils/order-table-actions-elem
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unknown }> {
-  protected dataFormatFactoryService = inject(DataFormatFactoryService);
   /**
    * Data that will populate the table.
    */


### PR DESCRIPTION
Use FirebaseStorageService.reset() in upload's catch block so fileUrl is also cleared on error. Drop the unused DataFormatFactoryService import and dead injection from SharedTableUiComponent.