### PR TITLE
Modernization and Standards Fix for PR #1072

### DIFF
--- a/libs/shared/storage/data-access/src/firebase/firebase-storage.service.ts
+++ b/libs/shared/storage/data-access/src/firebase/firebase-storage.service.ts
@@ -53,7 +53,7 @@ export class FirebaseStorageService extends StorageService implements StorageSer
       this.fileUrl.set(await getDownloadURL(snapshot.ref));
       this.progress.set(0);
     } catch (error) {
-      this.progress.set(0);
+      this.reset();
       throw error;
     }
   }

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
@@ -36,7 +36,6 @@ import { RouterLink } from '@angular/router';
 import { EntityId } from '@ngrx/signals/entities';
 import { BaseEntity } from '@plastik/core/entities';
 import {
-  DataFormatFactoryService,
   FormattingTypes,
   SafeFormattedPipe,
   SharedUtilFormattersModule,
@@ -255,6 +254,26 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
         this.dataSource.filter = '';
       }
     });
+
+    /**
+     * Synchronize MatSort and MatPaginator with the data source after they are initialized.
+     */
+    effect(() => {
+      const sortInstance = this.matSort();
+      const paginatorInstance = this.matPaginator();
+
+      if (sortInstance) {
+        if (this.sort()) {
+          sortInstance.active = this.sort()?.[0] || '';
+          sortInstance.direction = this.sort()?.[1] || 'asc';
+        }
+        this.dataSource.sort = sortInstance;
+      }
+
+      if (paginatorInstance) {
+        this.dataSource.paginator = paginatorInstance;
+      }
+    });
   }
 
   /**
@@ -273,27 +292,16 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
       return String(value).toLowerCase();
     };
 
-    if (this.filterPredicate && this.filterCriteria) {
-      this.dataSource.filterPredicate = (data: T) => {
-        return this.filterPredicate()?.(data as T, this.filterCriteria()) || false;
-      };
-    }
-
-    if (this.sort()) {
-      const matSortInstance = this.matSort();
-      if (matSortInstance) {
-        matSortInstance.active = this.sort()?.[0] || '';
-        matSortInstance.direction = this.sort()?.[1] || 'asc';
-        this.dataSource.sort = matSortInstance;
-      }
-    }
+    this.dataSource.filterPredicate = (data: T) => {
+      return this.filterPredicate()?.(data as T, this.filterCriteria()) || false;
+    };
   }
 
   /**
    * Handles pagination changes.
    * @param config - The pagination configuration.
    */
-  onChangePagination({ previousPageIndex, pageIndex, pageSize }: PageEventConfig) {
+  protected onChangePagination({ previousPageIndex, pageIndex, pageSize }: PageEventConfig) {
     if (pageSize !== this.pagination()?.pageSize) {
       pageIndex = 0;
     }
@@ -306,7 +314,9 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
 
   /**
    * Handles sorting changes.
-   * @param sorting - The sorting configuration.
+   * @param { TableSorting } param0 - The sorting configuration.
+   * @param { string } param0.active - The active column key.
+   * @param { SortDirection } param0.direction - The sorting direction.
    */
   protected onChangeSorting({ active, direction }: TableSorting): void {
     this.changeSorting.emit({
@@ -318,8 +328,8 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
 
   /**
    * Handles the delete action.
-   * @param event - The event object.
-   * @param element - The element to delete.
+   * @param { Event } event - The event object.
+   * @param { T } element - The element to delete.
    */
   protected onDelete(event: Event, element: T): void {
     event.stopPropagation();
@@ -328,9 +338,9 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
 
   /**
    * Handles input changes in editable cells.
-   * @param event - The event object.
-   * @param element - The element being edited.
-   * @param editableAttr - The editable attribute configuration.
+   * @param { Event | MatSelectChange | MatCheckboxChange | MatRadioChange | MatSlideToggleChange } event - The event object.
+   * @param { T } element - The element being edited.
+   * @param { EditableAttributeBase<T> } editableAttr - The editable attribute configuration.
    */
   protected onInputChange(
     event: Event | MatSelectChange | MatCheckboxChange | MatRadioChange | MatSlideToggleChange,
@@ -351,7 +361,7 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
 
   /**
    * Updates the expanded element.
-   * @param element - The element to expand or null to collapse.
+   * @param { T | null } element - The element to expand or null to collapse.
    */
   protected updateExpandedElement(element: T | null): void {
     requestAnimationFrame(() => {
@@ -361,7 +371,7 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
 
   /**
    * Announces the sort change for accessibility.
-   * @param sortState - The current sort state.
+   * @param { Sort } sortState - The current sort state.
    */
   #announceSortChange(sortState: Sort) {
     if (sortState.direction) {

--- a/libs/shared/table/ui/src/lib/utils/table-cell-title.directive.ts
+++ b/libs/shared/table/ui/src/lib/utils/table-cell-title.directive.ts
@@ -12,17 +12,20 @@ export class TableCellTitleDirective implements AfterViewInit {
     if (this.#elementRefElement.children.length > 0 && this.plastikTableCellTitle) {
       const childElement = this.#elementRefElement.children[0];
 
-      this.getTextContent(childElement);
-
-      const titleText = this.getTextContent(childElement);
+      const titleText = this.#getTextContent(childElement);
       this.#elementRefElement.setAttribute('title', titleText.trim());
       this.#elementRefElement.setAttribute('aria-label', titleText.trim());
 
-      this.addTitleToLiElements(childElement);
+      this.#addTitleToLiElements(childElement);
     }
   }
 
-  private getTextContent(node: Node): string {
+  /**
+   * Returns the text content of a node.
+   * @param { Node } node - The node to get the text content from.
+   * @returns { string } The text content.
+   */
+  #getTextContent(node: Node): string {
     let textContent = '';
 
     if (node.nodeType === Node.TEXT_NODE) {
@@ -36,7 +39,7 @@ export class TableCellTitleDirective implements AfterViewInit {
 
       if (!(node as HTMLElement).classList.contains('material-icons')) {
         Array.from(node.childNodes).forEach(childNode => {
-          textContent += this.getTextContent(childNode);
+          textContent += this.#getTextContent(childNode);
         });
       }
     }
@@ -44,19 +47,23 @@ export class TableCellTitleDirective implements AfterViewInit {
     return textContent;
   }
 
-  private addTitleToLiElements(node: Node): void {
+  /**
+   * Adds a title to <li> elements inside a <ul>.
+   * @param { Node } node - The node to search for <ul> elements.
+   */
+  #addTitleToLiElements(node: Node): void {
     if (node.nodeType === Node.ELEMENT_NODE) {
       const element = node as HTMLElement;
       if (element.tagName.toLowerCase() === 'ul') {
         const liElements = element.getElementsByTagName('li');
         for (let i = 0; i < liElements.length; i++) {
-          const liTextContent = this.getTextContent(liElements[i]);
+          const liTextContent = this.#getTextContent(liElements[i]);
           liElements[i].setAttribute('title', liTextContent);
           liElements[i].setAttribute('aria-label', liTextContent);
         }
       }
       Array.from(node.childNodes).forEach(childNode => {
-        this.addTitleToLiElements(childNode);
+        this.#addTitleToLiElements(childNode);
       });
     }
   }

--- a/libs/shared/util/formatters/src/lib/services/data-format-factory.service.ts
+++ b/libs/shared/util/formatters/src/lib/services/data-format-factory.service.ts
@@ -15,10 +15,10 @@ import {
 } from '../formatting';
 import { SharedUtilFormattersService } from './shared-util-formatters.service';
 
-@Injectable()
 /**
- * @description A service to format a value from an object applying a formatting configuration.
+ * A service to format a value from an object applying a formatting configuration.
  */
+@Injectable()
 export class DataFormatFactoryService<T extends FormattingInput<keyof T> & BaseEntity> {
   readonly #formatter = inject(SharedUtilFormattersService);
 
@@ -38,7 +38,7 @@ export class DataFormatFactoryService<T extends FormattingInput<keyof T> & BaseE
     index?: number,
     extraConfig?: unknown
   ): SafeHtml | string | FormattingComponentOutput {
-    const value = this.getValueFromRow(pathToKey, item);
+    const value = this.#getValueFromRow(pathToKey, item);
     const { type, extras } = formatting;
 
     switch (type) {
@@ -86,7 +86,13 @@ export class DataFormatFactoryService<T extends FormattingInput<keyof T> & BaseE
     }
   }
 
-  private getValueFromRow(
+  /**
+   * Extracts the value from a row based on the property path.
+   * @param { string } property - The property path.
+   * @param { T } item - The item to extract the value from.
+   * @returns { FormattingOutput } The extracted value.
+   */
+  #getValueFromRow(
     property: string,
     item: T extends BaseEntity ? T : never
   ): FormattingOutput {


### PR DESCRIPTION
Detailed analysis and refactoring of PR #1072 to ensure compliance with Plastikspace core standards.

Key improvements:
1. **Logic Fix**: Resolved a critical issue in `SharedTableUiComponent` where `matSort` and `matPaginator` were initialized too early in `ngOnInit`, potentially before the `@defer` block had rendered. They are now reactively synchronized via `effect()`.
2. **Standard Enforcement**: Converted `private` keywords to ES6 private fields (`#`) in `TableCellTitleDirective` and `DataFormatFactoryService` as per the project's strict architectural rules.
3. **Reactivity**: Leveraged Signals API and `effect()` for better state synchronization in the shared table component.
4. **State Management**: Improved error handling in `FirebaseStorageService` to maintain signal consistency.
5. **Documentation**: Standardized JSDoc descriptions and improved type documentation.
6. **Clean Code**: Removed unused `DataFormatFactoryService` injection in the table component and eliminated redundant computation in the title directive.

---
*PR created automatically by Jules for task [13937685716917111429](https://jules.google.com/task/13937685716917111429) started by @plastikaweb*