### PR TITLE
ci(workspace): reactivate claude code github workflows with oauth subscription auth

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,10 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    paths-ignore:
+      - '**/*.md'
+      - '.github/**'
+      - 'documentation/**'
 
 jobs:
   claude-review:
@@ -35,7 +33,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-17] - Workspace: Reactivate Claude Code GitHub workflows
+
+### Changed
+
+- **`.github/workflows/claude.yml` & `.github/workflows/claude-code-review.yml`**: Reactivated previously disabled (`.temp`) workflows and switched authentication from `ANTHROPIC_API_KEY` (pay-per-token API billing) to `CLAUDE_CODE_OAUTH_TOKEN` (counts against the Claude Code Max subscription quota, no extra billing). Added `paths-ignore` filter on the review workflow so PRs touching only Markdown, workflow YAML, or `documentation/` skip the automated review and preserve Max quota for substantive code changes.
+
 ## [2026-05-16] - Workspace: CLAUDE.md hierarchy refinement
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Scaffolding & Generators
 
 - For scaffolding tasks (creating apps, libs, project structure, setup), ALWAYS invoke the `nx-generate` skill FIRST before exploring or calling MCP tools
+  [text](CLAUDE.md)
 
 ## When to use nx_docs
 


### PR DESCRIPTION
## Summary

- Reactivate the two previously-disabled `.github/workflows/claude*.yml` files (restored from `.temp`)
- Swap auth from `ANTHROPIC_API_KEY` → `CLAUDE_CODE_OAUTH_TOKEN` so runs consume the Claude Code Max subscription quota instead of pay-per-token API billing (no extra cost beyond the existing subscription)
- Add `paths-ignore` filter on the review workflow so PRs touching only Markdown, workflow YAML, or `documentation/` skip the automated review and preserve quota for substantive code changes

## Context

First slice of the broader ClickUp / commit / PR / merge automation workflow we're building. Kept intentionally narrow so the OAuth + subscription-auth wiring is validated in isolation before the ClickUp-side phases land.

## Test plan

- [ ] PR opens cleanly on `develop`
- [ ] The review workflow does **not** fire on this PR (changes are workflow-only, matches `paths-ignore`) — that's expected behavior
- [ ] On the next code-touching PR, `claude-code-review` workflow fires and posts a review using the Max subscription quota
- [ ] `@claude` mention in a comment on any PR/issue triggers the `claude.yml` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)