### PR TITLE
docs(eco-store): backlog governance rules + file OPS-02 task

### DIFF
--- a/apps/eco-store/BACKLOG.md
+++ b/apps/eco-store/BACKLOG.md
@@ -5,7 +5,7 @@
 >
 > Companion to `TASKS.md` and PRD v1.8.
 
-**Document version:** 0.4 · **Last updated:** 2026-05-23
+**Document version:** 0.5 · **Last updated:** 2026-05-23
 
 ---
 
@@ -28,6 +28,7 @@
 
 | #   | Task                                                                | Priority   | Est   | Depends on | Notes                                                                                                                        |
 | --- | ------------------------------------------------------------------- | ---------- | ----- | ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 0.0 | **OPS-02** Claude review workflow `pull-requests: write`            | **Urgent** | 0.1d  | —          | One-line permission bump in `.github/workflows/claude-code-review.yml`. Unblocks automated PR review reports. CU `86c9y6xyb` |
 | 0.1 | **BUG-005** Profile routes auth guard                               | **Urgent** | 0.5d  | —          | `canActivate` on `/perfil` subtree; redirect to `/accedir` when unauthenticated. CU `86c99rjxt`                              |
 | 0.2 | **META-01** Delete obsolete PRD ✅                                  | MUST       | 0.25d | —          | Done 2026-05-23 — `eco-store-req.md` removed; stale refs in cspell/markdownlint/CLAUDE.md/TASKS.md cleaned up                |
 | 0.3 | **META-02** Remove `NOT_REGISTERED` enum                            | MUST       | 0.25d | —          | Admin UI → export → commit `pb_schema.json`                                                                                  |

--- a/apps/eco-store/CLAUDE.md
+++ b/apps/eco-store/CLAUDE.md
@@ -46,6 +46,21 @@ This is **in addition to** the ClickUp `#<task>` ID the `commitizen-git-flow` sk
 
 If you can't find a matching ID in TASKS.md, **stop and ask** rather than inventing one. New cross-cutting work without a PRD section should be filed under the appropriate non-PRD family (`BUG-`, `META-`, `OPS-`, `TECH-`, `SEO-`, `MKT-research-`) — propose the ID before committing.
 
+### Adding new tasks to `TASKS.md` / `BACKLOG.md` (MANDATORY)
+
+When you add a brand-new task entry to `apps/eco-store/TASKS.md` or `apps/eco-store/BACKLOG.md`, you **must also create the corresponding ClickUp ticket** via the ClickUp MCP in the same change. The TASKS.md row should then carry the new ClickUp ID. Don't leave entries with `—` or `_pending_` in the ClickUp column — that's how drift starts (see META-05 sync command and the 17 drift items it surfaced on first run).
+
+Before creating the ClickUp task: inspect a same-family analog already in the board (e.g. another `BOT-` or `OPS-` task) to pick the right list, tags, and assignee defaults. The ClickUp ID is the bridge for status sync.
+
+### Committing changes to `TASKS.md` / `BACKLOG.md` only
+
+`TASKS.md` and `BACKLOG.md` are living planning docs, not release artifacts. Treat them differently from code:
+
+- **Don't open standalone PRs for backlog-only edits.** Bundle them into a feature branch as a separate commit (one commit for the code change, one for the TASKS.md status flip) when the related work ships.
+- **No CHANGELOG entry** for backlog-only changes. Keep a Changelog is for release-impacting changes a reader cares about; planning metadata isn't that. When a feature commit includes a TASKS.md flip alongside the work, the CHANGELOG bullet describes the _work_ (with the PRD/CU ID), not the TASKS edit.
+- **For pure-grooming passes** with no associated code change (audits, ID corrections, version bumps, adding queued tasks): commit with `docs(eco-store):` scope. No standalone PR — fold them into the next feature branch instead, or push directly if branch protection allows.
+- The exception is _deleting an obsolete document_ (e.g. META-01) or other one-off cleanups where the change itself is the deliverable — those still get a CHANGELOG bullet and a PR.
+
 ---
 
 ## Library structure (`libs/eco-store/*`)

--- a/apps/eco-store/TASKS.md
+++ b/apps/eco-store/TASKS.md
@@ -10,7 +10,7 @@
 > - **`apps/eco-store/POCKETBASE.md`** — backend workflow & scripts
 > - **`apps/eco-store/CLAUDE.md`** — app-specific guidance for AI agents
 
-**Document version:** 0.6 · **Last updated:** 2026-05-23
+**Document version:** 0.7 · **Last updated:** 2026-05-23
 
 ---
 
@@ -44,22 +44,23 @@
 
 ## 🎯 Current focus
 
-| Task        | Module | Priority | Status | One-line summary                                                       |
-| ----------- | ------ | -------- | ------ | ---------------------------------------------------------------------- |
-| **META-02** | META   | MUST     | 📋     | Remove `NOT_REGISTERED` from `users.membershipStatus` enum             |
-| **BUG-001** | BOT-05 | MUST     | ❓     | Verify cart merge regression — code complete, needs manual test pass   |
-| **BUG-002** | BOT    | MUST     | 📋     | Deep-link to `/cistella/resum` redirects to `/botiga`                  |
-| **BUG-003** | BOT    | MUST     | 📋     | PWA manifest doesn't use tenant name as default app name               |
-| **PRV-02b** | PRV    | MUST     | 🔄     | Email change with async verification (CU `86c92g6ek`)                  |
-| **PRV-02c** | PRV    | MUST     | 🔄     | In-session password change (CU `86c92g60y`)                            |
-| **PRV-04d** | PRV    | MUST     | 📋     | Billing address typology + NIF on `user_addresses` (CU `86c99dev0`)    |
-| **PRV-08**  | PRV    | MUST     | 🔄     | Self-service account deletion (RGPD right to erasure) (CU `86c92g6hd`) |
-| **PRV-09**  | PRV    | SHOULD   | 🔄     | Notification preferences panel (CU `86c92g7fb`)                        |
-| **TRL-03**  | TRL    | MUST     | 📋     | Trial → member conversion CTA                                          |
-| **BOT-02b** | BOT    | MUST     | 📋     | Text search input above product grid                                   |
-| **BOT-02c** | BOT    | MUST     | 📋     | Tag filter chips above product grid                                    |
-| **BOT-08**  | BOT    | MUST     | 📋     | Stock badge + out-of-stock overlay with "Avisa'm"                      |
-| **VAL-01**  | VAL    | SHOULD   | 🔄     | Publish review form on product detail                                  |
+| Task        | Module | Priority   | Status | One-line summary                                                          |
+| ----------- | ------ | ---------- | ------ | ------------------------------------------------------------------------- |
+| **OPS-02**  | OPS    | **Urgent** | 📋     | Grant `pull-requests: write` to `claude-code-review.yml` (CU `86c9y6xyb`) |
+| **META-02** | META   | MUST       | 📋     | Remove `NOT_REGISTERED` from `users.membershipStatus` enum                |
+| **BUG-001** | BOT-05 | MUST       | ❓     | Verify cart merge regression — code complete, needs manual test pass      |
+| **BUG-002** | BOT    | MUST       | 📋     | Deep-link to `/cistella/resum` redirects to `/botiga`                     |
+| **BUG-003** | BOT    | MUST       | 📋     | PWA manifest doesn't use tenant name as default app name                  |
+| **PRV-02b** | PRV    | MUST       | 🔄     | Email change with async verification (CU `86c92g6ek`)                     |
+| **PRV-02c** | PRV    | MUST       | 🔄     | In-session password change (CU `86c92g60y`)                               |
+| **PRV-04d** | PRV    | MUST       | 📋     | Billing address typology + NIF on `user_addresses` (CU `86c99dev0`)       |
+| **PRV-08**  | PRV    | MUST       | 🔄     | Self-service account deletion (RGPD right to erasure) (CU `86c92g6hd`)    |
+| **PRV-09**  | PRV    | SHOULD     | 🔄     | Notification preferences panel (CU `86c92g7fb`)                           |
+| **TRL-03**  | TRL    | MUST       | 📋     | Trial → member conversion CTA                                             |
+| **BOT-02b** | BOT    | MUST       | 📋     | Text search input above product grid                                      |
+| **BOT-02c** | BOT    | MUST       | 📋     | Tag filter chips above product grid                                       |
+| **BOT-08**  | BOT    | MUST       | 📋     | Stock badge + out-of-stock overlay with "Avisa'm"                         |
+| **VAL-01**  | VAL    | SHOULD     | 🔄     | Publish review form on product detail                                     |
 
 See **`BACKLOG.md`** for the phased plan.
 
@@ -278,7 +279,7 @@ Hook update: `single_default_address.pb.js` → enforce single `defaultShipping=
 
 ### Done ✅
 
-TRL-01 (schema-ready), TRL-02 (header badge), TRL-05 (API rules backend).
+TRL-01 (schema-ready), TRL-02 (header badge), TRL-05 (API rules backend), TRL-06 (data preservation verified).
 
 ### Pending 📋
 
@@ -286,7 +287,6 @@ TRL-01 (schema-ready), TRL-02 (header badge), TRL-05 (API rules backend).
 | ---------- | --------------------------------------- | -------- | -------------------------------------------------- |
 | **TRL-03** | Conversion CTA in `/perfil`             | MUST     | Spec in earlier TASKS version; ClickUp `86c90qt5e` |
 | **TRL-04** | Frontend checkout block + upsell dialog | MUST     | UX mirror of TRL-05                                |
-| **TRL-06** | Data preservation verification          | MUST     | Mostly implicit; verify                            |
 | **TRL-07** | Admin-approved conversion (eco-admin)   | MUST     | Future                                             |
 | **TRL-08** | Trial expiry reminder email             | SHOULD   | New scheduled hook                                 |
 | **TRL-09** | Admin filter & transitions              | SHOULD   | Out of scope (eco-admin)                           |
@@ -404,12 +404,13 @@ All `COULD`, pending discovery.
 
 ### Ops / Release
 
-| ID                  | Description                                                                                        | Priority | ClickUp     |
-| ------------------- | -------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| **OPS-01** _(new)_  | Setup production deploy pipeline                                                                   | MUST     | `86c8cjgm0` |
-| **META-03** _(new)_ | Fix repo coverage badge update                                                                     | Low      | `86c8tqjma` |
-| **META-04** _(new)_ | Add a SKILL to format readme files                                                                 | Low      | `86c8cjgh6` |
-| **META-05** _(new)_ | Phase 1: read-only `/sync-eco-store-tasks` diff command (ClickUp ↔ TASKS.md automation foundation) | Low      | `86c9uwmzf` |
+| ID                  | Description                                                                                        | Priority   | ClickUp     |
+| ------------------- | -------------------------------------------------------------------------------------------------- | ---------- | ----------- |
+| **OPS-01** _(new)_  | Setup production deploy pipeline                                                                   | MUST       | `86c8cjgm0` |
+| **OPS-02** _(new)_  | Grant `pull-requests: write` to `claude-code-review.yml` workflow                                  | **Urgent** | `86c9y6xyb` |
+| **META-03** _(new)_ | Fix repo coverage badge update                                                                     | Low        | `86c8tqjma` |
+| **META-04** _(new)_ | Add a SKILL to format readme files                                                                 | Low        | `86c8cjgh6` |
+| **META-05** ✅      | Phase 1: read-only `/sync-eco-store-tasks` diff command (ClickUp ↔ TASKS.md automation foundation) | Low        | `86c9uwmzf` |
 
 ### Research / Marketing (not dev)
 
@@ -462,7 +463,7 @@ ClickUp `86c8tqjma`. Workflow at `.github/workflows/ci.yml` writes to a Gist; ba
 
 ClickUp `86c8cjgh6`. Internal tooling — add a Claude Code skill at `.claude/skills/format-readme/` for consistent README formatting across libs.
 
-### META-05 — ClickUp ↔ TASKS.md automation (Phase 1 of 4)
+### META-05 — ClickUp ↔ TASKS.md automation (Phase 1 of 4) ✅ Done (2026-05-17)
 
 ClickUp `86c9uwmzf`. Internal tooling — first slice of a multi-phase workflow that keeps `TASKS.md` and ClickUp in sync. Phase 1 is a **read-only** slash command `/sync-eco-store-tasks` that diffs both sides (TASKS.md vs ClickUp list `901521018763`) and outputs a three-section report (only-in-TASKS, only-in-ClickUp, status mismatches). No writes. Validates API token, IDs, and the PRD-ID-as-bridge matching assumption before later phases add hooks/Actions that write.
 
@@ -474,6 +475,7 @@ ClickUp `86c9uwmzf`. Internal tooling — first slice of a multi-phase workflow 
 
 | Version | Date       | Notes                                                                                                                                                                                                                                                                                                                                     |
 | ------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.7     | 2026-05-23 | Added **OPS-02** (Urgent, CU `86c9y6xyb`): grant `pull-requests: write` to `.github/workflows/claude-code-review.yml`. Backlog-grooming pass alongside: flipped **TRL-06** and **META-05** to ✅ (ClickUp was source of truth — `/sync-eco-store-tasks` flagged them as status mismatches).                                               |
 | 0.6     | 2026-05-23 | Added TECH-02 (modernize `libs/shared/*` to Angular 21 standards, derived from Jules PRs #1078 + #1073). Fixed stale TECH-01 ClickUp ID (`86c8cjghn` → `86c9uq9rf`).                                                                                                                                                                      |
 | 0.5     | 2026-05-17 | Added META-05 (Phase 1 of ClickUp ↔ TASKS.md automation: read-only `/sync-eco-store-tasks` diff command). CU `86c9uwmzf`.                                                                                                                                                                                                                 |
 | 0.4     | 2026-05-16 | ClickUp audit integrated. Re-added PRV-08/09/04d as in-scope (Carlos confirmed). Added PRV-02c, BUG-002..005, BOT-16, UI-04, SEO-01, PST-04, EST-06, TECH-01, OPS-01, META-03/04, A11Y-002, MKT-research-01. 10 ClickUp subtasks of #21 epic mapped: 6 closed (history) + 4 in-progress + billing. Q-15 added (tags store clarification). |


### PR DESCRIPTION
## Summary

- **Codify backlog governance in `apps/eco-store/CLAUDE.md`** — two new MANDATORY subsections under "Referencing task identifiers":
  - New TASKS.md / BACKLOG.md entries must be paired with a ClickUp ticket created via MCP (inspect a same-family analog for tags/list/priority).
  - Backlog-only edits don't get standalone PRs or CHANGELOG entries — they ride along on the related feature branch (or a `docs(eco-store):` grooming commit). The exception is one-off cleanups where the change itself is the deliverable (e.g. META-01), which still get a CHANGELOG bullet and a PR.
- **File OPS-02** (Urgent, CU [`86c9y6xyb`](https://app.clickup.com/t/86c9y6xyb)) — grant `pull-requests: write` to `.github/workflows/claude-code-review.yml` so the code-review plugin can post its report back to the PR. Permission gap caused 2 tool denials on PR #1080's review run (9 min of analysis, zero PR-visible output).
- **Backlog-grooming ride-along** — flipped **TRL-06** + **META-05** to ✅ per `/sync-eco-store-tasks` output (ClickUp was source of truth). Bumped TASKS.md → v0.7, BACKLOG.md → v0.5.

## Why a PR (under the new rule)

The new rule says "no standalone PRs for backlog-only edits." This PR is *not* backlog-only — it adds substantive governance rules to CLAUDE.md that every agent working in the repo needs to read. That falls under the explicit exception ("one-off cleanups where the change itself is the deliverable"). The OPS-02 filing + backlog grooming ride along.

## Test plan

- [x] Pre-push hooks green (PocketBase auto-export, i18n validation, lint on affected projects, markdownlint, Pa11y 7/7 URLs)
- [x] OPS-02 ClickUp ticket exists at <https://app.clickup.com/t/86c9y6xyb> (Urgent, tags: fix/ci/phase-0, mirroring BUG-005's Phase 0 pattern)
- [x] `/sync-eco-store-tasks` rerun should now show 2 fewer status mismatches (TRL-06, META-05) and OPS-02 bridged with its CU ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)