### PR TITLE
ci(workspace): #86c9y6xyb OPS-02 grant pull-requests: write to claude-code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-23] - Workspace: OPS-02 — Grant `pull-requests: write` to claude-code-review workflow
+
+### Fixed
+
+- **`.github/workflows/claude-code-review.yml`**: Raised `permissions.pull-requests` from `read` to `write` (and `issues` from `read` to `write` for summary-comment fallback). The Claude code-review plugin was running successfully end-to-end but its final step — calling `github.rest.pulls.createReview` / `createReviewComment` to attach the report to the PR — got denied by the GitHub permission gate, so every review run completed silently. PR #1080's run logged 2 `permission_denials_count` and `"No buffered inline comments"` after 9 min / $3.47 / 17 turns of analysis. From now on, every PR matching the existing `paths-ignore` filter will get Claude's review report posted as comments (OPS-02, [#86c9y6xyb](https://app.clickup.com/t/86c9y6xyb)).
+
 ## [2026-05-23] - Eco-store: META-01 — Remove obsolete v1.7 PRD + TECH-01/02 ClickUp ID corrections
 
 ### Removed

--- a/apps/eco-store/BACKLOG.md
+++ b/apps/eco-store/BACKLOG.md
@@ -28,7 +28,7 @@
 
 | #   | Task                                                                | Priority   | Est   | Depends on | Notes                                                                                                                        |
 | --- | ------------------------------------------------------------------- | ---------- | ----- | ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 0.0 | **OPS-02** Claude review workflow `pull-requests: write`            | **Urgent** | 0.1d  | —          | One-line permission bump in `.github/workflows/claude-code-review.yml`. Unblocks automated PR review reports. CU `86c9y6xyb` |
+| 0.0 | **OPS-02** Claude review workflow `pull-requests: write` ✅         | **Urgent** | 0.1d  | —          | Done 2026-05-23 — `permissions.pull-requests` raised `read` → `write` (also `issues`). CU `86c9y6xyb`                        |
 | 0.1 | **BUG-005** Profile routes auth guard                               | **Urgent** | 0.5d  | —          | `canActivate` on `/perfil` subtree; redirect to `/accedir` when unauthenticated. CU `86c99rjxt`                              |
 | 0.2 | **META-01** Delete obsolete PRD ✅                                  | MUST       | 0.25d | —          | Done 2026-05-23 — `eco-store-req.md` removed; stale refs in cspell/markdownlint/CLAUDE.md/TASKS.md cleaned up                |
 | 0.3 | **META-02** Remove `NOT_REGISTERED` enum                            | MUST       | 0.25d | —          | Admin UI → export → commit `pb_schema.json`                                                                                  |

--- a/apps/eco-store/TASKS.md
+++ b/apps/eco-store/TASKS.md
@@ -44,23 +44,22 @@
 
 ## 🎯 Current focus
 
-| Task        | Module | Priority   | Status | One-line summary                                                          |
-| ----------- | ------ | ---------- | ------ | ------------------------------------------------------------------------- |
-| **OPS-02**  | OPS    | **Urgent** | 📋     | Grant `pull-requests: write` to `claude-code-review.yml` (CU `86c9y6xyb`) |
-| **META-02** | META   | MUST       | 📋     | Remove `NOT_REGISTERED` from `users.membershipStatus` enum                |
-| **BUG-001** | BOT-05 | MUST       | ❓     | Verify cart merge regression — code complete, needs manual test pass      |
-| **BUG-002** | BOT    | MUST       | 📋     | Deep-link to `/cistella/resum` redirects to `/botiga`                     |
-| **BUG-003** | BOT    | MUST       | 📋     | PWA manifest doesn't use tenant name as default app name                  |
-| **PRV-02b** | PRV    | MUST       | 🔄     | Email change with async verification (CU `86c92g6ek`)                     |
-| **PRV-02c** | PRV    | MUST       | 🔄     | In-session password change (CU `86c92g60y`)                               |
-| **PRV-04d** | PRV    | MUST       | 📋     | Billing address typology + NIF on `user_addresses` (CU `86c99dev0`)       |
-| **PRV-08**  | PRV    | MUST       | 🔄     | Self-service account deletion (RGPD right to erasure) (CU `86c92g6hd`)    |
-| **PRV-09**  | PRV    | SHOULD     | 🔄     | Notification preferences panel (CU `86c92g7fb`)                           |
-| **TRL-03**  | TRL    | MUST       | 📋     | Trial → member conversion CTA                                             |
-| **BOT-02b** | BOT    | MUST       | 📋     | Text search input above product grid                                      |
-| **BOT-02c** | BOT    | MUST       | 📋     | Tag filter chips above product grid                                       |
-| **BOT-08**  | BOT    | MUST       | 📋     | Stock badge + out-of-stock overlay with "Avisa'm"                         |
-| **VAL-01**  | VAL    | SHOULD     | 🔄     | Publish review form on product detail                                     |
+| Task        | Module | Priority | Status | One-line summary                                                       |
+| ----------- | ------ | -------- | ------ | ---------------------------------------------------------------------- |
+| **META-02** | META   | MUST     | 📋     | Remove `NOT_REGISTERED` from `users.membershipStatus` enum             |
+| **BUG-001** | BOT-05 | MUST     | ❓     | Verify cart merge regression — code complete, needs manual test pass   |
+| **BUG-002** | BOT    | MUST     | 📋     | Deep-link to `/cistella/resum` redirects to `/botiga`                  |
+| **BUG-003** | BOT    | MUST     | 📋     | PWA manifest doesn't use tenant name as default app name               |
+| **PRV-02b** | PRV    | MUST     | 🔄     | Email change with async verification (CU `86c92g6ek`)                  |
+| **PRV-02c** | PRV    | MUST     | 🔄     | In-session password change (CU `86c92g60y`)                            |
+| **PRV-04d** | PRV    | MUST     | 📋     | Billing address typology + NIF on `user_addresses` (CU `86c99dev0`)    |
+| **PRV-08**  | PRV    | MUST     | 🔄     | Self-service account deletion (RGPD right to erasure) (CU `86c92g6hd`) |
+| **PRV-09**  | PRV    | SHOULD   | 🔄     | Notification preferences panel (CU `86c92g7fb`)                        |
+| **TRL-03**  | TRL    | MUST     | 📋     | Trial → member conversion CTA                                          |
+| **BOT-02b** | BOT    | MUST     | 📋     | Text search input above product grid                                   |
+| **BOT-02c** | BOT    | MUST     | 📋     | Tag filter chips above product grid                                    |
+| **BOT-08**  | BOT    | MUST     | 📋     | Stock badge + out-of-stock overlay with "Avisa'm"                      |
+| **VAL-01**  | VAL    | SHOULD   | 🔄     | Publish review form on product detail                                  |
 
 See **`BACKLOG.md`** for the phased plan.
 
@@ -407,7 +406,7 @@ All `COULD`, pending discovery.
 | ID                  | Description                                                                                        | Priority   | ClickUp     |
 | ------------------- | -------------------------------------------------------------------------------------------------- | ---------- | ----------- |
 | **OPS-01** _(new)_  | Setup production deploy pipeline                                                                   | MUST       | `86c8cjgm0` |
-| **OPS-02** _(new)_  | Grant `pull-requests: write` to `claude-code-review.yml` workflow                                  | **Urgent** | `86c9y6xyb` |
+| **OPS-02** ✅       | Grant `pull-requests: write` to `claude-code-review.yml` workflow                                  | **Urgent** | `86c9y6xyb` |
 | **META-03** _(new)_ | Fix repo coverage badge update                                                                     | Low        | `86c8tqjma` |
 | **META-04** _(new)_ | Add a SKILL to format readme files                                                                 | Low        | `86c8cjgh6` |
 | **META-05** ✅      | Phase 1: read-only `/sync-eco-store-tasks` diff command (ClickUp ↔ TASKS.md automation foundation) | Low        | `86c9uwmzf` |


### PR DESCRIPTION
## Summary

- **`.github/workflows/claude-code-review.yml`**: Raised `permissions.pull-requests` from `read` → `write` (and `issues` from `read` → `write` for the summary-comment fallback path). With `read` only, the Claude code-review plugin completed its analysis successfully but every `pulls.createReview` / `createReviewComment` tool call was denied by GitHub's permission gate — so the workflow ran ~9 min per PR and posted nothing.
- **Evidence**: PR #1080's review run logged `"permission_denials_count": 2` + `"No buffered inline comments"` despite `"subtype": "success"`, 17 turns, $3.47 cost.
- **Backlog flip**: OPS-02 → ✅ in TASKS.md (removed from current focus; Ops/Release detail table marked done) and BACKLOG.md (Phase 0.0).
- **Existing `paths-ignore` filter preserved** — docs-only PRs (`**/*.md`, `.github/**`, `documentation/**`) still skip the review.

## Test plan

- [x] Pre-push hooks green (PocketBase export, i18n validation, lint, markdownlint, Pa11y 7/7)
- [ ] Manual verification once this merges: open a tiny code-touching PR and confirm Claude posts its review comment(s) within the workflow run
- [ ] Watch the Actions log on this PR itself — once the workflow re-runs against the updated permissions on whatever branch picks it up, it should attach review output

## Refs

- OPS-02 ([#86c9y6xyb](https://app.clickup.com/t/86c9y6xyb))
- TASKS.md → OPS-02 (now ✅)
- BACKLOG.md → Phase 0, task 0.0 (now ✅)
- Related: PR #1080 review run that surfaced the gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)