### PR TITLE
ci(husky): add eco-store backlog/code separation pre-commit guard

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,38 @@
 #!/usr/bin/env sh
 set -e
 
+# --- BACKLOG / CODE SEPARATION GUARD (eco-store) ---
+# apps/eco-store/{TASKS,BACKLOG}.md are living planning docs and must be committed
+# on their own — mixing them with source code pollutes feature-commit history
+# (see apps/eco-store/CLAUDE.md, "Committing changes to TASKS.md / BACKLOG.md only").
+# NOTE: this hook ends with `git add -A`, so the commit = the whole working tree.
+# We therefore check every changed file (staged or not), not just the staged set.
+# Legitimate one-off cleanups (e.g. deleting an obsolete doc together with code)
+# can bypass:  ALLOW_BACKLOG_MIX=1 git commit ...
+if [ -z "$ALLOW_BACKLOG_MIX" ]; then
+  CHANGED=$(git status --porcelain | awk '{print $NF}')
+  BACKLOG=$(printf '%s\n' "$CHANGED" | grep -E '^apps/eco-store/(TASKS|BACKLOG)\.md$' || true)
+  if [ -n "$BACKLOG" ]; then
+    NON_DOC=$(printf '%s\n' "$CHANGED" | grep -vE '\.md$' || true)
+    if [ -n "$NON_DOC" ]; then
+      echo "❌ eco-store backlog docs would be committed together with non-doc files:"
+      printf '%s\n' "$BACKLOG" | sed 's/^/   backlog: /'
+      printf '%s\n' "$NON_DOC" | sed 's/^/   other:   /'
+      echo ""
+      echo "   TASKS.md / BACKLOG.md belong in their own commit. Split it:"
+      echo "     git stash push apps/eco-store/TASKS.md apps/eco-store/BACKLOG.md"
+      echo "     git commit                       # the code change"
+      echo "     git stash pop"
+      echo "     git add apps/eco-store/TASKS.md apps/eco-store/BACKLOG.md"
+      echo "     git commit -m 'docs(eco-store): #<task> <ID> flip status'"
+      echo ""
+      echo "   One-off cleanup that genuinely needs both? ALLOW_BACKLOG_MIX=1 git commit ..."
+      exit 1
+    fi
+  fi
+fi
+# ----------------------------------------------------
+
 # --- SANDBOX BRIDGE ---
 # Redirect HOME to a temp directory to avoid EPERM on /Users/plastikaweb/.yarnrc
 export HOME=/tmp/husky-sandbox


### PR DESCRIPTION
## What

Adds a guard at the top of `.husky/pre-commit` that rejects any commit mixing `apps/eco-store/TASKS.md` / `BACKLOG.md` with non-doc files, keeping feature-commit history clean.

These are living planning docs and, per `apps/eco-store/CLAUDE.md` ("Committing changes to TASKS.md / BACKLOG.md only"), they belong in their own commit — separate from code changes.

## How

- Runs **first** in the hook, so it fails fast (before the ~3s PocketBase export + lint).
- Checks the **whole working tree** via `git status --porcelain`, not just the staged set — because the hook ends with `git add -A`, so a staged-only check would be leaky.
- Triggers only when a backlog doc changes *alongside* a non-`.md` file. Markdown-only changes (grooming, CHANGELOG, CLAUDE.md edits) pass through.
- On block, prints the offending files split into `backlog:` / `other:` plus the exact split-commit commands.

## Bypass

Legitimate one-off cleanups (e.g. deleting an obsolete doc together with code) can override:

```
ALLOW_BACKLOG_MIX=1 git commit ...
```

## Notes

- No ClickUp task / TASKS.md entry / CHANGELOG — internal dev tooling, not a user-facing or PRD-tracked change.
- Verified against its own commit: passed correctly (hook file is non-`.md`, no backlog docs), full pre-commit chain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
