### PR TITLE
refactor(shared-table-ui): TECH-02 #86c9y6upw modernization residue + Jules root-cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-29] - Shared: TECH-02 — libs/shared Angular-21 modernization residue
+
+### Changed
+
+- **`libs/shared/table/ui`**: Converted `TableCellTitleDirective`'s `private` methods to ES6 `#` private methods (and dropped a redundant `getTextContent` call); removed the dead `@ViewChildren('matFormField')` query from `SharedTableUiComponent` (never read) along with its now-unused `ElementRef` / `ViewChildren` imports. Residual cleanup of the `libs/shared/*` Angular-21 modernization — the bulk of which already landed on `develop`. The recurring Jules modernization PRs (#1073/#1078/#1087, all closed) targeted `main` (llecoop's prod branch, ~595 commits behind `develop`), which is why they kept re-proposing already-merged work (TECH-02, [#86c9y6upw](https://app.clickup.com/t/86c9y6upw)).
+
 ## [2026-05-29] - Eco-store: BUG-002 — Deep-link to /cistella/resum no longer redirects to /botiga during SSR
 
 ### Fixed

--- a/apps/eco-store/BACKLOG.md
+++ b/apps/eco-store/BACKLOG.md
@@ -175,19 +175,19 @@
 
 **Estimated effort:** ~8 dev-days
 
-| #    | Task                                        | Priority | Est   | Depends on | Notes                                                    |
-| ---- | ------------------------------------------- | -------- | ----- | ---------- | -------------------------------------------------------- |
-| 7.1  | **UI-04** Footer view                       | MUST     | 1d    | —          | CU `86c8cjgg9`                                           |
-| 7.2  | **LGL-01** Legal pages                      | MUST     | 2d    | —          | Static content + footer links + i18n. CU `86c8cjgm2`     |
-| 7.3  | **Q-10** Resolve cookie consent strategy    | —        | 0.25d | —          | CMP vs in-house                                          |
-| 7.4  | **LGL-02** Cookie consent banner            | MUST     | 1.5d  | 7.3        | CU `86c8cjgm3`                                           |
-| 7.5  | **A11Y-001** + **A11Y-002** Fixes           | MUST     | 1d    | Phase 0.7  | Execute findings                                         |
-| 7.6  | **SEO-01** Dynamic SEO titles               | SHOULD   | 1d    | —          | CU `86c9autmu` — high priority                           |
-| 7.7  | **OPS-01** Production deploy pipeline       | MUST     | 1.5d  | —          | CU `86c8cjgm0` — needed before v1 launch                 |
-| 7.8  | **TECH-01** `string \| LocalizedField` util | SHOULD   | 0.5d  | —          | CU `86c9uq9rf`                                           |
-| 7.9  | **TECH-02** Modernize `libs/shared/*` libs  | SHOULD   | 1d    | —          | Cherry-pick from Jules PRs #1078 + #1073. CU `86c9y6upw` |
-| 7.10 | **BOT-16** Cart sidenav menu                | SHOULD   | 1d    | —          | CU `86c8cjgj2`                                           |
-| 7.11 | **UI-03** Per-tenant color theme            | COULD    | 1d    | —          | If time                                                  |
+| #    | Task                                          | Priority | Est   | Depends on | Notes                                                                                                                                                                                                   |
+| ---- | --------------------------------------------- | -------- | ----- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 7.1  | **UI-04** Footer view                         | MUST     | 1d    | —          | CU `86c8cjgg9`                                                                                                                                                                                          |
+| 7.2  | **LGL-01** Legal pages                        | MUST     | 2d    | —          | Static content + footer links + i18n. CU `86c8cjgm2`                                                                                                                                                    |
+| 7.3  | **Q-10** Resolve cookie consent strategy      | —        | 0.25d | —          | CMP vs in-house                                                                                                                                                                                         |
+| 7.4  | **LGL-02** Cookie consent banner              | MUST     | 1.5d  | 7.3        | CU `86c8cjgm3`                                                                                                                                                                                          |
+| 7.5  | **A11Y-001** + **A11Y-002** Fixes             | MUST     | 1d    | Phase 0.7  | Execute findings                                                                                                                                                                                        |
+| 7.6  | **SEO-01** Dynamic SEO titles                 | SHOULD   | 1d    | —          | CU `86c9autmu` — high priority                                                                                                                                                                          |
+| 7.7  | **OPS-01** Production deploy pipeline         | MUST     | 1.5d  | —          | CU `86c8cjgm0` — needed before v1 launch                                                                                                                                                                |
+| 7.8  | **TECH-01** `string \| LocalizedField` util   | SHOULD   | 0.5d  | —          | CU `86c9uq9rf`                                                                                                                                                                                          |
+| 7.9  | **TECH-02** Modernize `libs/shared/*` libs ✅ | SHOULD   | 1d    | —          | Done 2026-05-29 — develop already modernized (May-1); residual cleanup (`#` methods + dead `matFormField` query) landed. Jules PRs #1073/#1078/#1087 closed (all targeted stale `main`). CU `86c9y6upw` |
+| 7.10 | **BOT-16** Cart sidenav menu                  | SHOULD   | 1d    | —          | CU `86c8cjgj2`                                                                                                                                                                                          |
+| 7.11 | **UI-03** Per-tenant color theme              | COULD    | 1d    | —          | If time                                                                                                                                                                                                 |
 
 **Exit criteria:** Legally compliant (banner + pages), Pa11y CI passes, prod deploy works, footer present.
 

--- a/apps/eco-store/TASKS.md
+++ b/apps/eco-store/TASKS.md
@@ -395,10 +395,10 @@ All `COULD`, pending discovery.
 
 ### Tech debt
 
-| ID                  | Description                                                               | Priority | ClickUp     |
-| ------------------- | ------------------------------------------------------------------------- | -------- | ----------- |
-| **TECH-01** _(new)_ | Shared util to get string from `string \| LocalizedField`                 | SHOULD   | `86c9uq9rf` |
-| **TECH-02** _(new)_ | Modernize `libs/shared/*` to Angular 21 standards (cherry-pick Jules PRs) | SHOULD   | `86c9y6upw` |
+| ID                  | Description                                                                           | Priority | ClickUp     |
+| ------------------- | ------------------------------------------------------------------------------------- | -------- | ----------- |
+| **TECH-01** _(new)_ | Shared util to get string from `string \| LocalizedField`                             | SHOULD   | `86c9uq9rf` |
+| **TECH-02** ✅      | Modernize `libs/shared/*` to Angular 21 (already on develop; residual cleanup landed) | SHOULD   | `86c9y6upw` |
 
 ### Ops / Release
 

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
@@ -12,14 +12,12 @@ import {
   Component,
   computed,
   effect,
-  ElementRef,
   inject,
   input,
   output,
   signal,
   TemplateRef,
   viewChild,
-  ViewChildren,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
@@ -176,7 +174,6 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
 
   protected readonly matSort = viewChild<MatSort | null>(MatSort);
   protected readonly matPaginator = viewChild<MatPaginator | null>(MatPaginator);
-  @ViewChildren('matFormField', { emitDistinctChangesOnly: true }) matFormField?: ElementRef[];
 
   protected dataSource = new MatTableDataSource<T>();
   protected columnsToDisplay = computed(() => {

--- a/libs/shared/table/ui/src/lib/utils/table-cell-title.directive.ts
+++ b/libs/shared/table/ui/src/lib/utils/table-cell-title.directive.ts
@@ -12,17 +12,15 @@ export class TableCellTitleDirective implements AfterViewInit {
     if (this.#elementRefElement.children.length > 0 && this.plastikTableCellTitle) {
       const childElement = this.#elementRefElement.children[0];
 
-      this.getTextContent(childElement);
-
-      const titleText = this.getTextContent(childElement);
+      const titleText = this.#getTextContent(childElement);
       this.#elementRefElement.setAttribute('title', titleText.trim());
       this.#elementRefElement.setAttribute('aria-label', titleText.trim());
 
-      this.addTitleToLiElements(childElement);
+      this.#addTitleToLiElements(childElement);
     }
   }
 
-  private getTextContent(node: Node): string {
+  #getTextContent(node: Node): string {
     let textContent = '';
 
     if (node.nodeType === Node.TEXT_NODE) {
@@ -36,7 +34,7 @@ export class TableCellTitleDirective implements AfterViewInit {
 
       if (!(node as HTMLElement).classList.contains('material-icons')) {
         Array.from(node.childNodes).forEach(childNode => {
-          textContent += this.getTextContent(childNode);
+          textContent += this.#getTextContent(childNode);
         });
       }
     }
@@ -44,19 +42,19 @@ export class TableCellTitleDirective implements AfterViewInit {
     return textContent;
   }
 
-  private addTitleToLiElements(node: Node): void {
+  #addTitleToLiElements(node: Node): void {
     if (node.nodeType === Node.ELEMENT_NODE) {
       const element = node as HTMLElement;
       if (element.tagName.toLowerCase() === 'ul') {
         const liElements = element.getElementsByTagName('li');
         for (let i = 0; i < liElements.length; i++) {
-          const liTextContent = this.getTextContent(liElements[i]);
+          const liTextContent = this.#getTextContent(liElements[i]);
           liElements[i].setAttribute('title', liTextContent);
           liElements[i].setAttribute('aria-label', liTextContent);
         }
       }
       Array.from(node.childNodes).forEach(childNode => {
-        this.addTitleToLiElements(childNode);
+        this.#addTitleToLiElements(childNode);
       });
     }
   }


### PR DESCRIPTION
## TECH-02 — `libs/shared/*` Angular-21 modernization (residue + root-cause)

### TL;DR
The bulk of this modernization **already landed on `develop`** (~May 1). This PR carries the only genuine residue, and documents the real cause of the recurring Jules PRs.

### What changed (code)
- **`TableCellTitleDirective`**: `private` methods → ES6 `#` private methods; dropped a redundant `getTextContent` call.
- **`SharedTableUiComponent`**: removed the dead `@ViewChildren('matFormField')` query (never read) and its now-unused `ElementRef` / `ViewChildren` imports.

Verified: `shared-table-ui` lint clean, 14/14 tests pass.

### What did NOT need doing (already on `develop`)
- Table: `viewChild` signals + effect-based matSort/matPaginator sync (the `@defer` timing bug is already fixed), `changeSorting: SortConfig`, `sortingDataAccessor`.
- Form: `input()`/`output()`, `linkedSignal`/`mutableModel` + `deepClone`, `validChange`.
- `FirebaseStorageService.reset()` on the error path; `DataFormatFactoryService` `#` fields.

So **TECH-03 (the proposed form/breaking migration) is not needed.**

### Root cause of the recurring Jules PRs
Every Jules modernization PR (#955, #1049, #1073, #1078, #1087) targets **`base=main`**. `main` is **llecoop's production branch** (`llecoop-deploy-prod.yml`), ~595 commits behind `develop` by design. Jules analyzes main's older code and re-proposes modernizations already merged on `develop`.

- **Fix (in jules.google.com):** start tasks against **`develop`**, not `main`. Do **not** delete/realign `main` — it's the prod branch.
- #1073 / #1078 / #1087 closed as superseded.

Tracked: TECH-02 ([#86c9y6upw](https://app.clickup.com/t/86c9y6upw)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
