### PR TITLE
chore(eco-store): #86c9uq8k3 META-02 remove NOT_REGISTERED from users.membershipStatus enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-30] - Eco-store: META-02 — Remove `NOT_REGISTERED` from `users.membershipStatus` enum
+
+### Changed
+
+- **`apps/eco-store/pocketbase/pb_schema.json`**: Removed the deprecated `NOT_REGISTERED` value from the `users.membershipStatus` select field, leaving the four canonical values (`TRIAL`, `ACTIVE`, `INACTIVE`, `SUSPENDED`) already declared by `PocketBaseMembershipStatus` (`libs/core/entities`) and documented in `apps/eco-store/CLAUDE.md`. Verified 0 staging users held the value before removal — PocketBase does not auto-clean orphaned select values, so a populated value would have failed validation on the next write. Applied on the local PocketBase instance and re-exported; staging picks up the schema on merge to `develop` via `.github/workflows/pocketbase-schema.yml` (META-02, [#86c9uq8k3](https://app.clickup.com/t/86c9uq8k3)).
+
 ## [2026-05-29] - Shared: TECH-02 — libs/shared Angular-21 modernization residue
 
 ### Changed

--- a/apps/eco-store/BACKLOG.md
+++ b/apps/eco-store/BACKLOG.md
@@ -5,7 +5,7 @@
 >
 > Companion to `TASKS.md` and PRD v1.8.
 
-**Document version:** 0.5 · **Last updated:** 2026-05-23
+**Document version:** 0.6 · **Last updated:** 2026-05-30
 
 ---
 
@@ -31,7 +31,7 @@
 | 0.0 | **OPS-02** Claude review workflow `pull-requests: write` ✅         | **Urgent** | 0.1d  | —          | Done 2026-05-23 — `permissions.pull-requests` raised `read` → `write` (also `issues`). CU `86c9y6xyb`                                                  |
 | 0.1 | **BUG-005** Profile routes auth guard ✅                            | **Urgent** | 0.5d  | —          | Done 2026-05-23 (PR #1080) — shared `ecoStoreAuthGuard` on `/perfil` (also `/comandes`); redirect to `/accedir`, preserves `returnUrl`. CU `86c9uq8jq` |
 | 0.2 | **META-01** Delete obsolete PRD ✅                                  | MUST       | 0.25d | —          | Done 2026-05-23 — `eco-store-req.md` removed; stale refs in cspell/markdownlint/CLAUDE.md/TASKS.md cleaned up                                          |
-| 0.3 | **META-02** Remove `NOT_REGISTERED` enum                            | MUST       | 0.25d | —          | Admin UI → export → commit `pb_schema.json`                                                                                                            |
+| 0.3 | **META-02** Remove `NOT_REGISTERED` enum ✅                         | MUST       | 0.25d | —          | Done 2026-05-30 — removed on local PB; `pb_schema.json` now 4 values; verified 0 staging records held it; staging syncs on merge. CU `86c9uq8k3`       |
 | 0.4 | **BUG-001** Verify cart merge                                       | MUST       | 0.5d  | —          | 5 manual test cases from TASKS.md                                                                                                                      |
 | 0.5 | **BUG-002** Deep-link `/cistella/resum` redirect ✅                 | MUST       | 0.5d  | —          | Done 2026-05-29 — empty-cart guard no-ops during SSR (`isPlatformBrowser`); deep-links keep items. CU `86c9uq8kb`                                      |
 | 0.6 | **BUG-003** PWA manifest tenant name                                | MUST       | 0.5d  | —          | `PwaManifestService.applyBranding()`. CU `86c9dn9m0`                                                                                                   |
@@ -315,6 +315,7 @@
 
 | Version | Date       | Notes                                                                                                                                                                                                                                                              |
 | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 0.6     | 2026-05-30 | **META-02 done** (task 0.3): removed `NOT_REGISTERED` from `users.membershipStatus` (4 values remain). Verified 0 staging records; local PB change → `pb_schema.json` → staging sync on merge. CU `86c9uq8k3`.                                                     |
 | 0.4     | 2026-05-23 | Added TECH-02 to Phase 7 as task 7.9 (`libs/shared/*` Angular 21 modernization derived from Jules PRs #1078 + #1073, 1d). Phase 7 grew 7 → 8 dev-days; subsequent rows renumbered. Fixed stale TECH-01 ClickUp ID (`86c8cjghn` → `86c9uq9rf`).                     |
 | 0.3     | 2026-05-17 | Added META-05 to Phase 0 as task 0.9 (`/sync-eco-store-tasks` read-only diff command, CU `86c9uwmzf`, 0.5d). Phase 0 grew 4 → 4.5 dev-days; cumulative totals updated.                                                                                             |
 | 0.2     | 2026-05-16 | Re-cut after ClickUp audit. Phase 1 expanded with PRV-02c/08/09/04d. New Phase 11 for EST-06. Added BUG-002..005 to Phase 0. SEO-01, OPS-01, UI-04, BOT-16, TECH-01 added to Phase 7. ClickUp IDs cross-referenced throughout. Total grew from ~55 → ~66 dev-days. |

--- a/apps/eco-store/TASKS.md
+++ b/apps/eco-store/TASKS.md
@@ -10,7 +10,7 @@
 > - **`apps/eco-store/POCKETBASE.md`** — backend workflow & scripts
 > - **`apps/eco-store/CLAUDE.md`** — app-specific guidance for AI agents
 
-**Document version:** 0.7 · **Last updated:** 2026-05-23
+**Document version:** 0.8 · **Last updated:** 2026-05-30
 
 ---
 
@@ -46,7 +46,6 @@
 
 | Task        | Module | Priority | Status | One-line summary                                                       |
 | ----------- | ------ | -------- | ------ | ---------------------------------------------------------------------- |
-| **META-02** | META   | MUST     | 📋     | Remove `NOT_REGISTERED` from `users.membershipStatus` enum             |
 | **BUG-001** | BOT-05 | MUST     | ❓     | Verify cart merge regression — code complete, needs manual test pass   |
 | **BUG-003** | BOT    | MUST     | 📋     | PWA manifest doesn't use tenant name as default app name               |
 | **PRV-02b** | PRV    | MUST     | 🔄     | Email change with async verification (CU `86c92g6ek`)                  |
@@ -70,25 +69,24 @@ Workflow: edit in Admin UI → `yarn eco-store:pb:export` → `yarn eco-store:pb
 
 ### Required for queued work
 
-| Collection       | Field / Change          | Type                      | For task         | Notes                                                                                      |
-| ---------------- | ----------------------- | ------------------------- | ---------------- | ------------------------------------------------------------------------------------------ |
-| `users`          | `membershipStatus` enum | Modify                    | META-02          | **Remove** `NOT_REGISTERED` — leave 4 valid values                                         |
-| `users`          | `notificationPrefs`     | JSON                      | PRV-09           | 6 boolean toggles (offers, restock, order status, cycle open/close, announcements, social) |
-| `user_addresses` | `addressType`           | Select                    | PRV-04d          | `SHIPPING` \| `BILLING` \| `BOTH` (default `SHIPPING`)                                     |
-| `user_addresses` | `nif`                   | Text (nullable)           | PRV-04d          | Required server-side when `addressType` ∈ {`BILLING`, `BOTH`}                              |
-| `user_addresses` | `defaultShipping`       | Bool                      | PRV-04d          | Rename or alias from existing `default`                                                    |
-| `user_addresses` | `defaultBilling`        | Bool                      | PRV-04d          | New; at most one per user                                                                  |
-| `tenants`        | `heroTitle`             | String (i18n JSON)        | INI-01           |                                                                                            |
-| `tenants`        | `heroSubtitle`          | String (i18n JSON)        | INI-01           |                                                                                            |
-| `tenants`        | `heroImagePreset`       | Select                    | INI-01           | `hort` \| `cistella` \| `mercat` \| `default`                                              |
-| `tenants`        | `heroImageCustom`       | File (Image)              | INI-01           | Optional, overrides preset                                                                 |
-| `tenants`        | `aboutUsText`           | String (HTML, i18n JSON)  | INI-06           |                                                                                            |
-| `tenants`        | `howItWorksSteps`       | JSON (nullable)           | INI-03           | If null, derive from `logisticsConfig`                                                     |
-| `products`       | `isFeatured`            | Boolean (default `false`) | INI-04 / MKT-03  |                                                                                            |
-| _new collection_ | `wishlists`             | —                         | BOT-07 / BOT-13b | Per-user, per-tenant. Schema TBD (Q-14)                                                    |
-| _new collection_ | `stock_alerts`          | —                         | BOT-13a / NOT-03 | Email + product subscription                                                               |
-| _new collection_ | `reviews`               | —                         | VAL-01           | Q-13 pending (collection vs JSON-on-products)                                              |
-| _new collection_ | `promo_codes`           | —                         | MKT-02           | Tenant-scoped                                                                              |
+| Collection       | Field / Change      | Type                      | For task         | Notes                                                                                      |
+| ---------------- | ------------------- | ------------------------- | ---------------- | ------------------------------------------------------------------------------------------ |
+| `users`          | `notificationPrefs` | JSON                      | PRV-09           | 6 boolean toggles (offers, restock, order status, cycle open/close, announcements, social) |
+| `user_addresses` | `addressType`       | Select                    | PRV-04d          | `SHIPPING` \| `BILLING` \| `BOTH` (default `SHIPPING`)                                     |
+| `user_addresses` | `nif`               | Text (nullable)           | PRV-04d          | Required server-side when `addressType` ∈ {`BILLING`, `BOTH`}                              |
+| `user_addresses` | `defaultShipping`   | Bool                      | PRV-04d          | Rename or alias from existing `default`                                                    |
+| `user_addresses` | `defaultBilling`    | Bool                      | PRV-04d          | New; at most one per user                                                                  |
+| `tenants`        | `heroTitle`         | String (i18n JSON)        | INI-01           |                                                                                            |
+| `tenants`        | `heroSubtitle`      | String (i18n JSON)        | INI-01           |                                                                                            |
+| `tenants`        | `heroImagePreset`   | Select                    | INI-01           | `hort` \| `cistella` \| `mercat` \| `default`                                              |
+| `tenants`        | `heroImageCustom`   | File (Image)              | INI-01           | Optional, overrides preset                                                                 |
+| `tenants`        | `aboutUsText`       | String (HTML, i18n JSON)  | INI-06           |                                                                                            |
+| `tenants`        | `howItWorksSteps`   | JSON (nullable)           | INI-03           | If null, derive from `logisticsConfig`                                                     |
+| `products`       | `isFeatured`        | Boolean (default `false`) | INI-04 / MKT-03  |                                                                                            |
+| _new collection_ | `wishlists`         | —                         | BOT-07 / BOT-13b | Per-user, per-tenant. Schema TBD (Q-14)                                                    |
+| _new collection_ | `stock_alerts`      | —                         | BOT-13a / NOT-03 | Email + product subscription                                                               |
+| _new collection_ | `reviews`           | —                         | VAL-01           | Q-13 pending (collection vs JSON-on-products)                                              |
+| _new collection_ | `promo_codes`       | —                         | MKT-02           | Tenant-scoped                                                                              |
 
 ### Already in schema
 
@@ -447,11 +445,9 @@ All `COULD`, pending discovery.
 
 `apps/eco-store/eco-store-req.md` (v1.7 PRD) removed via `git rm`. Authoritative spec is now the external v1.8 PDF only (see CLAUDE.md source-of-truth table). Stale references in `cspell.json`, `.markdownlint-cli2.yaml`, `apps/eco-store/CLAUDE.md`, and `BACKLOG.md` cleaned up.
 
-### META-02 — Remove `NOT_REGISTERED` enum value
+### META-02 — Remove `NOT_REGISTERED` enum value ✅ Done (2026-05-30)
 
-1. Admin UI → edit `users.membershipStatus` → remove `NOT_REGISTERED`
-2. Verify no records have that value first (migrate to `TRIAL` if any)
-3. `yarn eco-store:pb:export` + commit
+`users.membershipStatus` now has 4 values (`TRIAL`, `ACTIVE`, `INACTIVE`, `SUSPENDED`), matching `PocketBaseMembershipStatus` and CLAUDE.md. Verified 0 staging users held `NOT_REGISTERED` before removal. Applied on the local PB instance; `pb_schema.json` syncs to staging via `pocketbase-schema.yml` on merge to `develop`. CU `86c9uq8k3`.
 
 ### META-03 — Coverage badge fix
 
@@ -473,6 +469,7 @@ ClickUp `86c9uwmzf`. Internal tooling — first slice of a multi-phase workflow 
 
 | Version | Date       | Notes                                                                                                                                                                                                                                                                                                                                     |
 | ------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.8     | 2026-05-30 | **META-02 done** — removed `NOT_REGISTERED` from `users.membershipStatus` (now 4 values). Verified 0 staging records held it; applied on local PB, `pb_schema.json` syncs to staging via `pocketbase-schema.yml` on merge. CU `86c9uq8k3`.                                                                                                |
 | 0.7     | 2026-05-23 | Added **OPS-02** (Urgent, CU `86c9y6xyb`): grant `pull-requests: write` to `.github/workflows/claude-code-review.yml`. Backlog-grooming pass alongside: flipped **TRL-06** and **META-05** to ✅ (ClickUp was source of truth — `/sync-eco-store-tasks` flagged them as status mismatches).                                               |
 | 0.6     | 2026-05-23 | Added TECH-02 (modernize `libs/shared/*` to Angular 21 standards, derived from Jules PRs #1078 + #1073). Fixed stale TECH-01 ClickUp ID (`86c8cjghn` → `86c9uq9rf`).                                                                                                                                                                      |
 | 0.5     | 2026-05-17 | Added META-05 (Phase 1 of ClickUp ↔ TASKS.md automation: read-only `/sync-eco-store-tasks` diff command). CU `86c9uwmzf`.                                                                                                                                                                                                                 |

--- a/apps/eco-store/pocketbase/pb_schema.json
+++ b/apps/eco-store/pocketbase/pb_schema.json
@@ -751,8 +751,7 @@
           "TRIAL",
           "ACTIVE",
           "INACTIVE",
-          "SUSPENDED",
-          "NOT_REGISTERED"
+          "SUSPENDED"
         ]
       },
       {


### PR DESCRIPTION
## META-02 — Remove `NOT_REGISTERED` from `users.membershipStatus` enum

Drops the deprecated `NOT_REGISTERED` value from the `users.membershipStatus` PocketBase select field, leaving the four canonical values (`TRIAL`, `ACTIVE`, `INACTIVE`, `SUSPENDED`) already declared by `PocketBaseMembershipStatus` (`libs/core/entities`) and documented in `apps/eco-store/CLAUDE.md`.

### Why
The value was dead — never present in the TS type, never set anywhere in code. It only lingered in the PocketBase schema.

### Safety
- Verified **0 of 4 staging users** held `NOT_REGISTERED` before removal (PocketBase does not auto-clean orphaned select values, so a populated value would fail validation on the next write).
- Change applied on the local PocketBase instance and re-exported (the pre-commit hook re-exports `pb_schema.json` from the live instance).

### Deployment
On merge to `develop`, `.github/workflows/pocketbase-schema.yml` syncs `pb_schema.json` to staging (PocketHost).

### Commits
- `chore` — `pb_schema.json` + `CHANGELOG.md`
- `docs` — `TASKS.md` + `BACKLOG.md` status flip (Phase 0 task 0.3 → ✅)

Closes ClickUp [#86c9uq8k3](https://app.clickup.com/t/86c9uq8k3).