### PR TITLE
🎨 Palette: Add matTooltip to shared button components

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,4 @@
 ## 2026-05-31 - [Standardizing tooltips for icon-only buttons]
+
 **Learning:** In this design system, interactive icon-only elements often have an `aria-label` for screen readers but lack a `matTooltip` for visual discovery. Users benefit from having both to ensure the interface is accessible and intuitive for all.
 **Action:** Always pair `aria-label` with `matTooltip` in shared button components to ensure consistent accessibility and UX patterns across the application.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-31 - [Standardizing tooltips for icon-only buttons]
+**Learning:** In this design system, interactive icon-only elements often have an `aria-label` for screen readers but lack a `matTooltip` for visual discovery. Users benefit from having both to ensure the interface is accessible and intuitive for all.
+**Action:** Always pair `aria-label` with `matTooltip` in shared button components to ensure consistent accessibility and UX patterns across the application.

--- a/libs/eco-store/shared/favorite-button/src/lib/eco-store-shared-favorite-button/eco-store-shared-favorite-button.component.html
+++ b/libs/eco-store/shared/favorite-button/src/lib/eco-store-shared-favorite-button/eco-store-shared-favorite-button.component.html
@@ -5,6 +5,7 @@
   [class.is-favorite]="isFavorite()"
   [class.heart-beat]="isAnimating()"
   [attr.aria-label]="ariaLabel()"
+  [matTooltip]="ariaLabel()"
   (click)="onToggle($event)">
   <mat-icon>
     {{ isFavorite() ? 'favorite' : 'favorite_border' }}

--- a/libs/eco-store/shared/favorite-button/src/lib/eco-store-shared-favorite-button/eco-store-shared-favorite-button.component.ts
+++ b/libs/eco-store/shared/favorite-button/src/lib/eco-store-shared-favorite-button/eco-store-shared-favorite-button.component.ts
@@ -1,13 +1,14 @@
 import { ChangeDetectionStrategy, Component, input, output, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 export type FavoriteButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 export type FavoriteButtonAppearance = 'glass' | 'none';
 
 @Component({
   selector: 'eco-store-shared-favorite-button',
-  imports: [MatButtonModule, MatIconModule],
+  imports: [MatButtonModule, MatIconModule, MatTooltipModule],
   templateUrl: './eco-store-shared-favorite-button.component.html',
   styleUrl: './eco-store-shared-favorite-button.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
@@ -4,6 +4,7 @@
     [class]="`button--rounded ${buttonConfig().classes || ''}`"
     [disabled]="buttonConfig().disabled"
     [attr.aria-label]="buttonConfig().ariaLabel"
+    [matTooltip]="buttonConfig().ariaLabel"
     [attr.data-test]="buttonConfig().dataTestId"
     (click)="onClick()">
     <ng-container *ngTemplateOutlet="content"></ng-container>
@@ -15,6 +16,7 @@
     class="block"
     target="_blank"
     [attr.aria-label]="buttonConfig().ariaLabel"
+    [matTooltip]="buttonConfig().ariaLabel"
     [href]="linkHref()"
     [attr.data-test]="buttonConfig().dataTestId">
     <ng-container *ngTemplateOutlet="content">button content</ng-container>

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.ts
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.ts
@@ -1,6 +1,7 @@
 import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { PushPipe } from '@ngrx/component';
 import { Action } from '@ngrx/store';
 import { ButtonConfig, ButtonConfigWithAction, buttonHasALinkGuard } from '@plastik/shared/button';
@@ -13,6 +14,7 @@ import { AngularSvgIconModule } from 'angular-svg-icon';
     NgTemplateOutlet,
     PushPipe,
     MatButtonModule,
+    MatTooltipModule,
     AngularSvgIconModule,
     ReturnAsObservablePipe,
   ],


### PR DESCRIPTION
🎨 Palette: Add matTooltip to shared button components

💡 What: Added `matTooltip` to `EcoStoreSharedFavoriteButtonComponent` and `SharedButtonUiComponent`.
🎯 Why: Interactive icon-only buttons had `aria-label` for screen readers but lacked visual tooltips for sighted users.
♿ Accessibility: Improved visual discovery and ensured consistency between screen reader labels and visual tooltips.

Changes:
- `libs/eco-store/shared/favorite-button/src/lib/eco-store-shared-favorite-button/eco-store-shared-favorite-button.component.ts`: Added `MatTooltipModule`.
- `libs/eco-store/shared/favorite-button/src/lib/eco-store-shared-favorite-button/eco-store-shared-favorite-button.component.html`: Added `[matTooltip]="ariaLabel()"`.
- `libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.ts`: Added `MatTooltipModule`.
- `libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html`: Added `[matTooltip]="buttonConfig().ariaLabel"` to button and link.
- `.Jules/palette.md`: Recorded UX learning.

---
*PR created automatically by Jules for task [1596925683174884535](https://jules.google.com/task/1596925683174884535) started by @plastikaweb*