### PR TITLE
refactor(shared): modernize components and secure formatters for PR #1094

### DIFF
--- a/libs/shared/form/feature/src/lib/shared-form-feature.component.html
+++ b/libs/shared/form/feature/src/lib/shared-form-feature.component.html
@@ -19,7 +19,7 @@
       type="submit"
       class="w-full sm:w-auto"
       data-test="submit-button"
-      [ngClass]="config().buttonStyle || ''"
+      [class]="config().buttonStyle || ''"
       [disabled]="!form.valid">
       {{ config().label || 'Submit' }}
     </button>

--- a/libs/shared/form/feature/src/lib/shared-form-feature.component.ts
+++ b/libs/shared/form/feature/src/lib/shared-form-feature.component.ts
@@ -93,22 +93,33 @@ export class SharedFormFeatureComponent<T> implements AfterViewInit {
     );
   }
 
+  /**
+   * Handles the form submission.
+   * @param event - The form submission event.
+   */
   onSubmit(event: Event): void {
     event.preventDefault();
     event.stopPropagation();
-    this.emitChange();
+    this.#emitChange();
   }
 
+  /**
+   * Handles model changes from the formly form.
+   * @param model - The updated model.
+   */
   onModelChange(model: T): void {
     if (this.#submitted()) return;
 
     this.#newModel.set(model);
     this.pendingChangesEvent.emit(this.form.dirty);
-    if (!this.config().submitAvailable) this.emitChange();
+    if (!this.config().submitAvailable) this.#emitChange();
     if (this.config().emitOnChange) this.temporaryChangeEvent.emit(model);
   }
 
-  private emitChange(): void {
+  /**
+   * Emits the form changes if the form is valid.
+   */
+  #emitChange(): void {
     if (this.form.valid) {
       if (this.config().disableOnSubmit) {
         this.form.disable({ emitEvent: false });

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
@@ -280,6 +280,7 @@
             <button
               mat-icon-button
               aria-label="expand row"
+              matTooltip="Expand row"
               class="-left-sub"
               (click)="$event.stopPropagation(); updateExpandedElement(element)">
               @if (expandedElement()?.id === element.id) {

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
@@ -36,7 +36,6 @@ import { RouterLink } from '@angular/router';
 import { EntityId } from '@ngrx/signals/entities';
 import { BaseEntity } from '@plastik/core/entities';
 import {
-  DataFormatFactoryService,
   FormattingTypes,
   SafeFormattedPipe,
   SharedUtilFormattersModule,
@@ -96,9 +95,7 @@ import { OrderTableActionsElementsPipe } from '../utils/order-table-actions-elem
   styleUrl: './shared-table-ui.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unknown }>
-  implements OnInit
-{
+export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unknown }> {
   readonly #liveAnnouncer = inject(LiveAnnouncer);
 
   /**
@@ -236,6 +233,18 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
   protected expandedElement = signal<T | null>(null);
 
   constructor() {
+    this.dataSource.sortingDataAccessor = (data: T, sortHeaderId: string): string | number => {
+      const value = sortHeaderId.split('.').reduce((obj, key) => {
+        return obj && typeof obj === 'object' ? (obj as Record<string, unknown>)[key] : obj;
+      }, data as unknown) as unknown;
+
+      if (value === null || value === undefined) return '';
+      if (typeof value === 'number') return value;
+      if (typeof value === 'boolean') return value ? 1 : 0;
+      if (value instanceof Date) return value.getTime();
+      return String(value).toLowerCase();
+    };
+
     /**
      * Synchronize the data source with the data input signal.
      */
@@ -249,44 +258,38 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
       const predicate = this.filterPredicate();
 
       if (criteria && predicate) {
+        this.dataSource.filterPredicate = (data: T) => {
+          return predicate(data, criteria);
+        };
         // We set a non-empty string to trigger the filterPredicate
         this.dataSource.filter = JSON.stringify(criteria);
       } else {
         this.dataSource.filter = '';
       }
     });
-  }
 
-  /**
-   * Initializes the component.
-   */
-  ngOnInit(): void {
-    this.dataSource.sortingDataAccessor = (data: T, sortHeaderId: string): string | number => {
-      const value = sortHeaderId.split('.').reduce((obj, key) => {
-        return obj && typeof obj === 'object' ? (obj as Record<string, unknown>)[key] : obj;
-      }, data as unknown) as unknown;
-
-      if (value === null || value === undefined) return '';
-      if (typeof value === 'number') return value;
-      if (typeof value === 'boolean') return value ? 1 : 0;
-      if (value instanceof Date) return value.getTime();
-      return String(value).toLowerCase();
-    };
-
-    if (this.filterPredicate && this.filterCriteria) {
-      this.dataSource.filterPredicate = (data: T) => {
-        return this.filterPredicate()?.(data as T, this.filterCriteria()) || false;
-      };
-    }
-
-    if (this.sort()) {
+    /**
+     * Synchronize the data source sort with the sort input and matSort viewChild signals.
+     */
+    effect(() => {
       const matSortInstance = this.matSort();
-      if (matSortInstance) {
-        matSortInstance.active = this.sort()?.[0] || '';
-        matSortInstance.direction = this.sort()?.[1] || 'asc';
+      const sortConfig = this.sort();
+      if (matSortInstance && sortConfig) {
+        matSortInstance.active = sortConfig[0] || '';
+        matSortInstance.direction = sortConfig[1] || 'asc';
         this.dataSource.sort = matSortInstance;
       }
-    }
+    });
+
+    /**
+     * Synchronize the data source paginator with the matPaginator viewChild signal.
+     */
+    effect(() => {
+      const paginator = this.matPaginator();
+      if (paginator) {
+        this.dataSource.paginator = paginator;
+      }
+    });
   }
 
   /**

--- a/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
+++ b/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
@@ -10,6 +10,7 @@ import { inject, Injectable, LOCALE_ID } from '@angular/core';
 import { Timestamp } from '@angular/fire/firestore';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { BaseEntity } from '@plastik/core/entities';
+import { escapeHtml } from '@plastik/shared/objects';
 
 import {
   FormattingComponentOutput,
@@ -217,11 +218,7 @@ export class SharedUtilFormattersService {
         ...extras(item),
       };
     }
-    return `
-    ${format.prefix ? format.prefix : ''}
-    ${formatNumber(Number(value), format.locale, format.numberDigitsInfo)}
-    ${format.suffix ? format.suffix : ''}
-    `;
+    return `${format.prefix ? format.prefix : ''}${formatNumber(Number(value), format.locale, format.numberDigitsInfo)}${format.suffix ? format.suffix : ''}`;
   }
 
   /**
@@ -311,6 +308,6 @@ export class SharedUtilFormattersService {
    * @returns { SafeHtml } The value passed through the sanitizer.
    */
   defaultFormatter(value: string): SafeHtml {
-    return this.#sanitizer.bypassSecurityTrustHtml(value);
+    return this.#sanitizer.bypassSecurityTrustHtml(escapeHtml(value));
   }
 }

--- a/libs/shared/util/objects/src/util-objects.ts
+++ b/libs/shared/util/objects/src/util-objects.ts
@@ -221,3 +221,22 @@ export function transformToString(value: unknown): string {
 export function collectionToArray<T>(collection: Record<string, T>): T[] {
   return Object.keys(collection).map((key: string) => collection[key]);
 }
+
+/**
+ * Escapes HTML special characters in a string.
+ * @param value - The string to escape.
+ * @returns The escaped string.
+ */
+export function escapeHtml(value: string): string {
+  const entityMap: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+    '/': '&#x2F;',
+    '`': '&#x60;',
+    '=': '&#x3D;',
+  };
+  return value.replace(/[&<>"'\/`=]/g, s => entityMap[s]);
+}


### PR DESCRIPTION
This PR modernizes several shared components and utilities to align with Angular 21 standards and project-specific conventions.

Key changes:
1. **SharedTableUiComponent**:
   - Replaced `ngOnInit` with `effect()`-based synchronization for `MatTableDataSource` (sort, paginator, and filter). This is critical for components used within `@defer` blocks where view children might not be available during initial lifecycle hooks.
   - Removed unused `OnInit` implementation and `DataFormatFactoryService` import.
   - Added `matTooltip` to the expansion button for improved accessibility.

2. **SharedFormFeatureComponent**:
   - Renamed `emitChange` to the ES6 private field `#emitChange`.
   - Updated the template to use `[class]` instead of `ngClass`.
   - Added/refined JSDoc for better maintainability.

3. **Security & Utilities**:
   - Introduced `escapeHtml` utility in `shared-util-objects`.
   - Secured `SharedUtilFormattersService.defaultFormatter` by escaping input before using `bypassSecurityTrustHtml`.
   - Refactored `quantityFormatter` to avoid multiline template literal whitespace artifacts in the UI.

All changes were verified for syntax correctness using `node --experimental-strip-types --check` due to the restricted environment's lack of a full Nx/Vitest toolchain.

---
*PR created automatically by Jules for task [10486832162229909413](https://jules.google.com/task/10486832162229909413) started by @plastikaweb*