### PR TITLE
docs(eco-store): TECH-03 mark object-utils optimization done in TASKS/BACKLOG

### DIFF
--- a/apps/eco-store/BACKLOG.md
+++ b/apps/eco-store/BACKLOG.md
@@ -5,7 +5,7 @@
 >
 > Companion to `TASKS.md` and PRD v1.8.
 
-**Document version:** 0.6 · **Last updated:** 2026-05-30
+**Document version:** 0.7 · **Last updated:** 2026-05-31
 
 ---
 
@@ -173,21 +173,22 @@
 
 **Goal:** Ship-ready compliance + finally execute the a11y fixes from Phase 0 audit + production deploy.
 
-**Estimated effort:** ~8 dev-days
+**Estimated effort:** ~8.25 dev-days
 
-| #    | Task                                          | Priority | Est   | Depends on | Notes                                                                                                                                                                                                   |
-| ---- | --------------------------------------------- | -------- | ----- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 7.1  | **UI-04** Footer view                         | MUST     | 1d    | —          | CU `86c8cjgg9`                                                                                                                                                                                          |
-| 7.2  | **LGL-01** Legal pages                        | MUST     | 2d    | —          | Static content + footer links + i18n. CU `86c8cjgm2`                                                                                                                                                    |
-| 7.3  | **Q-10** Resolve cookie consent strategy      | —        | 0.25d | —          | CMP vs in-house                                                                                                                                                                                         |
-| 7.4  | **LGL-02** Cookie consent banner              | MUST     | 1.5d  | 7.3        | CU `86c8cjgm3`                                                                                                                                                                                          |
-| 7.5  | **A11Y-001** + **A11Y-002** Fixes             | MUST     | 1d    | Phase 0.7  | Execute findings                                                                                                                                                                                        |
-| 7.6  | **SEO-01** Dynamic SEO titles                 | SHOULD   | 1d    | —          | CU `86c9autmu` — high priority                                                                                                                                                                          |
-| 7.7  | **OPS-01** Production deploy pipeline         | MUST     | 1.5d  | —          | CU `86c8cjgm0` — needed before v1 launch                                                                                                                                                                |
-| 7.8  | **TECH-01** `string \| LocalizedField` util   | SHOULD   | 0.5d  | —          | CU `86c9uq9rf`                                                                                                                                                                                          |
-| 7.9  | **TECH-02** Modernize `libs/shared/*` libs ✅ | SHOULD   | 1d    | —          | Done 2026-05-29 — develop already modernized (May-1); residual cleanup (`#` methods + dead `matFormField` query) landed. Jules PRs #1073/#1078/#1087 closed (all targeted stale `main`). CU `86c9y6upw` |
-| 7.10 | **BOT-16** Cart sidenav menu                  | SHOULD   | 1d    | —          | CU `86c8cjgj2`                                                                                                                                                                                          |
-| 7.11 | **UI-03** Per-tenant color theme              | COULD    | 1d    | —          | If time                                                                                                                                                                                                 |
+| #    | Task                                               | Priority | Est   | Depends on | Notes                                                                                                                                                                                                   |
+| ---- | -------------------------------------------------- | -------- | ----- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 7.1  | **UI-04** Footer view                              | MUST     | 1d    | —          | CU `86c8cjgg9`                                                                                                                                                                                          |
+| 7.2  | **LGL-01** Legal pages                             | MUST     | 2d    | —          | Static content + footer links + i18n. CU `86c8cjgm2`                                                                                                                                                    |
+| 7.3  | **Q-10** Resolve cookie consent strategy           | —        | 0.25d | —          | CMP vs in-house                                                                                                                                                                                         |
+| 7.4  | **LGL-02** Cookie consent banner                   | MUST     | 1.5d  | 7.3        | CU `86c8cjgm3`                                                                                                                                                                                          |
+| 7.5  | **A11Y-001** + **A11Y-002** Fixes                  | MUST     | 1d    | Phase 0.7  | Execute findings                                                                                                                                                                                        |
+| 7.6  | **SEO-01** Dynamic SEO titles                      | SHOULD   | 1d    | —          | CU `86c9autmu` — high priority                                                                                                                                                                          |
+| 7.7  | **OPS-01** Production deploy pipeline              | MUST     | 1.5d  | —          | CU `86c8cjgm0` — needed before v1 launch                                                                                                                                                                |
+| 7.8  | **TECH-01** `string \| LocalizedField` util        | SHOULD   | 0.5d  | —          | CU `86c9uq9rf`                                                                                                                                                                                          |
+| 7.9  | **TECH-02** Modernize `libs/shared/*` libs ✅      | SHOULD   | 1d    | —          | Done 2026-05-29 — develop already modernized (May-1); residual cleanup (`#` methods + dead `matFormField` query) landed. Jules PRs #1073/#1078/#1087 closed (all targeted stale `main`). CU `86c9y6upw` |
+| 7.10 | **TECH-03** Optimize `libs/shared/util/objects` ✅ | SHOULD   | 0.25d | —          | Done 2026-05-31 — `isEmpty`/`formatURLQueryParams`/`collectionToArray` O(N) perf. Jules PR #1095 (superset of #1091, closed as subset). CU `86ca226tz`                                                  |
+| 7.11 | **BOT-16** Cart sidenav menu                       | SHOULD   | 1d    | —          | CU `86c8cjgj2`                                                                                                                                                                                          |
+| 7.12 | **UI-03** Per-tenant color theme                   | COULD    | 1d    | —          | If time                                                                                                                                                                                                 |
 
 **Exit criteria:** Legally compliant (banner + pages), Pa11y CI passes, prod deploy works, footer present.
 
@@ -315,6 +316,7 @@
 
 | Version | Date       | Notes                                                                                                                                                                                                                                                              |
 | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 0.7     | 2026-05-31 | Added **TECH-03** to Phase 7 as task 7.10 (`libs/shared/util/objects` O(N) perf, 0.25d, done); BOT-16/UI-03 renumbered 7.11/7.12; Phase 7 grew 8 → 8.25 dev-days. CU `86ca226tz`.                                                                                  |
 | 0.6     | 2026-05-30 | **META-02 done** (task 0.3): removed `NOT_REGISTERED` from `users.membershipStatus` (4 values remain). Verified 0 staging records; local PB change → `pb_schema.json` → staging sync on merge. CU `86c9uq8k3`.                                                     |
 | 0.4     | 2026-05-23 | Added TECH-02 to Phase 7 as task 7.9 (`libs/shared/*` Angular 21 modernization derived from Jules PRs #1078 + #1073, 1d). Phase 7 grew 7 → 8 dev-days; subsequent rows renumbered. Fixed stale TECH-01 ClickUp ID (`86c8cjghn` → `86c9uq9rf`).                     |
 | 0.3     | 2026-05-17 | Added META-05 to Phase 0 as task 0.9 (`/sync-eco-store-tasks` read-only diff command, CU `86c9uwmzf`, 0.5d). Phase 0 grew 4 → 4.5 dev-days; cumulative totals updated.                                                                                             |

--- a/apps/eco-store/TASKS.md
+++ b/apps/eco-store/TASKS.md
@@ -10,7 +10,7 @@
 > - **`apps/eco-store/POCKETBASE.md`** — backend workflow & scripts
 > - **`apps/eco-store/CLAUDE.md`** — app-specific guidance for AI agents
 
-**Document version:** 0.8 · **Last updated:** 2026-05-30
+**Document version:** 0.9 · **Last updated:** 2026-05-31
 
 ---
 
@@ -393,10 +393,11 @@ All `COULD`, pending discovery.
 
 ### Tech debt
 
-| ID                  | Description                                                                           | Priority | ClickUp     |
-| ------------------- | ------------------------------------------------------------------------------------- | -------- | ----------- |
-| **TECH-01** _(new)_ | Shared util to get string from `string \| LocalizedField`                             | SHOULD   | `86c9uq9rf` |
-| **TECH-02** ✅      | Modernize `libs/shared/*` to Angular 21 (already on develop; residual cleanup landed) | SHOULD   | `86c9y6upw` |
+| ID                  | Description                                                                                                       | Priority | ClickUp     |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| **TECH-01** _(new)_ | Shared util to get string from `string \| LocalizedField`                                                         | SHOULD   | `86c9uq9rf` |
+| **TECH-02** ✅      | Modernize `libs/shared/*` to Angular 21 (already on develop; residual cleanup landed)                             | SHOULD   | `86c9y6upw` |
+| **TECH-03** ✅      | Optimize `libs/shared/util/objects` (O(N²)→O(N) `reduce`, drop O(N) alloc in `isEmpty`, native `Object.values()`) | SHOULD   | `86ca226tz` |
 
 ### Ops / Release
 
@@ -469,6 +470,7 @@ ClickUp `86c9uwmzf`. Internal tooling — first slice of a multi-phase workflow 
 
 | Version | Date       | Notes                                                                                                                                                                                                                                                                                                                                     |
 | ------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.9     | 2026-05-31 | **TECH-03 done** — optimized `libs/shared/util/objects` (`isEmpty`, `formatURLQueryParams`, `collectionToArray`) for O(N) perf. Cherry-picked from Jules PR #1095 (superset of #1091, closed as subset). On develop. CU `86ca226tz`.                                                                                                      |
 | 0.8     | 2026-05-30 | **META-02 done** — removed `NOT_REGISTERED` from `users.membershipStatus` (now 4 values). Verified 0 staging records held it; applied on local PB, `pb_schema.json` syncs to staging via `pocketbase-schema.yml` on merge. CU `86c9uq8k3`.                                                                                                |
 | 0.7     | 2026-05-23 | Added **OPS-02** (Urgent, CU `86c9y6xyb`): grant `pull-requests: write` to `.github/workflows/claude-code-review.yml`. Backlog-grooming pass alongside: flipped **TRL-06** and **META-05** to ✅ (ClickUp was source of truth — `/sync-eco-store-tasks` flagged them as status mismatches).                                               |
 | 0.6     | 2026-05-23 | Added TECH-02 (modernize `libs/shared/*` to Angular 21 standards, derived from Jules PRs #1078 + #1073). Fixed stale TECH-01 ClickUp ID (`86c8cjghn` → `86c9uq9rf`).                                                                                                                                                                      |


### PR DESCRIPTION
Backlog grooming for **TECH-03** ([#86ca226tz](https://app.clickup.com/t/86ca226tz)). The `libs/shared/util/objects` O(N) perf work shipped via #1095 (now on `develop`; #1091 closed as a subset).

- TASKS.md: added TECH-03 ✅ to the tech-debt table; version → 0.9.
- BACKLOG.md: added TECH-03 as Phase 7 task 7.10 (BOT-16/UI-03 renumbered 7.11/7.12; effort 8 → 8.25 dev-days); version → 0.7.

No CHANGELOG entry (backlog-only; the work's CHANGELOG bullet landed with #1095).

🤖 Generated with [Claude Code](https://claude.com/claude-code)