### PR TITLE
🎨 Palette: Improve password visibility toggle accessibility and UX

### DIFF
--- a/apps/eco-store/public/i18n/ca.json
+++ b/apps/eco-store/public/i18n/ca.json
@@ -63,7 +63,10 @@
         "invalid-username": "Format de nom d'usuari no vàlid",
         "zip": "Format de codi no vàlid"
       },
-      "charactersCount": "{count, plural, one {caràcter} other {caràcters}}"
+      "charactersCount": "{count, plural, one {caràcter} other {caràcters}}",
+      "password": "Contrasenya",
+      "showPassword": "Mostrar contrasenya",
+      "hidePassword": "Amagar contrasenya"
     },
     "a11y": {
       "skipToContent": "Saltar al contingut principal",

--- a/apps/eco-store/public/i18n/en.json
+++ b/apps/eco-store/public/i18n/en.json
@@ -63,7 +63,10 @@
         "invalid-username": "Invalid username",
         "zip": "Invalid zip code format"
       },
-      "charactersCount": "{count, plural, one {character} other {characters}}"
+      "charactersCount": "{count, plural, one {character} other {characters}}",
+      "password": "Password",
+      "showPassword": "Show password",
+      "hidePassword": "Hide password"
     },
     "a11y": {
       "skipToContent": "Skip to main content",

--- a/apps/eco-store/public/i18n/es.json
+++ b/apps/eco-store/public/i18n/es.json
@@ -63,7 +63,10 @@
         "invalid-username": "Nombre de usuario inválido",
         "zip": "Formato de código postal no válido"
       },
-      "charactersCount": "{count, plural, one {carácter} other {caracteres}}"
+      "charactersCount": "{count, plural, one {carácter} other {caracteres}}",
+      "password": "Contraseña",
+      "showPassword": "Mostrar contraseña",
+      "hidePassword": "Ocultar contraseña"
     },
     "a11y": {
       "skipToContent": "Saltar al contenido principal",

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
@@ -1,4 +1,6 @@
-<label class="sr-only" [for]="`password-${field.id}`">{{ 'form.password' | translate }}</label>
+<label class="sr-only" [for]="`password-${field.id}`">{{
+  'common.form.password' | translate
+}}</label>
 <input
   matInput
   [id]="`password-${field.id}`"
@@ -14,8 +16,13 @@
   matSuffix
   tabindex="-1"
   type="button"
-  [attr.aria-label]="!hiddenPass() ? 'form.hide-password' : ('form.show-password' | translate)"
-  [attr.aria-pressed]="hiddenPass()"
+  [attr.aria-label]="
+    (!hiddenPass() ? 'common.form.hidePassword' : 'common.form.showPassword') | translate
+  "
+  [matTooltip]="
+    (!hiddenPass() ? 'common.form.hidePassword' : 'common.form.showPassword') | translate
+  "
+  [attr.aria-pressed]="!hiddenPass()"
   (click)="hidePassword($event)">
   <mat-icon>{{ hiddenPass() ? 'visibility_off' : 'visibility' }}</mat-icon>
 </button>

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.ts
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.ts
@@ -3,6 +3,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { FieldTypeConfig, FormlyModule } from '@ngx-formly/core';
 import { FieldType } from '@ngx-formly/material/form-field';
 import { TranslateModule } from '@ngx-translate/core';
@@ -13,6 +14,7 @@ import { TranslateModule } from '@ngx-translate/core';
     MatButtonModule,
     MatIconModule,
     MatInputModule,
+    MatTooltipModule,
     FormlyModule,
     ReactiveFormsModule,
     TranslateModule,


### PR DESCRIPTION
This PR improves the micro-UX and accessibility of the password visibility toggle in the `InputPasswordWithVisibilityTypeComponent`.

### 💡 What
- Added `password`, `showPassword`, and `hidePassword` translation keys to the `common.form` section in Catalan, English, and Spanish.
- Updated the component to use these keys for the field label and toggle button.
- Added a `matTooltip` to the toggle button to improve visual discovery for mouse users.
- Fixed a bug where the `aria-label` for "hide password" was not being translated.
- Corrected the `aria-pressed` attribute logic to properly reflect the visibility state.

### 🎯 Why
The previous implementation had broken translation logic for the ARIA label and lacked a tooltip, which is against our project's UX standards for icon-only buttons. Screen reader users were getting untranslated labels, and keyboard/mouse users lacked visual hints.

### ♿ Accessibility
- Fixed broken ARIA label translation.
- Added descriptive tooltip.
- Aligned `aria-pressed` with the visual state.


---
*PR created automatically by Jules for task [17235915685502576527](https://jules.google.com/task/17235915685502576527) started by @plastikaweb*