### PR TITLE
🎨 Palette: improve password visibility toggle accessibility and UX

### DIFF
--- a/apps/eco-store/public/i18n/ca.json
+++ b/apps/eco-store/public/i18n/ca.json
@@ -63,7 +63,10 @@
         "invalid-username": "Format de nom d'usuari no vàlid",
         "zip": "Format de codi no vàlid"
       },
-      "charactersCount": "{count, plural, one {caràcter} other {caràcters}}"
+      "charactersCount": "{count, plural, one {caràcter} other {caràcters}}",
+      "password": "Contrasenya",
+      "showPassword": "Mostrar contrasenya",
+      "hidePassword": "Amagar contrasenya"
     },
     "a11y": {
       "skipToContent": "Saltar al contingut principal",

--- a/apps/eco-store/public/i18n/en.json
+++ b/apps/eco-store/public/i18n/en.json
@@ -63,7 +63,10 @@
         "invalid-username": "Invalid username",
         "zip": "Invalid zip code format"
       },
-      "charactersCount": "{count, plural, one {character} other {characters}}"
+      "charactersCount": "{count, plural, one {character} other {characters}}",
+      "password": "Password",
+      "showPassword": "Show password",
+      "hidePassword": "Hide password"
     },
     "a11y": {
       "skipToContent": "Skip to main content",

--- a/apps/eco-store/public/i18n/es.json
+++ b/apps/eco-store/public/i18n/es.json
@@ -63,7 +63,10 @@
         "invalid-username": "Nombre de usuario inválido",
         "zip": "Formato de código postal no válido"
       },
-      "charactersCount": "{count, plural, one {carácter} other {caracteres}}"
+      "charactersCount": "{count, plural, one {carácter} other {caracteres}}",
+      "password": "Contraseña",
+      "showPassword": "Mostrar contraseña",
+      "hidePassword": "Ocultar contraseña"
     },
     "a11y": {
       "skipToContent": "Saltar al contenido principal",

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
@@ -1,4 +1,6 @@
-<label class="sr-only" [for]="`password-${field.id}`">{{ 'form.password' | translate }}</label>
+<label class="sr-only" [for]="`password-${field.id}`">{{
+  'common.form.password' | translate
+}}</label>
 <input
   matInput
   [id]="`password-${field.id}`"
@@ -14,8 +16,13 @@
   matSuffix
   tabindex="-1"
   type="button"
-  [attr.aria-label]="!hiddenPass() ? 'form.hide-password' : ('form.show-password' | translate)"
-  [attr.aria-pressed]="hiddenPass()"
+  [attr.aria-label]="
+    (hiddenPass() ? 'common.form.showPassword' : 'common.form.hidePassword') | translate
+  "
+  [matTooltip]="
+    (hiddenPass() ? 'common.form.showPassword' : 'common.form.hidePassword') | translate
+  "
+  [attr.aria-pressed]="!hiddenPass()"
   (click)="hidePassword($event)">
   <mat-icon>{{ hiddenPass() ? 'visibility_off' : 'visibility' }}</mat-icon>
 </button>

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
@@ -58,4 +58,16 @@ describe('InputPasswordWithVisibilityTypeComponent', () => {
 
     expect(component.hiddenPass()).toBe(!initialVisibility);
   });
+
+  it('should have correct aria-label based on visibility', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('aria-label')).toBe('common.form.showPassword');
+    expect(button.getAttribute('aria-pressed')).toBe('false');
+
+    component.hidePassword(new Event('click'));
+    fixture.detectChanges();
+
+    expect(button.getAttribute('aria-label')).toBe('common.form.hidePassword');
+    expect(button.getAttribute('aria-pressed')).toBe('true');
+  });
 });

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.ts
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.ts
@@ -3,6 +3,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { FieldTypeConfig, FormlyModule } from '@ngx-formly/core';
 import { FieldType } from '@ngx-formly/material/form-field';
 import { TranslateModule } from '@ngx-translate/core';
@@ -13,6 +14,7 @@ import { TranslateModule } from '@ngx-translate/core';
     MatButtonModule,
     MatIconModule,
     MatInputModule,
+    MatTooltipModule,
     FormlyModule,
     ReactiveFormsModule,
     TranslateModule,


### PR DESCRIPTION
This PR implements a micro-UX and accessibility improvement for the shared `InputPasswordWithVisibilityTypeComponent`.

### 🎨 Palette: Improve Password Visibility Toggle Accessibility

#### 💡 What
- Added dynamic `matTooltip` to the password visibility toggle.
- Fixed `aria-pressed` logic (now sets `true` when password is shown).
- Standardized translation keys under `common.form` for Catalan, Spanish, and English.
- Corrected a bug where `aria-label` displayed the raw key when the password was hidden.

#### 🎯 Why
- **Accessibility:** Screen reader users now receive correct state information via `aria-pressed` and translated labels.
- **Usability:** Sighted users get visual hints via tooltips on the icon-only toggle button.
- **Consistency:** Aligns the component with the project's i18n standards.

#### ♿ Accessibility Improvements
- Correct use of `aria-pressed`.
- Proper `aria-label` translation.
- Keyboard-accessible feedback (via tooltips and aria-labels).

#### ✅ Verification
- Ran unit tests: `yarn nx test input-password-with-visibility` (Passed).
- Performed frontend verification using Playwright in the `eco-store` app, confirming attribute updates on toggle.

---
*PR created automatically by Jules for task [9522690136622760636](https://jules.google.com/task/9522690136622760636) started by @plastikaweb*