### PR TITLE
🛡️ Sentinel: fix XSS vulnerability in shared formatters

### DIFF
--- a/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.spec.ts
+++ b/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.spec.ts
@@ -23,4 +23,28 @@ describe('SharedUtilFormattersService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  describe('Security', () => {
+    it('should escape HTML in defaultFormatter', () => {
+      const unsafeValue = '<script>alert("xss")</script>';
+      const formatted = service.defaultFormatter(unsafeValue) as any;
+      // In Angular testing, SafeHtml is often an object with a property like 'changingThisBreaksApplicationSecurity'
+      const sanitizedValue =
+        formatted['changingThisBreaksApplicationSecurity'] || formatted.toString();
+      expect(sanitizedValue).toContain('&lt;script&gt;alert(&quot;xss&quot;)&lt;&#x2F;script&gt;');
+      expect(sanitizedValue).not.toContain('<script>');
+    });
+
+    it('should escape HTML in booleanWithIconFormatter icons', () => {
+      const unsafeTrueIcon = 'check"><script>alert(1)</script>';
+      const formatted = service.booleanWithIconFormatter(true, () => ({
+        iconTrue: unsafeTrueIcon,
+        iconFalse: 'close',
+      })) as any;
+      const sanitizedValue =
+        formatted['changingThisBreaksApplicationSecurity'] || formatted.toString();
+      expect(sanitizedValue).toContain('check&quot;&gt;&lt;script&gt;alert(1)&lt;&#x2F;script&gt;');
+      expect(sanitizedValue).not.toContain('<script>');
+    });
+  });
 });

--- a/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
+++ b/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
@@ -10,6 +10,7 @@ import { inject, Injectable, LOCALE_ID } from '@angular/core';
 import { Timestamp } from '@angular/fire/firestore';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { BaseEntity } from '@plastik/core/entities';
+import { escapeHtml } from '@plastik/shared/objects';
 
 import {
   FormattingComponentOutput,
@@ -260,7 +261,7 @@ export class SharedUtilFormattersService {
       };
     }
     return this.#sanitizer.bypassSecurityTrustHtml(
-      `<span class="material-icons">${value ? format.iconTrue : format.iconFalse}</span>`
+      `<span class="material-icons">${escapeHtml(value ? format.iconTrue : format.iconFalse)}</span>`
     );
   }
 
@@ -314,6 +315,6 @@ export class SharedUtilFormattersService {
    * @returns {SafeHtml} The value passed through the sanitizer.
    */
   defaultFormatter(value: string): SafeHtml {
-    return this.#sanitizer.bypassSecurityTrustHtml(value);
+    return this.#sanitizer.bypassSecurityTrustHtml(escapeHtml(value));
   }
 }


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix XSS vulnerability in shared formatters

🚨 **Severity:** HIGH
💡 **Vulnerability:** The \`SharedUtilFormattersService\` was passing unescaped dynamic strings directly to \`DomSanitizer.bypassSecurityTrustHtml\`, creating a potential Cross-Site Scripting (XSS) vector wherever these formatters (especially the \`defaultFormatter\`) were used, such as in data tables.
🎯 **Impact:** An attacker could inject malicious scripts through data fields that are subsequently rendered via the \`safeFormatted\` pipe or direct service calls, potentially stealing user sessions or performing unauthorized actions.
🔧 **Fix:** Integrated the \`escapeHtml\` utility from \`@plastik/shared/objects\` into \`defaultFormatter\` and \`booleanWithIconFormatter\` to ensure all dynamic segments are sanitized before being marked as trusted for Angular.
✅ **Verification:** Added new unit tests in \`shared-util-formatters.service.spec.ts\` that explicitly verify HTML tags and special characters are correctly escaped. All 21 tests in the library pass.

---
*PR created automatically by Jules for task [2562761311191951574](https://jules.google.com/task/2562761311191951574) started by @plastikaweb*