### PR TITLE
🎨 Palette: improve header accessibility and micro-UX

### DIFF
--- a/libs/eco-store/core/layout/src/header/header.component.html
+++ b/libs/eco-store/core/layout/src/header/header.component.html
@@ -10,6 +10,9 @@
           [attr.aria-label]="
             (sideNavOpen() ? 'common.a11y.closeSidenav' : 'common.a11y.openSidenav') | translate
           "
+          [matTooltip]="
+            (sideNavOpen() ? 'common.a11y.closeSidenav' : 'common.a11y.openSidenav') | translate
+          "
           (click)="toggleSidenav.emit()">
           @if (!sideNavOpen()) {
             <mat-icon>menu</mat-icon>

--- a/libs/eco-store/core/layout/src/header/header.component.ts
+++ b/libs/eco-store/core/layout/src/header/header.component.ts
@@ -3,6 +3,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatToolbar } from '@angular/material/toolbar';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { FormConfig } from '@plastik/core/entities';
 import { EcoStoreTenant, EcoStoreTenantWindowStatus } from '@plastik/eco-store/entities';
@@ -19,6 +20,7 @@ import { EcoTenantLinkComponent } from '../tenant-link/tenant-link.component';
     MatToolbar,
     MatIcon,
     MatButtonModule,
+    MatTooltipModule,
     TranslateModule,
     StoreWindowComponent,
     EcoTenantLinkComponent,

--- a/libs/eco-store/core/layout/src/tenant-link/tenant-link.component.ts
+++ b/libs/eco-store/core/layout/src/tenant-link/tenant-link.component.ts
@@ -1,14 +1,22 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
 import { EcoStoreTenant } from '@plastik/eco-store/entities';
 import { EcoTenantLogoComponent } from '../tenant-logo/tenant-logo.component';
 
 @Component({
   selector: 'eco-tenant-link',
-  imports: [MatButtonModule, RouterLink, EcoTenantLogoComponent],
+  imports: [MatButtonModule, MatTooltipModule, TranslateModule, RouterLink, EcoTenantLogoComponent],
   template: `
-    <button matButton routerLink="/" type="button" (click)="linkClicked.emit()">
+    <button
+      matButton
+      routerLink="/"
+      type="button"
+      [matTooltip]="'common.navigation.backToStore' | translate"
+      [attr.aria-label]="'common.navigation.backToStore' | translate"
+      (click)="linkClicked.emit()">
       <eco-tenant-logo showName="responsive" [tenant]="tenant()" />
     </button>
   `,


### PR DESCRIPTION
This PR introduces micro-UX and accessibility improvements to the eco-store header.

### 💡 What:
- Added `matTooltip` to the sidenav toggle button, ensuring it matches the dynamic `aria-label`.
- Added `matTooltip` and `aria-label` to the tenant logo link (the main button that returns to the home page), providing context that was previously missing for screen readers and mouse users.
- Ensured all necessary Angular Material and Translate modules are correctly imported into the standalone components.

### 🎯 Why:
- **Accessibility:** Icon-only buttons and logo links often lack descriptive labels. Adding `aria-label` ensures screen reader users know where the link leads.
- **UX:** Tooltips provide helpful context for mouse users, making the interface more discoverable and intuitive.

### ♿ Accessibility Improvements:
- Described the purpose of the store logo link using `'common.navigation.backToStore'`.
- Synchronized tooltips with ARIA labels for consistent feedback.

Verified with unit tests, linting, and manual inspection via Playwright screenshots.

---
*PR created automatically by Jules for task [9325176443100410432](https://jules.google.com/task/9325176443100410432) started by @plastikaweb*