### PR TITLE
🎨 Palette: Add tooltips to product quantity buttons

### DIFF
--- a/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.html
+++ b/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.html
@@ -27,6 +27,12 @@
             : 'products.quantity.decrement'
           ) | translate: { value: product().name }
         "
+        [matTooltip]="
+          (quantity() <= minLimit() && mode() === 'card'
+            ? 'products.quantity.remove'
+            : 'products.quantity.decrement'
+          ) | translate: { value: product().name }
+        "
         [class]="
           quantity() <= minLimit() && mode() === 'card' ? 'remove-button' : 'decrement-button'
         "
@@ -76,7 +82,8 @@
         type="button"
         class="increment-button"
         [disabled]="quantity() >= maxLimit()"
-        [attr.aria-label]="`${('products.quantity.increment' | translate)} ${product().name}`"
+        [attr.aria-label]="('products.quantity.increment' | translate) + ' ' + product().name"
+        [matTooltip]="('products.quantity.increment' | translate) + ' ' + product().name"
         [attr.aria-disabled]="quantity() >= maxLimit()"
         [class.opacity-50]="quantity() >= maxLimit()"
         (click)="onIncrementClick($event)">

--- a/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.ts
+++ b/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.ts
@@ -10,12 +10,13 @@ import {
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { EcoStoreProductWithCategoryName } from '@plastik/eco-store/entities';
 
 @Component({
   selector: 'eco-store-product-quantity',
-  imports: [TranslateModule, MatIcon, MatButton, MatIconButton, MatInput],
+  imports: [TranslateModule, MatIcon, MatButton, MatIconButton, MatInput, MatTooltipModule],
   templateUrl: './eco-store-product-quantity.component.html',
   styleUrl: './eco-store-product-quantity.component.scss',
   host: {


### PR DESCRIPTION
### 🎨 Palette: Add tooltips to product quantity buttons

#### 💡 What:
Added tooltips to the increment and decrement/remove buttons in the `EcoStoreProductQuantityComponent`.

#### 🎯 Why:
Icon-only buttons can sometimes be ambiguous. Adding tooltips provides immediate visual feedback on the button's purpose, improving the overall discoverability and delight of the user interface. This is especially helpful when the button's function changes (e.g., from "decrement" to "remove" when reaching the minimum quantity).

#### ♿ Accessibility:
- Tooltips are consistent with `aria-label` content.
- Dynamic tooltips correctly reflect the button state (Decrement vs. Remove).
- Uses standard Angular Material `matTooltip` which is screen-reader friendly.

#### ✅ Verification:
- Ran `nx lint eco-store-product-quantity` (Passed).
- Ran `nx test eco-store-product-quantity` (Passed, including accessibility tests).
- Visual verification performed using a Playwright script with a mock UI.

---
*PR created automatically by Jules for task [14619352471419133064](https://jules.google.com/task/14619352471419133064) started by @plastikaweb*