### PR TITLE
🎨 Palette: add tooltips to eco-store action buttons

### DIFF
--- a/libs/eco-store/cart/feature/src/lib/ui/cart-product-card/cart-product-card.component.html
+++ b/libs/eco-store/cart/feature/src/lib/ui/cart-product-card/cart-product-card.component.html
@@ -75,6 +75,7 @@
         type="button"
         class="cart-delete-button col-start-3! row-start-1! @xl:col-start-2! @xl:row-start-2!"
         [aria-label]="'cart.summary.removeItem' | translate"
+        [matTooltip]="'cart.summary.removeItem' | translate"
         (click)="quantityChange.emit({ quantity: 0, product })">
         <mat-icon aria-hidden="true">delete_outline</mat-icon>
       </button>

--- a/libs/eco-store/cart/feature/src/lib/ui/cart-product-card/cart-product-card.component.spec.ts
+++ b/libs/eco-store/cart/feature/src/lib/ui/cart-product-card/cart-product-card.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatTooltip } from '@angular/material/tooltip';
+import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
 import { EcoStoreCartItem } from '@plastik/eco-store/entities';
@@ -94,5 +96,13 @@ describe('CartProductCardComponent', () => {
     deleteButton.click();
 
     expect(spy).toHaveBeenCalledWith({ quantity: 0, product: mockProduct });
+  });
+
+  it('should have a tooltip on the delete button', () => {
+    fixture.componentRef.setInput('editable', true);
+    fixture.detectChanges();
+
+    const deleteButton = fixture.debugElement.query(By.css('.cart-delete-button'));
+    expect(deleteButton.injector.get(MatTooltip)).toBeTruthy();
   });
 });

--- a/libs/eco-store/cart/feature/src/lib/ui/cart-product-card/cart-product-card.component.ts
+++ b/libs/eco-store/cart/feature/src/lib/ui/cart-product-card/cart-product-card.component.ts
@@ -3,6 +3,7 @@ import { ChangeDetectionStrategy, Component, input, output } from '@angular/core
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 import { EcoStoreCartItem, EcoStoreProductWithCategoryName } from '@plastik/eco-store/entities';
@@ -18,6 +19,7 @@ import { NewPriceWarningComponent } from '../new-price-warning/new-price-warning
     MatCardModule,
     MatButtonModule,
     MatIconModule,
+    MatTooltipModule,
     RouterLink,
     PocketBaseImageUrlPipe,
     SharedImgContainerComponent,

--- a/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.html
+++ b/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.html
@@ -27,6 +27,12 @@
             : 'products.quantity.decrement'
           ) | translate: { value: product().name }
         "
+        [matTooltip]="
+          (quantity() <= minLimit() && mode() === 'card'
+            ? 'products.quantity.remove'
+            : 'products.quantity.decrement'
+          ) | translate: { value: product().name }
+        "
         [class]="
           quantity() <= minLimit() && mode() === 'card' ? 'remove-button' : 'decrement-button'
         "
@@ -77,6 +83,7 @@
         class="increment-button"
         [disabled]="quantity() >= maxLimit()"
         [attr.aria-label]="`${('products.quantity.increment' | translate)} ${product().name}`"
+        [matTooltip]="`${('products.quantity.increment' | translate)} ${product().name}`"
         [attr.aria-disabled]="quantity() >= maxLimit()"
         [class.opacity-50]="quantity() >= maxLimit()"
         (click)="onIncrementClick($event)">

--- a/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.spec.ts
+++ b/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatTooltip } from '@angular/material/tooltip';
+import { By } from '@angular/platform-browser';
 import { provideTranslateService } from '@ngx-translate/core';
 import { axe } from 'vitest-axe';
 import { EcoStoreProductQuantityComponent } from './eco-store-product-quantity.component';
@@ -25,5 +27,20 @@ describe('EcoStoreProductQuantityComponent', () => {
   it('should have no accessibility violations', async () => {
     const results = await axe(fixture.nativeElement);
     expect(results).toHaveNoViolations();
+  });
+
+  it('should have tooltips on action buttons', async () => {
+    fixture.componentRef.setInput('product', {
+      id: '1',
+      name: 'Product',
+      unitType: 'unit',
+      minQuantity: 1,
+    });
+    fixture.componentRef.setInput('quantity', 1);
+    fixture.componentRef.setInput('mode', 'card');
+    fixture.detectChanges();
+
+    const tooltips = fixture.debugElement.queryAll(By.directive(MatTooltip));
+    expect(tooltips.length).toBe(2);
   });
 });

--- a/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.ts
+++ b/libs/eco-store/shared/product-quantity/src/lib/eco-store-product-quantity.component.ts
@@ -10,12 +10,13 @@ import {
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { EcoStoreProductWithCategoryName } from '@plastik/eco-store/entities';
 
 @Component({
   selector: 'eco-store-product-quantity',
-  imports: [TranslateModule, MatIcon, MatButton, MatIconButton, MatInput],
+  imports: [TranslateModule, MatIcon, MatButton, MatIconButton, MatInput, MatTooltipModule],
   templateUrl: './eco-store-product-quantity.component.html',
   styleUrl: './eco-store-product-quantity.component.scss',
   host: {


### PR DESCRIPTION
### 🎨 Palette: [UX improvement]

#### 💡 What:
Added visual tooltips (`matTooltip`) to several icon-only buttons in the `eco-store` application, specifically in the product quantity selector and the cart item card.

#### 🎯 Why:
Following the project's UX standards, interactive elements (especially icon-only buttons) should include a `matTooltip` for visual discovery and discovery by users who may not immediately recognize the icons. This complements the existing `aria-label` and makes the interface more intuitive and accessible.

#### ♿ Accessibility:
- Ensured that `matTooltip` and `aria-label` content are consistent for all updated buttons.
- Improved discoverability for mouse and touch users.

#### ✅ Verification:
- Ran `yarn nx test eco-store-product-quantity` and `yarn nx test eco-store-cart`.
- Ran `yarn nx lint eco-store-product-quantity` and `yarn nx lint eco-store-cart`.
- Added specific unit tests to verify the presence of the `MatTooltip` directive on the affected buttons.

---
*PR created automatically by Jules for task [11516519836566654638](https://jules.google.com/task/11516519836566654638) started by @plastikaweb*