### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SharedUtilFormattersService

### DIFF
--- a/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.spec.ts
+++ b/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.spec.ts
@@ -1,6 +1,7 @@
 import { DatePipe, PercentPipe, TitleCasePipe } from '@angular/common';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { DomSanitizer } from '@angular/platform-browser';
 
 import { SharedUtilFormattersService } from './shared-util-formatters.service';
 
@@ -15,6 +16,12 @@ describe('SharedUtilFormattersService', () => {
         TitleCasePipe,
         DatePipe,
         PercentPipe,
+        {
+          provide: DomSanitizer,
+          useValue: {
+            bypassSecurityTrustHtml: (val: string) => val,
+          },
+        },
       ],
     });
     service = TestBed.inject(SharedUtilFormattersService);
@@ -22,5 +29,26 @@ describe('SharedUtilFormattersService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('defaultFormatter', () => {
+    it('should escape HTML special characters', () => {
+      const unsafeValue = '<script>alert("XSS")</script>';
+      const expectedEscapedValue = '&lt;script&gt;alert(&quot;XSS&quot;)&lt;&#x2F;script&gt;';
+      const result = service.defaultFormatter(unsafeValue);
+      expect(result.toString()).toBe(expectedEscapedValue);
+    });
+  });
+
+  describe('booleanWithIconFormatter', () => {
+    it('should escape icon names', () => {
+      const unsafeIcon = 'check"><script>alert("XSS")</script>';
+      const result = service.booleanWithIconFormatter(true, () => ({
+        iconTrue: unsafeIcon,
+        iconFalse: 'close',
+      }));
+      expect(result.toString()).toContain('&lt;script&gt;');
+      expect(result.toString()).not.toContain('<script>');
+    });
   });
 });

--- a/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
+++ b/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
@@ -10,6 +10,7 @@ import { inject, Injectable, LOCALE_ID } from '@angular/core';
 import { Timestamp } from '@angular/fire/firestore';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { BaseEntity } from '@plastik/core/entities';
+import { escapeHtml } from '@plastik/shared/objects';
 
 import {
   FormattingComponentOutput,
@@ -260,7 +261,7 @@ export class SharedUtilFormattersService {
       };
     }
     return this.#sanitizer.bypassSecurityTrustHtml(
-      `<span class="material-icons">${value ? format.iconTrue : format.iconFalse}</span>`
+      `<span class="material-icons">${escapeHtml(value ? format.iconTrue : format.iconFalse)}</span>`
     );
   }
 
@@ -314,6 +315,6 @@ export class SharedUtilFormattersService {
    * @returns {SafeHtml} The value passed through the sanitizer.
    */
   defaultFormatter(value: string): SafeHtml {
-    return this.#sanitizer.bypassSecurityTrustHtml(value);
+    return this.#sanitizer.bypassSecurityTrustHtml(escapeHtml(value));
   }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential Cross-Site Scripting (XSS) via improper use of `DomSanitizer.bypassSecurityTrustHtml` on unescaped user-controlled input in `SharedUtilFormattersService.defaultFormatter` and `SharedUtilFormattersService.booleanWithIconFormatter`.
🎯 Impact: An attacker could inject malicious scripts into the application by providing specially crafted strings that are subsequently rendered via these formatters, for example in tables or lists.
🔧 Fix: Integrated the `escapeHtml` utility to sanitize dynamic values before they are wrapped in trusted HTML or returned by the formatters. This ensures that only intended markup is rendered, while user-provided content is treated as safe text.
✅ Verification: Added new unit tests in `libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.spec.ts` that specifically check for correct HTML escaping in both affected methods. All tests for the project passed.

---
*PR created automatically by Jules for task [752045898191833039](https://jules.google.com/task/752045898191833039) started by @plastikaweb*