### PR TITLE
🎨 Palette: Enhance password visibility toggle accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-06] - Shared: A11Y-01 — Enhance `InputPasswordWithVisibilityTypeComponent` accessibility
+
+### Added
+
+- **`libs/shared/form/ui/input-password-with-visibility`**: Added a `matTooltip` to the password visibility toggle button and verified it with a new unit test. Added missing `password`, `showPassword`, and `hidePassword` translation keys to the `eco-store` app in English, Spanish, and Catalan.
+
+### Changed
+
+- **`libs/shared/form/ui/input-password-with-visibility`**: Updated the component to use camelCase translation keys (`common.form.password`, `common.form.showPassword`, `common.form.hidePassword`). Corrected the `aria-pressed` attribute to reflect the visible state (active) instead of the hidden state.
+
 ## [2026-06-06] - Shared: SEC-01 — Fix XSS in `SharedUtilFormattersService` table-cell formatters
 
 ### Fixed

--- a/apps/eco-store/public/i18n/ca.json
+++ b/apps/eco-store/public/i18n/ca.json
@@ -63,6 +63,9 @@
         "invalid-username": "Format de nom d'usuari no vàlid",
         "zip": "Format de codi no vàlid"
       },
+      "password": "Contrasenya",
+      "showPassword": "Mostrar contrasenya",
+      "hidePassword": "Ocultar contrasenya",
       "charactersCount": "{count, plural, one {caràcter} other {caràcters}}"
     },
     "a11y": {

--- a/apps/eco-store/public/i18n/en.json
+++ b/apps/eco-store/public/i18n/en.json
@@ -63,6 +63,9 @@
         "invalid-username": "Invalid username",
         "zip": "Invalid zip code format"
       },
+      "password": "Password",
+      "showPassword": "Show password",
+      "hidePassword": "Hide password",
       "charactersCount": "{count, plural, one {character} other {characters}}"
     },
     "a11y": {

--- a/apps/eco-store/public/i18n/es.json
+++ b/apps/eco-store/public/i18n/es.json
@@ -63,6 +63,9 @@
         "invalid-username": "Nombre de usuario inválido",
         "zip": "Formato de código postal no válido"
       },
+      "password": "Contraseña",
+      "showPassword": "Mostrar contraseña",
+      "hidePassword": "Ocultar contraseña",
       "charactersCount": "{count, plural, one {carácter} other {caracteres}}"
     },
     "a11y": {

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
@@ -1,4 +1,6 @@
-<label class="sr-only" [for]="`password-${field.id}`">{{ 'form.password' | translate }}</label>
+<label class="sr-only" [for]="`password-${field.id}`">{{
+  'common.form.password' | translate
+}}</label>
 <input
   matInput
   [id]="`password-${field.id}`"
@@ -14,8 +16,13 @@
   matSuffix
   tabindex="-1"
   type="button"
-  [attr.aria-label]="!hiddenPass() ? 'form.hide-password' : ('form.show-password' | translate)"
-  [attr.aria-pressed]="hiddenPass()"
+  [attr.aria-label]="
+    (!hiddenPass() ? 'common.form.hidePassword' : 'common.form.showPassword') | translate
+  "
+  [matTooltip]="
+    (!hiddenPass() ? 'common.form.hidePassword' : 'common.form.showPassword') | translate
+  "
+  [attr.aria-pressed]="!hiddenPass()"
   (click)="hidePassword($event)">
   <mat-icon>{{ hiddenPass() ? 'visibility_off' : 'visibility' }}</mat-icon>
 </button>

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
@@ -1,6 +1,8 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { MatTooltip } from '@angular/material/tooltip';
 import { FormlyModule } from '@ngx-formly/core';
 
 import { InputPasswordWithVisibilityTypeComponent } from './input-password-with-visibility-type.component';
@@ -57,5 +59,10 @@ describe('InputPasswordWithVisibilityTypeComponent', () => {
     component.hidePassword(event);
 
     expect(component.hiddenPass()).toBe(!initialVisibility);
+  });
+
+  it('should have a tooltip on the toggle button', () => {
+    const tooltip = fixture.debugElement.query(By.directive(MatTooltip));
+    expect(tooltip).toBeTruthy();
   });
 });

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.ts
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.ts
@@ -3,6 +3,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { FieldTypeConfig, FormlyModule } from '@ngx-formly/core';
 import { FieldType } from '@ngx-formly/material/form-field';
 import { TranslateModule } from '@ngx-translate/core';
@@ -13,6 +14,7 @@ import { TranslateModule } from '@ngx-translate/core';
     MatButtonModule,
     MatIconModule,
     MatInputModule,
+    MatTooltipModule,
     FormlyModule,
     ReactiveFormsModule,
     TranslateModule,


### PR DESCRIPTION
💡 What: Added a `matTooltip` to the password visibility toggle button and corrected its ARIA attributes.
🎯 Why: Icon-only buttons are hard to discover for sighted users without tooltips, and the previous ARIA implementation had incorrect states and missing translations.
♿ Accessibility:
- Added `matTooltip` for visual discovery.
- Fixed `aria-pressed` to correctly reflect the visible state.
- Ensured `aria-label` is correctly translated for all states.
- Added missing translation keys for English, Spanish, and Catalan.

---
*PR created automatically by Jules for task [3718125246019143207](https://jules.google.com/task/3718125246019143207) started by @plastikaweb*