### PR TITLE
fix: #86ca59u43 SEC-02 add rel="noopener noreferrer" to all target="_blank" links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-06] - Workspace: SEC-02 — Reverse-tabnabbing: add `rel="noopener noreferrer"` to all `target="_blank"` links
+
+### Fixed
+
+- **Workspace-wide**: All 7 `target="_blank"` anchor elements across 5 files were missing `rel="noopener noreferrer"`, leaving them open to reverse-tabnabbing (opened page can navigate `window.opener` back to the originating tab). Fixed in `libs/core/cms-layout/feature` (2), `libs/llecoop/cms-layout` (2), `libs/shared/button/ui` (1), `libs/eco-store/core/layout` (1), and `apps/llecoop-firebase/public` (1). Closes [#86ca59u43](https://app.clickup.com/t/86ca59u43).
+
 ## [2026-06-06] - Shared: SEC-01 — Fix XSS in `SharedUtilFormattersService` table-cell formatters
 
 ### Fixed

--- a/apps/eco-store/TASKS.md
+++ b/apps/eco-store/TASKS.md
@@ -407,10 +407,10 @@ All `COULD`, pending discovery.
 
 ### Security
 
-| ID                 | Description                                                                                                 | Priority   | ClickUp     |
-| ------------------ | ----------------------------------------------------------------------------------------------------------- | ---------- | ----------- |
-| **SEC-01** ✅      | XSS: `escapeHtml` in `SharedUtilFormattersService` (`defaultFormatter` + `booleanWithIconFormatter`) — HIGH | **Urgent** | `86ca59u6g` |
-| **SEC-02** _(new)_ | Reverse-tabnabbing: `rel="noopener noreferrer"` on all `target="_blank"` links (workspace-wide) — MEDIUM    | SHOULD     | `86ca59u43` |
+| ID            | Description                                                                                                 | Priority   | ClickUp     |
+| ------------- | ----------------------------------------------------------------------------------------------------------- | ---------- | ----------- |
+| **SEC-01** ✅ | XSS: `escapeHtml` in `SharedUtilFormattersService` (`defaultFormatter` + `booleanWithIconFormatter`) — HIGH | **Urgent** | `86ca59u6g` |
+| **SEC-02** ✅ | Reverse-tabnabbing: `rel="noopener noreferrer"` on all `target="_blank"` links (workspace-wide) — MEDIUM    | SHOULD     | `86ca59u43` |
 
 ### Ops / Release
 

--- a/apps/llecoop-firebase/public/index.html
+++ b/apps/llecoop-firebase/public/index.html
@@ -107,7 +107,7 @@
         You're seeing this because you've successfully setup Firebase Hosting. Now it's time to go
         build something extraordinary!
       </p>
-      <a target="_blank" href="https://firebase.google.com/docs/hosting/"
+      <a target="_blank" rel="noopener noreferrer" href="https://firebase.google.com/docs/hosting/"
         >Open Hosting Documentation</a
       >
     </div>

--- a/libs/core/cms-layout/feature/src/lib/core-cms-layout-feature/core-cms-layout-feature.component.html
+++ b/libs/core/cms-layout/feature/src/lib/core-cms-layout-feature/core-cms-layout-feature.component.html
@@ -98,6 +98,7 @@
           class="underline underline-offset-2"
           href="https://www.plastikaweb.com"
           target="_blank"
+          rel="noopener noreferrer"
           >Plastikaweb</a
         >
         |
@@ -106,6 +107,7 @@
           class="underline underline-offset-2"
           href="https://www.llevat.org"
           target="_blank"
+          rel="noopener noreferrer"
           >El Llevat</a
         >
       </div>

--- a/libs/eco-store/core/layout/src/footer/footer.component.html
+++ b/libs/eco-store/core/layout/src/footer/footer.component.html
@@ -21,7 +21,11 @@
     </div>
 
     <div class="flex flex-col items-center gap-2 text-sm md:flex-row md:gap-6">
-      <a href="https://www.plastikaweb.com" target="_blank" class="transition-colors"
+      <a
+        href="https://www.plastikaweb.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="transition-colors"
         >www.plastikaweb.com</a
       >
       <span class="hidden md:block">|</span>

--- a/libs/llecoop/cms-layout/src/lib/cms-layout/cms-layout.component.html
+++ b/libs/llecoop/cms-layout/src/lib/cms-layout/cms-layout.component.html
@@ -163,6 +163,7 @@
         aria-label="visit www.plastikaweb.com page"
         href="https://www.plastikaweb.com"
         target="_blank"
+        rel="noopener noreferrer"
         >Plastikaweb</a
       >
       &vert;
@@ -170,6 +171,7 @@
         aria-label="visitar la pàgina de El Llevat a www.llevat.org"
         href="https://www.llevat.org"
         target="_blank"
+        rel="noopener noreferrer"
         >El Llevat</a
       >
     </div>

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
@@ -15,6 +15,7 @@
   <a
     class="block"
     target="_blank"
+    rel="noopener noreferrer"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
     [href]="linkHref()"


### PR DESCRIPTION
## Summary

- All 7 `target="_blank"` anchor elements across 5 files were missing `rel="noopener noreferrer"`, leaving them open to reverse-tabnabbing (the opened page can navigate `window.opener` back to the originating tab)
- Fixed in `libs/core/cms-layout/feature` (2), `libs/llecoop/cms-layout` (2), `libs/shared/button/ui` (1), `libs/eco-store/core/layout` (1), and `apps/llecoop-firebase/public` (1)
- Pure attribute addition — no logic change, no test change needed

ClickUp: `86ca59u43` (SEC-02)

## Test plan

- [ ] `yarn affected:lint` — 42 projects, 0 errors ✅ (verified locally)
- [ ] Pa11y: 7/7 URLs passed ✅ (verified via pre-push hook)
- [ ] Confirm no `target="_blank"` without `rel="noopener noreferrer"` remains: `grep -r 'target="_blank"' --include="*.html" --include="*.ts" . | grep -v node_modules | grep -v rel=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)