### PR TITLE
ci(husky): skip heavy checks for markdown-only commits and pushes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -33,6 +33,16 @@ if [ -z "$ALLOW_BACKLOG_MIX" ]; then
 fi
 # ----------------------------------------------------
 
+# --- MARKDOWN-ONLY FAST PATH ---
+# If every changed file is a .md, skip the heavy checks (PocketBase export,
+# i18n validation, nx lint) — none of them are relevant for doc-only commits.
+# branch:lint, markdownlint and format:write still run.
+ALL_CHANGED=$(git status --porcelain | awk '{print $NF}' | grep -v '^$')
+NON_MD=$(printf '%s\n' "$ALL_CHANGED" | grep -v '\.md$' | grep -v '^$' || true)
+ONLY_MD=false
+[ -z "$NON_MD" ] && ONLY_MD=true
+# --------------------------------
+
 # --- SANDBOX BRIDGE ---
 # Redirect HOME to a temp directory to avoid EPERM on /Users/plastikaweb/.yarnrc
 export HOME=/tmp/husky-sandbox
@@ -44,37 +54,49 @@ alias yarn="npx yarn"
 export NX_CLI_SET=classic
 export PAGER=cat
 
-# 1. Start PocketBase in the background
-(cd apps/eco-store/pocketbase && ./pocketbase serve > /dev/null 2>&1) &
-PB_PID=$!
-
-# 2. Wait for initialization
-sleep 3
-
-# 3. Run the export (Using npx to ensure Yarn 4 is used)
-npx yarn eco-store:pb:export
-EXPORT_EXIT_CODE=$?
-
-# 4. Kill the background PocketBase instance
-kill $PB_PID 2>/dev/null || true
-wait $PB_PID 2>/dev/null || true
-
-# 5. Check if export failed
-if [ $EXPORT_EXIT_CODE -ne 0 ]; then
-  echo "❌ PocketBase schema export failed!"
-  exit $EXPORT_EXIT_CODE
-fi
-
-# Run checks using npx yarn to ensure Yarn 4 Berry execution
-if npx yarn branch:lint \
-  && npx yarn i18n:validate \
-  && npx yarn nx affected --target=lint --parallel --max-parallel=2 --cache \
-  && npx yarn markdownlint \
-  && npx yarn nx format:write --affected; then
-
-  # 6. Add all changes to the commit
-  git add -A
+if [ "$ONLY_MD" = "true" ]; then
+  echo "📝 Markdown-only commit — skipping PocketBase export, i18n, and lint"
+  if npx yarn branch:lint \
+    && npx yarn markdownlint \
+    && npx yarn nx format:write --affected; then
+    git add -A
+  else
+    echo "❌ Checks failed! Commit aborted!"
+    exit 1
+  fi
 else
-  echo "❌ Checks failed! Commit aborted!"
-  exit 1
+  # 1. Start PocketBase in the background
+  (cd apps/eco-store/pocketbase && ./pocketbase serve > /dev/null 2>&1) &
+  PB_PID=$!
+
+  # 2. Wait for initialization
+  sleep 3
+
+  # 3. Run the export (Using npx to ensure Yarn 4 is used)
+  npx yarn eco-store:pb:export
+  EXPORT_EXIT_CODE=$?
+
+  # 4. Kill the background PocketBase instance
+  kill $PB_PID 2>/dev/null || true
+  wait $PB_PID 2>/dev/null || true
+
+  # 5. Check if export failed
+  if [ $EXPORT_EXIT_CODE -ne 0 ]; then
+    echo "❌ PocketBase schema export failed!"
+    exit $EXPORT_EXIT_CODE
+  fi
+
+  # Run checks using npx yarn to ensure Yarn 4 Berry execution
+  if npx yarn branch:lint \
+    && npx yarn i18n:validate \
+    && npx yarn nx affected --target=lint --parallel --max-parallel=2 --cache \
+    && npx yarn markdownlint \
+    && npx yarn nx format:write --affected; then
+
+    # 6. Add all changes to the commit
+    git add -A
+  else
+    echo "❌ Checks failed! Commit aborted!"
+    exit 1
+  fi
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,6 +3,19 @@ set -e
 export NX_CLI_SET=classic
 export PAGER=cat
 
+CHANGED_FILES=$(git diff --name-only @{upstream}...HEAD 2>/dev/null || git diff --name-only HEAD~1...HEAD)
+
+# --- MARKDOWN-ONLY FAST PATH ---
+# If every file changed across all commits being pushed is a .md, skip tests,
+# build and a11y entirely — none of them are relevant for doc-only pushes.
+NON_MD_CHANGED=$(printf '%s\n' "$CHANGED_FILES" | grep -v '\.md$' | grep -v '^$' || true)
+if [ -z "$NON_MD_CHANGED" ]; then
+  echo "📝 Markdown-only push — skipping tests, build and a11y checks"
+  echo "✅ All checks passed. Pushing..."
+  exit 0
+fi
+# --------------------------------
+
 echo "🏃 Running affected tests..."
 if ! yarn nx affected --target=test --parallel --max-parallel=2 --cache; then
   echo "❌ Tests failed! Push aborted."
@@ -17,7 +30,6 @@ if ! yarn nx run-many --target=build --configuration=production --parallel --max
   exit 1
 fi
 
-CHANGED_FILES=$(git diff --name-only @{upstream}...HEAD 2>/dev/null || git diff --name-only HEAD~1...HEAD)
 if echo "$CHANGED_FILES" | grep -Eq '^(apps/eco-store/|libs/eco-store/)'; then
   echo "🏁 Running eco-store:a11y (using existing build)..."
   if ! yarn npm-run-all --parallel --race eco-store:http-server eco-store:a11y:run; then


### PR DESCRIPTION
## Summary

- **pre-commit**: when every changed file is `.md`, bypass PocketBase export, i18n validation, and `nx affected lint` — only `branch:lint`, `markdownlint`, and `format:write` run
- **pre-push**: when every file across all pushed commits is `.md`, skip tests, build, and a11y entirely and exit immediately
- Non-markdown commits and pushes are completely unchanged — all existing gates still apply

This eliminates the ~2-minute overhead (PocketBase export + 92 file downloads + i18n scan + nx lint) on pure `docs(eco-store):` backlog flips and similar doc-only commits.

## Test plan

- [ ] Make a docs-only change (e.g. edit `apps/eco-store/TASKS.md`) and commit — should see `📝 Markdown-only commit — skipping PocketBase export, i18n, and lint`
- [ ] Push that branch — should see `📝 Markdown-only push — skipping tests, build and a11y checks`
- [ ] Make a code change and commit/push — full hook pipeline runs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)