### PR TITLE
perf(shared-util-objects): #86ca59u6d TECH-05 convert remaining reduce fns to for...in

### DIFF
--- a/libs/shared/util/objects/src/util-objects.ts
+++ b/libs/shared/util/objects/src/util-objects.ts
@@ -117,37 +117,43 @@ export function formatURLQueryParams(url: string): Record<string, unknown> {
 }
 
 /**
- * @description Returns an object without properties with null value.
+ * @description Returns an object without properties with null value. Uses a `for...in`
+ * loop instead of `Object.entries().reduce()` to avoid the O(N) array allocation.
  * @param  {Record<string, string | number | boolean | null>} collection Object parameter passed.
  * @returns {Record<string, string | number | boolean>}.
  */
 export function removeNullProperties(
   collection: Record<string, string | number | boolean | null>
 ): Record<string, string | number | boolean> {
-  return Object.entries(collection).reduce(
-    (currentCollection: Record<string, string | number | boolean | null>, [property, value]) =>
-      value === null
-        ? currentCollection
-        : ((currentCollection[property] = value), currentCollection),
-    {}
-  ) as Record<string, string | number | boolean>;
+  const result: Record<string, string | number | boolean> = {};
+  for (const property in collection) {
+    if (Object.prototype.hasOwnProperty.call(collection, property)) {
+      const value = collection[property];
+      if (value !== null) {
+        result[property] = value;
+      }
+    }
+  }
+  return result;
 }
 
 /**
  * @description Returns an object with properties with empty string value replaced by null.
+ * Uses a `for...in` loop instead of `Object.entries().reduce()` to avoid the O(N) array allocation.
  * @param  {Record<string, string | number | boolean | null>} collection Object parameter passed.
  * @returns {Record<string, string | number | boolean | null>}.
  */
 export function setEmptyStringPropertiesToNull(
   collection: Record<string, string | number | boolean | null>
 ): Record<string, string | number | boolean | null> {
-  return Object.entries(collection).reduce(
-    (currentCollection: Record<string, string | number | boolean | null>, [property, value]) => {
-      currentCollection[property] = isString(value) && !value.length ? null : value;
-      return currentCollection;
-    },
-    {}
-  ) as Record<string, string | number | boolean | null>;
+  const result: Record<string, string | number | boolean | null> = {};
+  for (const property in collection) {
+    if (Object.prototype.hasOwnProperty.call(collection, property)) {
+      const value = collection[property];
+      result[property] = isString(value) && !value.length ? null : value;
+    }
+  }
+  return result;
 }
 
 /**
@@ -179,22 +185,24 @@ export function areObjectEntriesEqual(prev: object, curr: object): boolean {
 
 /**
  * @description Returns an object with replaced values for"false" and"true" as boolean values.
+ * Uses a `for...in` loop instead of `Object.entries().reduce()` to avoid the O(N) array allocation.
  * @param  {Record<string, string | number | boolean | null>} collection Object parameter passed.
  * @returns {Record<string, string | number | boolean>}.
  */
 export function transformStringToBooleanProperties(
   collection: Record<string, string | number | boolean | null>
 ): Record<string, string | number | boolean> {
-  return Object.entries(collection).reduce(
-    (currentCollection: Record<string, string | number | boolean | null>, [property, value]) => {
-      currentCollection[property] =
+  const result: Record<string, string | number | boolean> = {};
+  for (const property in collection) {
+    if (Object.prototype.hasOwnProperty.call(collection, property)) {
+      const value = collection[property];
+      result[property] =
         isString(value) && (value === 'false' || value === 'true')
           ? coerceBooleanProperty(value)
-          : value;
-      return currentCollection;
-    },
-    {}
-  ) as Record<string, string | number | boolean>;
+          : (value as string | number | boolean);
+    }
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

TECH-03 follow-up. Converts the 3 remaining `Object.entries().reduce()` functions in `libs/shared/util/objects` to imperative `for...in` loops with `hasOwnProperty` guards, eliminating the O(N) intermediate `[key, value][]` array allocation per call:

- `removeNullProperties`
- `setEmptyStringPropertiesToNull`
- `transformStringToBooleanProperties`

Behaviour is identical — the `hasOwnProperty` guard makes `for...in` iterate exactly the own enumerable string keys, same as `Object.entries()`. JSDoc notes follow the style TECH-03 established on `isEmpty`/`formatURLQueryParams`.

**Note:** clean re-cut of Jules PR #1114 (closed separately) with project commit conventions.

## Test plan

- [x] All 39 unit tests pass (`yarn nx test shared-util-objects`)
- [x] Lint clean (pre-commit ran 85 affected projects)
- [ ] TASKS.md/BACKLOG.md flip follows in a docs commit (preserved in stash, worktree currently in use by another session)

Closes: #86ca59u6d
Supersedes: PR #1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)