### PR TITLE
🎨 Palette: Improve password visibility toggle accessibility

### DIFF
--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
@@ -14,7 +14,6 @@
 <button
   matIconButton
   matSuffix
-  tabindex="-1"
   type="button"
   [attr.aria-label]="
     (hiddenPass() ? 'common.form.showPassword' : 'common.form.hidePassword') | translate


### PR DESCRIPTION
🎨 Palette: Improve password visibility toggle accessibility

💡 What: Removed `tabindex="-1"` from the password visibility toggle button in `InputPasswordWithVisibilityTypeComponent`.

🎯 Why: Interactive elements should be focusable via keyboard. `tabindex="-1"` was preventing keyboard-only users from accessing the show/hide password feature.

♿ Accessibility:
- Made the toggle button focusable via the `Tab` key.
- Ensures compatibility with screen readers and keyboard navigation.
- Maintained existing `aria-label`, `aria-pressed`, and `matTooltip` for a consistent accessible experience.

---
*PR created automatically by Jules for task [14322174872235662330](https://jules.google.com/task/14322174872235662330) started by @plastikaweb*