### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SharedConfirmFeatureComponent

### DIFF
--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
@@ -46,4 +46,40 @@ describe('SharedConfirmFeatureComponent', () => {
       'Hello test'
     );
   });
+
+  it('should escape malicious parameters to prevent XSS', () => {
+    const maliciousName = '<img src=x onerror=alert(1)>';
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [SharedConfirmFeatureComponent, TranslateModule.forRoot()],
+      providers: [
+        provideZonelessChangeDetection(),
+        {
+          provide: DIALOG_DATA,
+          useValue: {
+            title: 'Title',
+            message: 'test.message',
+            params: { name: maliciousName },
+            ok: 'common.ok',
+            ko: 'common.cancel',
+          },
+        },
+      ],
+    });
+
+    const fixtureXss = TestBed.createComponent(SharedConfirmFeatureComponent);
+    const componentXss = fixtureXss.componentInstance;
+    const translateXss = TestBed.inject(TranslateService);
+    translateXss.use('en');
+    translateXss.setTranslation('en', { 'test.message': 'Hello {{name}}' });
+    fixtureXss.detectChanges();
+
+    const message = (componentXss as any).message();
+    // We check the internal value of SafeHtml or its string representation
+    const renderedMessage = message.toString();
+
+    expect(renderedMessage).toContain('Hello &lt;img src&#x3D;x onerror&#x3D;alert(1)&gt;');
+    expect(renderedMessage).not.toContain(maliciousName);
+  });
 });

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
@@ -11,6 +11,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 import { RouterLink } from '@angular/router';
+import { escapeHtml } from '@plastik/shared/objects';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 @Component({
@@ -31,7 +32,14 @@ export class SharedConfirmFeatureComponent {
   protected readonly icon = computed(() => this.data.icon || 'help_outline');
 
   protected readonly message = computed(() => {
-    const translated = this.#translate.instant(this.data.message, this.data.params);
+    const params = this.data.params
+      ? Object.entries(this.data.params).reduce((acc, [key, value]) => {
+          acc[key] = typeof value === 'string' ? escapeHtml(value) : value;
+          return acc;
+        }, {} as Record<string, unknown>)
+      : undefined;
+
+    const translated = this.#translate.instant(this.data.message, params);
     return this.#sanitizer.bypassSecurityTrustHtml(translated);
   });
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SharedConfirmFeatureComponent

🚨 Severity: HIGH
💡 Vulnerability: Reflected XSS via unsanitized translation parameters. The component was using `DomSanitizer.bypassSecurityTrustHtml` on a translated string that included dynamic parameters. Since `ngx-translate` does not escape these parameters by default, malicious data could execute arbitrary JavaScript.
🎯 Impact: An attacker could execute malicious scripts in the context of the user's session if they can influence data that appears in a confirmation dialog (e.g., item names, user details).
🔧 Fix: Implemented manual escaping of all string values in `data.params` using the `escapeHtml` utility before passing them to the translation service.
✅ Verification: Added a new unit test in `shared-confirm-feature.component.spec.ts` that specifically verifies malicious payloads in parameters are correctly escaped and not rendered as live HTML. All existing tests passed.

---
*PR created automatically by Jules for task [4973099796600939365](https://jules.google.com/task/4973099796600939365) started by @plastikaweb*