### PR TITLE
fix(nasa-images): #86ca59u43 SEC-02 follow-up — rel=noopener on FAQ links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-07] - Workspace: SEC-02 follow-up — Reverse-tabnabbing on `nasa-images` FAQ links
+
+### Fixed
+
+- **`apps/nasa-images` (`faqs.json`)**: The 7 `target="_blank"` anchors embedded in the FAQ answers — rendered as live DOM via `[innerHTML]` in `nasa-images-faqs-feature.component.html` — were missing `rel="noopener noreferrer"`, leaving them open to reverse-tabnabbing. SEC-02 fixed all template-level `target="_blank"` links workspace-wide but did not scan anchors embedded inside JSON data files, so these slipped through. Added `rel="noopener noreferrer"` to all 7. Completes SEC-02 ([#86ca59u43](https://app.clickup.com/t/86ca59u43)); supersedes the remaining unmerged portion of Jules PR [#1100](https://github.com/plastikaweb/plastikspace/pull/1100) (the rest was already on develop via SEC-01/SEC-02).
+
 ## [2026-06-07] - Eco-store: A11Y-005 — Header sidenav + tenant-link tooltips/aria-label
 
 ### Fixed

--- a/apps/nasa-images/src/assets/json/faqs.json
+++ b/apps/nasa-images/src/assets/json/faqs.json
@@ -1,11 +1,11 @@
 [
   {
     "question": "What is the main purpose of the Nasa Images search page?",
-    "answer": "Its main purpose is to allow users to search for images using the <a href=\"https://images.nasa.gov/docs/images.nasa.gov_api_docs.pdf\" title=\"NASA images API docs (pdf)\" target=\"_blank\">images.nasa.gov API Documentation <span class=\"sr-only\">(opens in new window)</span></a>.<br>The page includes search filters for the user to refine their search results."
+    "answer": "Its main purpose is to allow users to search for images using the <a href=\"https://images.nasa.gov/docs/images.nasa.gov_api_docs.pdf\" title=\"NASA images API docs (pdf)\" target=\"_blank\" rel=\"noopener noreferrer\">images.nasa.gov API Documentation <span class=\"sr-only\">(opens in new window)</span></a>.<br>The page includes search filters for the user to refine their search results."
   },
   {
     "question": "Where can I find the code for the website?",
-    "answer": "The code for the website can be found on the GitHub repository at <a href=\"https://github.com/plastikaweb/plastikspace\" target=\"_blank\">plastikspace</a>. This is a monorepo and includes the code for the <span class=\"highlight\">NASA Images</span> application as well as shared code to create other apps.<div class=\"py-sm\">Other related links:</div><ul><li><a href=\"https://github.com/users/plastikaweb/projects/2\" target=\"_blank\">Plastikaweb NASA gallery Github Project</a></li><li><a href=\"https://github.com/plastikaweb/plastikspace/wiki/nasa-image-library-project\" target=\"_blank\">NASA Image Library Analysis Wiki</a></li></ul></div>"
+    "answer": "The code for the website can be found on the GitHub repository at <a href=\"https://github.com/plastikaweb/plastikspace\" target=\"_blank\" rel=\"noopener noreferrer\">plastikspace</a>. This is a monorepo and includes the code for the <span class=\"highlight\">NASA Images</span> application as well as shared code to create other apps.<div class=\"py-sm\">Other related links:</div><ul><li><a href=\"https://github.com/users/plastikaweb/projects/2\" target=\"_blank\" rel=\"noopener noreferrer\">Plastikaweb NASA gallery Github Project</a></li><li><a href=\"https://github.com/plastikaweb/plastikspace/wiki/nasa-image-library-project\" target=\"_blank\" rel=\"noopener noreferrer\">NASA Image Library Analysis Wiki</a></li></ul></div>"
   },
   {
     "question": "Why have I created this repository?",
@@ -13,11 +13,11 @@
   },
   {
     "question": "What technologies are being used to build the website?",
-    "answer": "The website is built using <span class=\"highlight\">Angular, Nx, and @ngrx</span> as the main technologies. The application consumes the <a href=\"https://images.nasa.gov/docs/images.nasa.gov_api_docs.pdf\" title=\"NASA images API docs (pdf)\" target=\"_blank\">NASA images REST API <span class=\"sr-only\">(opens in new window)</span></a> and uses <span class=\"highlight\">Material Design + TailwindCSS</span> for the UI."
+    "answer": "The website is built using <span class=\"highlight\">Angular, Nx, and @ngrx</span> as the main technologies. The application consumes the <a href=\"https://images.nasa.gov/docs/images.nasa.gov_api_docs.pdf\" title=\"NASA images API docs (pdf)\" target=\"_blank\" rel=\"noopener noreferrer\">NASA images REST API <span class=\"sr-only\">(opens in new window)</span></a> and uses <span class=\"highlight\">Material Design + TailwindCSS</span> for the UI."
   },
   {
     "question": "What is the architecture used for the website?",
-    "answer": "The website is built using the <span class=\"highlight\">Nx monorepo</span> approach, which allows for a modular and scalable code structure. See <a href=\"https://github.com/plastikaweb/plastikspace/blob/develop/documentation/nx-architecture.md\" target=\"_blank\">NX architecture</a> for detailed info.<br>The code also follows the principles of reactive programming and is built using <span class=\"highlight\">@ngrx</span> for state management."
+    "answer": "The website is built using the <span class=\"highlight\">Nx monorepo</span> approach, which allows for a modular and scalable code structure. See <a href=\"https://github.com/plastikaweb/plastikspace/blob/develop/documentation/nx-architecture.md\" target=\"_blank\" rel=\"noopener noreferrer\">NX architecture</a> for detailed info.<br>The code also follows the principles of reactive programming and is built using <span class=\"highlight\">@ngrx</span> for state management."
   },
   {
     "question": "What CSS style is used for the website?",
@@ -33,6 +33,6 @@
   },
   {
     "question": "How can I contact you?",
-    "answer": "My name is Carlos Matheu, and you can reach out to me through the <a href=\"https://www.plastikaweb.com\" target=\"_blank\">Plastikaweb site</a>. Here you\"ll find more info about my skills, contact and my CV.<br>Alternatively, you can send me an email directly at [info@plastikaweb.com]. I\"m always open to new opportunities and collaborations, so don\"t hesitate to get in touch!"
+    "answer": "My name is Carlos Matheu, and you can reach out to me through the <a href=\"https://www.plastikaweb.com\" target=\"_blank\" rel=\"noopener noreferrer\">Plastikaweb site</a>. Here you\"ll find more info about my skills, contact and my CV.<br>Alternatively, you can send me an email directly at [info@plastikaweb.com]. I\"m always open to new opportunities and collaborations, so don\"t hesitate to get in touch!"
   }
 ]


### PR DESCRIPTION
## SEC-02 follow-up — reverse-tabnabbing on nasa-images FAQ links

Closes the one gap SEC-02 left behind. CU [`86ca59u43`](https://app.clickup.com/t/86ca59u43).

### What

Added `rel="noopener noreferrer"` to the **7 `target="_blank"` anchors embedded in `apps/nasa-images/src/assets/json/faqs.json`**. These FAQ answers are rendered as live DOM via `[innerHTML]="faq.answer"` ([nasa-images-faqs-feature.component.html](libs/nasa-images/faqs/feature/src/lib/nasa-images-faqs-feature/nasa-images-faqs-feature.component.html#L20)), so the links are real and were exposed to reverse-tabnabbing.

### Why it was missed

SEC-02 (PR #1122) fixed all **template-level** `target="_blank"` links workspace-wide but did not scan anchors embedded inside **JSON data files**, so these slipped through despite SEC-02 being "workspace-wide."

### Provenance

This is the only part of Jules draft PR #1100 that wasn't already on `develop` — its XSS-escape and the other `rel=noopener` edits had already shipped via SEC-01/SEC-02. #1100 will be closed as superseded, with this PR carrying the remaining fix.

### Verification

- JSON re-parses cleanly; all 7 anchors now carry `rel="noopener noreferrer"`; 0 `target="_blank"` links remain without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)