### PR TITLE
🎨 Palette: password visibility toggle keyboard focusable

### DIFF
--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
@@ -14,7 +14,6 @@
 <button
   matIconButton
   matSuffix
-  tabindex="-1"
   type="button"
   [attr.aria-label]="
     (hiddenPass() ? 'common.form.showPassword' : 'common.form.hidePassword') | translate

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
@@ -71,4 +71,9 @@ describe('InputPasswordWithVisibilityTypeComponent', () => {
     expect(button.getAttribute('aria-label')).toBe('common.form.hidePassword');
     expect(button.getAttribute('aria-pressed')).toBe('true');
   });
+
+  it('should be keyboard focusable', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('tabindex')).not.toBe('-1');
+  });
 });


### PR DESCRIPTION
💡 **What**: Removed `tabindex="-1"` from the password visibility toggle button in `InputPasswordWithVisibilityTypeComponent`.
🎯 **Why**: Keyboard users were unable to reach the toggle button, preventing them from showing or hiding the password they typed to verify it. This is a critical accessibility issue for users who rely on keyboard navigation or screen readers.
♿ **Accessibility**: Improved keyboard navigation by ensuring all interactive elements are in the tab order. Added a unit test to prevent future regressions.
✅ **Verification**: 
- Ran `yarn nx test input-password-with-visibility` and all tests passed (including the new focusability test).
- Verified manually using a Playwright script that the button receives focus after tabbing from the password input field.

Screenshot:
![Password Toggle Focus](/home/jules/verification/password_toggle_focus.png) (Uploaded via frontend_verification_complete)

---
*PR created automatically by Jules for task [14361905872026540793](https://jules.google.com/task/14361905872026540793) started by @plastikaweb*