### PR TITLE
🎨 Palette: Make password visibility toggle keyboard-focusable

### DIFF
--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
@@ -14,7 +14,6 @@
 <button
   matIconButton
   matSuffix
-  tabindex="-1"
   type="button"
   [attr.aria-label]="
     (hiddenPass() ? 'common.form.showPassword' : 'common.form.hidePassword') | translate

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
@@ -71,4 +71,9 @@ describe('InputPasswordWithVisibilityTypeComponent', () => {
     expect(button.getAttribute('aria-label')).toBe('common.form.hidePassword');
     expect(button.getAttribute('aria-pressed')).toBe('true');
   });
+
+  it('should be keyboard-focusable (not have tabindex="-1")', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('tabindex')).not.toBe('-1');
+  });
 });


### PR DESCRIPTION
This PR makes the password visibility toggle button in \`InputPasswordWithVisibilityTypeComponent\` keyboard-focusable by removing the \`tabindex="-1"\` attribute. This ensures that users relying on keyboard navigation can access and use the toggle functionality, improving the overall accessibility of the login and password reset forms.

💡 **What**: Removed \`tabindex="-1"\` from the toggle button.
🎯 **Why**: Previously, the button was unreachable via the Tab key, preventing keyboard-only users from revealing their password.
♿ **Accessibility**: Restored natural tab order for the interactive control.
✅ **Verification**: 
- Added a unit test asserting the absence of \`tabindex="-1"\`.
- Verified via Playwright script that the button receives focus after tabbing from the password input.

---
*PR created automatically by Jules for task [10067133641096258035](https://jules.google.com/task/10067133641096258035) started by @plastikaweb*