### PR TITLE
🎨 Palette: improve keyboard accessibility for password visibility toggle

### DIFF
--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
@@ -14,7 +14,6 @@
 <button
   matIconButton
   matSuffix
-  tabindex="-1"
   type="button"
   [attr.aria-label]="
     (hiddenPass() ? 'common.form.showPassword' : 'common.form.hidePassword') | translate

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
@@ -71,4 +71,9 @@ describe('InputPasswordWithVisibilityTypeComponent', () => {
     expect(button.getAttribute('aria-label')).toBe('common.form.hidePassword');
     expect(button.getAttribute('aria-pressed')).toBe('true');
   });
+
+  it('should be keyboard focusable', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('tabindex')).not.toBe('-1');
+  });
 });


### PR DESCRIPTION
💡 **What:** Removed `tabindex="-1"` from the password visibility toggle button in the `InputPasswordWithVisibilityTypeComponent`.
🎯 **Why:** This solves task **A11Y-006** and ensures the toggle is keyboard-accessible, improving overall WCAG 2.1 AA compliance. Previously, keyboard users were unable to reach the toggle button to verify their password input.
♿ **Accessibility:** The toggle is now reachable via the `Tab` key, making it accessible to keyboard-only and screen reader users.

**Verification:**
- Ran `yarn nx test input-password-with-visibility` (all 4 tests passed, including the new focusability check).
- Ran `yarn nx lint input-password-with-visibility` (clean).
- Recorded learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [1593123333125749249](https://jules.google.com/task/1593123333125749249) started by @plastikaweb*