### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in confirm dialog and snackbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-08] - Workspace: SEC-03 — XSS in confirm-dialog translation params + snackbar
+
+### Fixed
+
+- **`libs/shared/confirm/data-access`**: In `SharedConfirmFeatureComponent`, the `message()` signal processed dynamic parameters into a translation string that was سپس marked as "trusted" via `DomSanitizer.bypassSecurityTrustHtml`. Because `ngx-translate` does not automatically escape interpolation parameters, a malicious payload in a parameter (e.g., a product name containing `<img src=x onerror=alert(1)>`) was rendered as live markup — a reflected XSS vector. Now manually escapes each string value in `data.params` with the `escapeHtml` utility before passing them to the translation service, so while the translation file itself can safely contain HTML (like `<b>`), dynamic parameters cannot. Added a unit test verifying that malicious tags in parameters are escaped in the final signal output. Completes SEC-03 ([#86ca5gpx8](https://app.clickup.com/t/86ca5gpx8)).
+- **`libs/shared/notification/ui/mat-snackbar`**: Replaced `[innerHTML]="data.message"` with standard Angular interpolation `{{ data.message }}` in `NotificationUiMatSnackbarComponent`. This ensures notification messages are rendered as safe plain text by default, eliminating XSS risk from untrusted messages.
+
 ## [2026-06-07] - Workspace: SEC-02 follow-up — Reverse-tabnabbing on `nasa-images` FAQ links
 
 ### Fixed

--- a/apps/eco-store/TASKS.md
+++ b/apps/eco-store/TASKS.md
@@ -413,7 +413,7 @@ All `COULD`, pending discovery.
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ----------- |
 | **SEC-01** ✅      | XSS: `escapeHtml` in `SharedUtilFormattersService` (`defaultFormatter` + `booleanWithIconFormatter`) — HIGH                                         | **Urgent** | `86ca59u6g` |
 | **SEC-02** ✅      | Reverse-tabnabbing: `rel="noopener noreferrer"` on all `target="_blank"` links (workspace-wide) — MEDIUM                                            | SHOULD     | `86ca59u43` |
-| **SEC-03** _(new)_ | XSS: `SharedConfirmFeatureComponent` (`shared-confirm-feature.component.ts:34-35`) `bypassSecurityTrustHtml` on unescaped `translate` params — HIGH | **Urgent** | `86ca5gpx8` |
+| **SEC-03** ✅      | XSS: `SharedConfirmFeatureComponent` (`shared-confirm-feature.component.ts:34-35`) `bypassSecurityTrustHtml` on unescaped `translate` params — HIGH | **Urgent** | `86ca5gpx8` |
 
 ### Ops / Release
 

--- a/apps/eco-store/TASKS.md
+++ b/apps/eco-store/TASKS.md
@@ -409,11 +409,11 @@ All `COULD`, pending discovery.
 
 ### Security
 
-| ID                 | Description                                                                                                                                         | Priority   | ClickUp     |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ----------- |
-| **SEC-01** ✅      | XSS: `escapeHtml` in `SharedUtilFormattersService` (`defaultFormatter` + `booleanWithIconFormatter`) — HIGH                                         | **Urgent** | `86ca59u6g` |
-| **SEC-02** ✅      | Reverse-tabnabbing: `rel="noopener noreferrer"` on all `target="_blank"` links (workspace-wide) — MEDIUM                                            | SHOULD     | `86ca59u43` |
-| **SEC-03** ✅      | XSS: `SharedConfirmFeatureComponent` (`shared-confirm-feature.component.ts:34-35`) `bypassSecurityTrustHtml` on unescaped `translate` params — HIGH | **Urgent** | `86ca5gpx8` |
+| ID            | Description                                                                                                                                         | Priority   | ClickUp     |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ----------- |
+| **SEC-01** ✅ | XSS: `escapeHtml` in `SharedUtilFormattersService` (`defaultFormatter` + `booleanWithIconFormatter`) — HIGH                                         | **Urgent** | `86ca59u6g` |
+| **SEC-02** ✅ | Reverse-tabnabbing: `rel="noopener noreferrer"` on all `target="_blank"` links (workspace-wide) — MEDIUM                                            | SHOULD     | `86ca59u43` |
+| **SEC-03** ✅ | XSS: `SharedConfirmFeatureComponent` (`shared-confirm-feature.component.ts:34-35`) `bypassSecurityTrustHtml` on unescaped `translate` params — HIGH | **Urgent** | `86ca5gpx8` |
 
 ### Ops / Release
 

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
@@ -1,6 +1,7 @@
 import { DIALOG_DATA } from '@angular/cdk/dialog';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
@@ -16,6 +17,7 @@ describe('SharedConfirmFeatureComponent', () => {
       imports: [SharedConfirmFeatureComponent, TranslateModule.forRoot()],
       providers: [
         provideZonelessChangeDetection(),
+        provideRouter([]),
         {
           provide: DIALOG_DATA,
           useValue: {
@@ -45,5 +47,41 @@ describe('SharedConfirmFeatureComponent', () => {
     expect((component as unknown as { message: () => string }).message()?.toString()).toContain(
       'Hello test'
     );
+  });
+
+  it('should escape HTML in params', () => {
+    const maliciousName = '<img src=x onerror=alert(1)>';
+    const escapedName = '&lt;img src&#x3D;x onerror&#x3D;alert(1)&gt;';
+    translate.setTranslation('en', { 'test.xss': 'Hello {{name}}' }, true);
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [SharedConfirmFeatureComponent, TranslateModule.forRoot()],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        {
+          provide: DIALOG_DATA,
+          useValue: {
+            title: 'Title',
+            message: 'test.xss',
+            params: { name: maliciousName },
+            ok: 'OK',
+            ko: 'Cancel',
+          },
+        },
+      ],
+    });
+
+    const xssFixture = TestBed.createComponent(SharedConfirmFeatureComponent);
+    const xssComponent = xssFixture.componentInstance;
+    const xssTranslate = TestBed.inject(TranslateService);
+    xssTranslate.use('en');
+    xssTranslate.setTranslation('en', { 'test.xss': 'Hello {{name}}' });
+    xssFixture.detectChanges();
+
+    const output = (xssComponent.message() as any).changingThisBreaksApplicationSecurity;
+    expect(output).toContain(escapedName);
+    expect(output).not.toContain(maliciousName);
   });
 });

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
@@ -11,6 +11,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 import { RouterLink } from '@angular/router';
+import { escapeHtml } from '@plastik/shared/objects';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 @Component({
@@ -31,7 +32,17 @@ export class SharedConfirmFeatureComponent {
   protected readonly icon = computed(() => this.data.icon || 'help_outline');
 
   protected readonly message = computed(() => {
-    const translated = this.#translate.instant(this.data.message, this.data.params);
+    const params = this.data.params
+      ? Object.entries(this.data.params).reduce(
+          (acc, [key, value]) => ({
+            ...acc,
+            [key]: typeof value === 'string' ? escapeHtml(value) : value,
+          }),
+          {}
+        )
+      : undefined;
+
+    const translated = this.#translate.instant(this.data.message, params);
     return this.#sanitizer.bypassSecurityTrustHtml(translated);
   });
 }

--- a/libs/shared/notification/ui/mat-snackbar/src/lib/notification-ui-mat-snackbar/notification-ui-mat-snackbar.component.html
+++ b/libs/shared/notification/ui/mat-snackbar/src/lib/notification-ui-mat-snackbar/notification-ui-mat-snackbar.component.html
@@ -3,7 +3,7 @@
     @if (data.icon; as icon) {
       <mat-icon aria-hidden="true" class="basis-5 md:basis-2">{{ icon }}</mat-icon>
     }
-    <p class="text-balance" [innerHTML]="data.message"></p>
+    <p class="text-balance">{{ data.message }}</p>
   </div>
   @if (data.action; as action) {
     <button matButton matSnackBarAction [attr.aria-label]="data.ariaLabel" (click)="dismiss()">


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix XSS in confirm dialog and snackbar

🚨 **Severity:** HIGH
💡 **Vulnerability:** Reflected XSS via translation placeholders in `SharedConfirmFeatureComponent` and potential XSS in `NotificationUiMatSnackbarComponent`.
🎯 **Impact:** Malicious actors could execute arbitrary JavaScript in the user's browser context by providing crafted input (e.g., a product name with `<script>` tags) that is then displayed in a confirmation dialog or notification.
🔧 **Fix:** 
1.  **`SharedConfirmFeatureComponent`**: String values in `data.params` are now manually escaped using the `escapeHtml` utility before being passed to `ngx-translate`. This ensures that while the translation strings themselves can contain safe HTML (like `<b>`), any dynamic user-provided values are safely neutralized.
2.  **`NotificationUiMatSnackbarComponent`**: Replaced `[innerHTML]` with safe Angular interpolation `{{ data.message }}` to ensure notifications are rendered as plain text.
✅ **Verification:** Added a unit test in `shared-confirm-feature.component.spec.ts` that provides a malicious HTML payload in parameters and asserts that it is correctly escaped in the final output. Verified that all affected projects pass linting and unit tests.

---

### Security Learning recorded in `.jules/sentinel.md`:
**XSS in Translation Parameters**: `ngx-translate` interpolation parameters are not automatically escaped when the resulting string is subsequently marked as \"trusted\" via `DomSanitizer.bypassSecurityTrustHtml`. Always escape dynamic string parameters before passing them to a translation service if the result bypasses Angular's built-in XSS protection.

---
*PR created automatically by Jules for task [6952036253397248051](https://jules.google.com/task/6952036253397248051) started by @plastikaweb*