### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in SharedConfirmFeatureComponent and harden NotificationUiMatSnackbar

### DIFF
--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
@@ -1,6 +1,7 @@
 import { DIALOG_DATA } from '@angular/cdk/dialog';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
@@ -16,6 +17,7 @@ describe('SharedConfirmFeatureComponent', () => {
       imports: [SharedConfirmFeatureComponent, TranslateModule.forRoot()],
       providers: [
         provideZonelessChangeDetection(),
+        provideRouter([]),
         {
           provide: DIALOG_DATA,
           useValue: {
@@ -45,5 +47,38 @@ describe('SharedConfirmFeatureComponent', () => {
     expect((component as unknown as { message: () => string }).message()?.toString()).toContain(
       'Hello test'
     );
+  });
+
+  it('should escape HTML in params to prevent XSS', async () => {
+    const maliciousName = '<img src=x onerror=alert(1)>';
+    await TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [SharedConfirmFeatureComponent, TranslateModule.forRoot()],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        {
+          provide: DIALOG_DATA,
+          useValue: {
+            title: 'Title',
+            message: 'test.xss',
+            params: { name: maliciousName },
+            ok: 'OK',
+            ko: 'KO',
+          },
+        },
+      ],
+    }).compileComponents();
+
+    const fixtureXss = TestBed.createComponent(SharedConfirmFeatureComponent);
+    const translateXss = TestBed.inject(TranslateService);
+    translateXss.use('en');
+    translateXss.setTranslation('en', { 'test.xss': 'Hello {{name}}' });
+    fixtureXss.detectChanges();
+
+    const message = (fixtureXss.componentInstance as any).message();
+    const rawHtml = (message as any).changingThisBreaksApplicationSecurity;
+    expect(rawHtml).not.toContain(maliciousName);
+    expect(rawHtml).toContain('&lt;img');
   });
 });

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
@@ -11,6 +11,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 import { RouterLink } from '@angular/router';
+import { escapeHtml } from '@plastik/shared/objects';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 @Component({
@@ -31,7 +32,14 @@ export class SharedConfirmFeatureComponent {
   protected readonly icon = computed(() => this.data.icon || 'help_outline');
 
   protected readonly message = computed(() => {
-    const translated = this.#translate.instant(this.data.message, this.data.params);
+    const params = { ...this.data.params };
+    for (const key in params) {
+      if (typeof params[key] === 'string') {
+        params[key] = escapeHtml(params[key] as string);
+      }
+    }
+
+    const translated = this.#translate.instant(this.data.message, params);
     return this.#sanitizer.bypassSecurityTrustHtml(translated);
   });
 }

--- a/libs/shared/notification/ui/mat-snackbar/src/lib/notification-ui-mat-snackbar/notification-ui-mat-snackbar.component.html
+++ b/libs/shared/notification/ui/mat-snackbar/src/lib/notification-ui-mat-snackbar/notification-ui-mat-snackbar.component.html
@@ -3,7 +3,7 @@
     @if (data.icon; as icon) {
       <mat-icon aria-hidden="true" class="basis-5 md:basis-2">{{ icon }}</mat-icon>
     }
-    <p class="text-balance" [innerHTML]="data.message"></p>
+    <p class="text-balance">{{ data.message }}</p>
   </div>
   @if (data.action; as action) {
     <button matButton matSnackBarAction [attr.aria-label]="data.ariaLabel" (click)="dismiss()">


### PR DESCRIPTION
The PR addresses two security-related items in shared UI components:

1.  **XSS Protection in `SharedConfirmFeatureComponent`**:
    *   **Vulnerability**: The component used `DomSanitizer.bypassSecurityTrustHtml` on translated strings without escaping dynamic interpolation parameters (`params`). This allowed an attacker to inject malicious HTML if they could control the content of those parameters.
    *   **Fix**: All string values in `data.params` are now manually escaped using the `escapeHtml` utility before being passed to `TranslateService`.
    *   **Verification**: A new unit test `should escape HTML in params to prevent XSS` was added to `shared-confirm-feature.component.spec.ts`.

2.  **Hardening `NotificationUiMatSnackbarComponent`**:
    *   **Vulnerability**: The component rendered the notification message using `[innerHTML]`, posing an XSS risk if the message contained unsanitized user input.
    *   **Fix**: Replaced `[innerHTML]` with standard Angular interpolation `{{ data.message }}`.
    *   **Verification**: Verified with existing unit tests for `shared-notification-ui-mat-snackbar`.

All changes were verified with `yarn nx test` and `yarn nx lint`.

---
*PR created automatically by Jules for task [18191106678707574856](https://jules.google.com/task/18191106678707574856) started by @plastikaweb*