### PR TITLE
🎨 Palette: Make password visibility toggle keyboard-focusable

### DIFF
--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
@@ -14,7 +14,6 @@
 <button
   matIconButton
   matSuffix
-  tabindex="-1"
   type="button"
   [attr.aria-label]="
     (hiddenPass() ? 'common.form.showPassword' : 'common.form.hidePassword') | translate

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
@@ -71,4 +71,9 @@ describe('InputPasswordWithVisibilityTypeComponent', () => {
     expect(button.getAttribute('aria-label')).toBe('common.form.hidePassword');
     expect(button.getAttribute('aria-pressed')).toBe('true');
   });
+
+  it('should be keyboard-focusable', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('tabindex')).not.toBe('-1');
+  });
 });


### PR DESCRIPTION
### 💡 What
Removed \`tabindex="-1"\` from the password visibility toggle button in the \`input-password-with-visibility\` component.

### 🎯 Why
The password visibility toggle was previously excluded from the keyboard tab order. This prevented keyboard-only and screen-reader users from being able to toggle the password visibility, making it impossible for them to verify their input before submission—a critical usability and accessibility hurdle.

### ♿ Accessibility
-   **WCAG 2.1 AA Compliance**: Ensures all interactive elements are reachable via keyboard navigation.
-   **Inclusive Design**: Allows users who cannot use a mouse to benefit from the "show password" feature.

### ✅ Verification
-   **Tests**: Added a new unit test in \`input-password-with-visibility-type.component.spec.ts\` to assert that the button is keyboard-focusable.
-   **Lint**: Verified that the changes pass ESLint checks.
-   **Manual/Visual**: Verified using a Playwright script that the toggle button correctly receives focus when tabbing from the password field.

---
*PR created automatically by Jules for task [17237949229145057240](https://jules.google.com/task/17237949229145057240) started by @plastikaweb*