### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in SharedConfirmFeatureComponent

### DIFF
--- a/apps/eco-store/TASKS.md
+++ b/apps/eco-store/TASKS.md
@@ -413,7 +413,7 @@ All `COULD`, pending discovery.
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ----------- |
 | **SEC-01** ✅      | XSS: `escapeHtml` in `SharedUtilFormattersService` (`defaultFormatter` + `booleanWithIconFormatter`) — HIGH                                         | **Urgent** | `86ca59u6g` |
 | **SEC-02** ✅      | Reverse-tabnabbing: `rel="noopener noreferrer"` on all `target="_blank"` links (workspace-wide) — MEDIUM                                            | SHOULD     | `86ca59u43` |
-| **SEC-03** _(new)_ | XSS: `SharedConfirmFeatureComponent` (`shared-confirm-feature.component.ts:34-35`) `bypassSecurityTrustHtml` on unescaped `translate` params — HIGH | **Urgent** | `86ca5gpx8` |
+| **SEC-03** ✅      | XSS: `SharedConfirmFeatureComponent` (`shared-confirm-feature.component.ts:34-35`) `bypassSecurityTrustHtml` on unescaped `translate` params — HIGH | **Urgent** | `86ca5gpx8` |
 
 ### Ops / Release
 

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
@@ -46,4 +46,39 @@ describe('SharedConfirmFeatureComponent', () => {
       'Hello test'
     );
   });
+
+  it('should escape HTML in params to prevent XSS', () => {
+    const xssPayload = '<img src=x onerror=alert(1)>';
+    const escapedPayload = '&lt;img src&#x3D;x onerror&#x3D;alert(1)&gt;';
+    translate.setTranslation('en', { 'test.xss': 'Vulnerable {{payload}}' }, true);
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [SharedConfirmFeatureComponent, TranslateModule.forRoot()],
+      providers: [
+        provideZonelessChangeDetection(),
+        {
+          provide: DIALOG_DATA,
+          useValue: {
+            title: 'Title',
+            message: 'test.xss',
+            params: { payload: xssPayload },
+            ok: 'common.ok',
+            ko: 'common.cancel',
+          },
+        },
+      ],
+    });
+
+    const xssFixture = TestBed.createComponent(SharedConfirmFeatureComponent);
+    const xssComponent = xssFixture.componentInstance;
+    const xssTranslate = TestBed.inject(TranslateService);
+    xssTranslate.use('en');
+    xssTranslate.setTranslation('en', { 'test.xss': 'Vulnerable {{payload}}' });
+    xssFixture.detectChanges();
+
+    const message = (xssComponent as any).message().changingThisBreaksApplicationSecurity;
+    expect(message).toContain(escapedPayload);
+    expect(message).not.toContain(xssPayload);
+  });
 });

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
@@ -11,6 +11,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 import { RouterLink } from '@angular/router';
+import { escapeHtml } from '@plastik/shared/objects';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 @Component({
@@ -31,7 +32,15 @@ export class SharedConfirmFeatureComponent {
   protected readonly icon = computed(() => this.data.icon || 'help_outline');
 
   protected readonly message = computed(() => {
-    const translated = this.#translate.instant(this.data.message, this.data.params);
+    const params = { ...this.data.params };
+
+    for (const key in params) {
+      if (typeof params[key] === 'string') {
+        params[key] = escapeHtml(params[key]);
+      }
+    }
+
+    const translated = this.#translate.instant(this.data.message, params);
     return this.#sanitizer.bypassSecurityTrustHtml(translated);
   });
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS in SharedConfirmFeatureComponent

The `SharedConfirmFeatureComponent` uses `DomSanitizer.bypassSecurityTrustHtml` on translated strings to allow intended HTML in translation keys. However, `@ngx-translate/core` does not automatically escape interpolation parameters, creating a reflected XSS vulnerability when user-provided data is passed via `params`.

This change:
1.  Imports `escapeHtml` utility from `@plastik/shared/objects`.
2.  Updates `SharedConfirmFeatureComponent` to escape all string values in `data.params` before passing them to the translation service.
3.  Adds a comprehensive unit test verifying that XSS payloads in parameters are correctly escaped in the final `SafeHtml` output.

Ref: SEC-03, CU 86ca5gpx8.

---
*PR created automatically by Jules for task [10366182682115421681](https://jules.google.com/task/10366182682115421681) started by @plastikaweb*