### PR TITLE
🎨 Palette: Remove tabindex=-1 from password visibility toggle

### DIFF
--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
@@ -14,7 +14,6 @@
 <button
   matIconButton
   matSuffix
-  tabindex="-1"
   type="button"
   [attr.aria-label]="
     (hiddenPass() ? 'common.form.showPassword' : 'common.form.hidePassword') | translate

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
@@ -71,4 +71,9 @@ describe('InputPasswordWithVisibilityTypeComponent', () => {
     expect(button.getAttribute('aria-label')).toBe('common.form.hidePassword');
     expect(button.getAttribute('aria-pressed')).toBe('true');
   });
+
+  it('should be keyboard-focusable (no tabindex="-1")', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('tabindex')).not.toBe('-1');
+  });
 });


### PR DESCRIPTION
### 🎨 Palette: Remove tabindex=-1 from password visibility toggle

#### 💡 What:
Removed the `tabindex="-1"` attribute from the password visibility toggle button in the `input-password-with-visibility` component.

#### 🎯 Why:
The `tabindex="-1"` attribute prevented keyboard-only users from focusing on and activating the password visibility toggle. This made it impossible for them to verify their password input visually, which is a significant accessibility barrier.

#### ♿ Accessibility:
- Ensures the visibility toggle is part of the natural tab order.
- Complies with WCAG 2.1 AA standards for keyboard accessibility.
- Verified that the toggle receives focus via Tab from the password input field.

#### ✅ Verification:
- Added a unit test to `input-password-with-visibility-type.component.spec.ts` to ensure the button is keyboard-focusable.
- Performed visual and interaction verification using a Playwright script on the `/accedir` route of the `eco-store` application.
- All tests passed.

---
*PR created automatically by Jules for task [4757461026537860971](https://jules.google.com/task/4757461026537860971) started by @plastikaweb*