### PR TITLE
🎨 Palette: fix password visibility toggle accessibility

### DIFF
--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
@@ -14,7 +14,6 @@
 <button
   matIconButton
   matSuffix
-  tabindex="-1"
   type="button"
   [attr.aria-label]="
     (hiddenPass() ? 'common.form.showPassword' : 'common.form.hidePassword') | translate

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
@@ -71,4 +71,9 @@ describe('InputPasswordWithVisibilityTypeComponent', () => {
     expect(button.getAttribute('aria-label')).toBe('common.form.hidePassword');
     expect(button.getAttribute('aria-pressed')).toBe('true');
   });
+
+  it('should be keyboard focusable', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('tabindex')).not.toBe('-1');
+  });
 });


### PR DESCRIPTION
This PR improves the accessibility of the password visibility toggle in the `input-password-with-visibility` component by removing the `tabindex="-1"` attribute. This allows keyboard users to reach the button via the `Tab` key.

💡 What: Removed `tabindex="-1"` from the toggle button.
🎯 Why: To make the password visibility feature accessible to keyboard-only users.
♿ Accessibility: Ensures compliance with WCAG 2.1 AA by making interactive elements focusable.
✅ Verified: Unit tests passed, and Playwright verification confirmed the button is now in the tab order on the login page.

---
*PR created automatically by Jules for task [14928620406597837085](https://jules.google.com/task/14928620406597837085) started by @plastikaweb*