### PR TITLE
🎨 Palette: Fix keyboard accessibility for password visibility toggle

### DIFF
--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.html
@@ -14,7 +14,6 @@
 <button
   matIconButton
   matSuffix
-  tabindex="-1"
   type="button"
   [attr.aria-label]="
     (hiddenPass() ? 'common.form.showPassword' : 'common.form.hidePassword') | translate

--- a/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
+++ b/libs/shared/form/ui/input-password-with-visibility/src/lib/input-password-with-visibility-type.component.spec.ts
@@ -71,4 +71,9 @@ describe('InputPasswordWithVisibilityTypeComponent', () => {
     expect(button.getAttribute('aria-label')).toBe('common.form.hidePassword');
     expect(button.getAttribute('aria-pressed')).toBe('true');
   });
+
+  it('should be keyboard-focusable (no tabindex="-1")', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('tabindex')).not.toBe('-1');
+  });
 });


### PR DESCRIPTION
### 🎨 Palette: Fix keyboard accessibility for password visibility toggle

#### 💡 What: The UX enhancement added
Removed the `tabindex="-1"` attribute from the password visibility toggle button in the `input-password-with-visibility` component. Added a unit test to ensure the button remains in the tab order.

#### 🎯 Why: The user problem it solves
Previously, keyboard users could not access the password visibility toggle because it was explicitly excluded from the tab order. This prevented them from verifying their input or using the feature entirely.

#### ♿ Accessibility: Any a11y improvements made
- Restored natural tab order for the interactive visibility toggle button.
- Ensures compliance with WCAG 2.1 AA regarding keyboard accessibility.
- Verified that the button is focusable and functional using keyboard only (Tab + Enter).

#### 📸 Before/After: Screenshots if visual change
The visual appearance remains the same, but the element now correctly receives the focus indicator when tabbing through the form.
Verification screenshot shows the focus state and tooltip active on the toggle button after tabbing from the password field.

---
*PR created automatically by Jules for task [6400451409729808743](https://jules.google.com/task/6400451409729808743) started by @plastikaweb*