### PR TITLE
🎨 Palette: Enhance search input accessibility and UX

### DIFF
--- a/apps/eco-store/public/i18n/ca.json
+++ b/apps/eco-store/public/i18n/ca.json
@@ -66,7 +66,9 @@
       "charactersCount": "{count, plural, one {caràcter} other {caràcters}}",
       "password": "Contrasenya",
       "showPassword": "Mostrar contrasenya",
-      "hidePassword": "Amagar contrasenya"
+      "hidePassword": "Amagar contrasenya",
+      "search": "Cercar",
+      "clear": "Netejar"
     },
     "a11y": {
       "skipToContent": "Saltar al contingut principal",

--- a/apps/eco-store/public/i18n/en.json
+++ b/apps/eco-store/public/i18n/en.json
@@ -66,7 +66,9 @@
       "charactersCount": "{count, plural, one {character} other {characters}}",
       "password": "Password",
       "showPassword": "Show password",
-      "hidePassword": "Hide password"
+      "hidePassword": "Hide password",
+      "search": "Search",
+      "clear": "Clear"
     },
     "a11y": {
       "skipToContent": "Skip to main content",

--- a/apps/eco-store/public/i18n/es.json
+++ b/apps/eco-store/public/i18n/es.json
@@ -66,7 +66,9 @@
       "charactersCount": "{count, plural, one {carácter} other {caracteres}}",
       "password": "Contraseña",
       "showPassword": "Mostrar contraseña",
-      "hidePassword": "Ocultar contraseña"
+      "hidePassword": "Ocultar contraseña",
+      "search": "Buscar",
+      "clear": "Limpiar"
     },
     "a11y": {
       "skipToContent": "Saltar al contenido principal",

--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.html
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.html
@@ -19,7 +19,8 @@
       matIconButton
       matSuffix
       type="button"
-      [attr.aria-label]="'form.search' | translate"
+      [attr.aria-label]="'common.form.search' | translate"
+      [matTooltip]="'common.form.search' | translate"
       [disabled]="isDisabled()"
       (click)="triggerSearch($event)">
       <mat-icon aria-hidden="true">search</mat-icon>
@@ -31,10 +32,11 @@
       matIconButton
       matSuffix
       type="button"
-      [attr.aria-label]="'form.clear' | translate"
-      [disabled]="isDisabled()"
+      [attr.aria-label]="'common.form.clear' | translate"
+      [matTooltip]="'common.form.clear' | translate"
+      [disabled]="formStatus() === 'INVALID' && !props.buttonEnabledIfValue"
       (click)="resetSearch()">
-      <mat-icon>clear</mat-icon>
+      <mat-icon aria-hidden="true">clear</mat-icon>
     </button>
   }
 </mat-form-field>

--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.spec.ts
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.spec.ts
@@ -99,4 +99,24 @@ describe('InputSearchTypeComponent', () => {
       expect(onPartialSearchSpy).toHaveBeenCalledWith('abc', component.field);
     });
   });
+
+  describe('isDisabled', () => {
+    it('should return true if term length is 1 and minLength is 2', () => {
+      component.formControl.setValue('a');
+      component['syncControl']();
+      expect(component['isDisabled']()).toBe(true);
+    });
+
+    it('should return false if term length is 0', () => {
+      component.formControl.setValue('');
+      component['syncControl']();
+      expect(component['isDisabled']()).toBe(false);
+    });
+
+    it('should return false if term length is >= minLength', () => {
+      component.formControl.setValue('ab');
+      component['syncControl']();
+      expect(component['isDisabled']()).toBe(false);
+    });
+  });
 });

--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.ts
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.ts
@@ -12,6 +12,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatTooltip } from '@angular/material/tooltip';
 import { FieldTypeConfig, FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
 import { FieldType } from '@ngx-formly/material/form-field';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -31,6 +32,7 @@ export type InputSearchProps = FieldTypeConfig['props'] & {
     MatButtonModule,
     MatIconModule,
     MatInputModule,
+    MatTooltip,
     FormlyModule,
     ReactiveFormsModule,
     TranslatePipe,


### PR DESCRIPTION
### 🎨 Palette: Enhance search input accessibility and UX

#### 💡 What:
- Added tooltips to the search and clear buttons in the shared search input component.
- Standardized translation keys to `common.form.search` and `common.form.clear`.
- Decoupled the "Clear" button's disabled state from the "Search" button's minimum length requirement.
- Added missing translation keys to all application locales.

#### 🎯 Why:
- Icon-only buttons were missing visual labels (tooltips), making them less intuitive for some users.
- The "Clear" button was frustratingly disabled when a user typed only 1 character (below the `minLength` of 2), preventing them from clearing the input easily.
- Inconsistent translation keys were causing broken labels in some parts of the app.

#### ♿ Accessibility:
- Added `matTooltip` for visual hover feedback.
- Ensured `aria-label` is present and correctly localized for screen readers.
- Added `aria-hidden="true"` to decorative icons.

#### ✅ Verification:
- Ran `yarn nx test input-search` (9 tests passed, including new cases).
- Ran `yarn nx lint input-search` (passed).
- Updated `.Jules/palette.md` with UX learnings.

---
*PR created automatically by Jules for task [16351418018773726526](https://jules.google.com/task/16351418018773726526) started by @plastikaweb*