### PR TITLE
🎨 Palette: Improve search input accessibility and UX

### DIFF
--- a/apps/eco-store/public/i18n/ca.json
+++ b/apps/eco-store/public/i18n/ca.json
@@ -66,7 +66,9 @@
       "charactersCount": "{count, plural, one {caràcter} other {caràcters}}",
       "password": "Contrasenya",
       "showPassword": "Mostrar contrasenya",
-      "hidePassword": "Amagar contrasenya"
+      "hidePassword": "Amagar contrasenya",
+      "search": "Cercar",
+      "clear": "Netejar"
     },
     "a11y": {
       "skipToContent": "Saltar al contingut principal",

--- a/apps/eco-store/public/i18n/en.json
+++ b/apps/eco-store/public/i18n/en.json
@@ -66,7 +66,9 @@
       "charactersCount": "{count, plural, one {character} other {characters}}",
       "password": "Password",
       "showPassword": "Show password",
-      "hidePassword": "Hide password"
+      "hidePassword": "Hide password",
+      "search": "Search",
+      "clear": "Clear"
     },
     "a11y": {
       "skipToContent": "Skip to main content",

--- a/apps/eco-store/public/i18n/es.json
+++ b/apps/eco-store/public/i18n/es.json
@@ -66,7 +66,9 @@
       "charactersCount": "{count, plural, one {carácter} other {caracteres}}",
       "password": "Contraseña",
       "showPassword": "Mostrar contraseña",
-      "hidePassword": "Ocultar contraseña"
+      "hidePassword": "Ocultar contraseña",
+      "search": "Buscar",
+      "clear": "Limpiar"
     },
     "a11y": {
       "skipToContent": "Saltar al contenido principal",

--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.html
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.html
@@ -20,19 +20,21 @@
       matSuffix
       type="button"
       [attr.aria-label]="'form.search' | translate"
+      [matTooltip]="'form.search' | translate"
       [disabled]="isDisabled()"
       (click)="triggerSearch($event)">
       <mat-icon aria-hidden="true">search</mat-icon>
     </button>
   }
-  @if (props.resetSearch && formControl.value) {
+  @if (props.resetSearch && formValue()) {
     <button
       class="reset-search-button -left-2"
       matIconButton
       matSuffix
       type="button"
       [attr.aria-label]="'form.clear' | translate"
-      [disabled]="isDisabled()"
+      [matTooltip]="'form.clear' | translate"
+      [disabled]="formControl.disabled"
       (click)="resetSearch()">
       <mat-icon>clear</mat-icon>
     </button>

--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.spec.ts
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatTooltip } from '@angular/material/tooltip';
+import { By } from '@angular/platform-browser';
 import { FormlyModule } from '@ngx-formly/core';
 import { provideTranslateService } from '@ngx-translate/core';
 import { InputSearchTypeComponent } from './input-search-type.component';
@@ -44,6 +46,16 @@ describe('InputSearchTypeComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should have tooltips on buttons', () => {
+    component.field.props!.resetSearch = true;
+    component.formControl.setValue('abc');
+    component['syncControl']();
+    fixture.detectChanges();
+
+    const buttons = fixture.debugElement.queryAll(By.directive(MatTooltip));
+    expect(buttons.length).toBeGreaterThan(0);
   });
 
   describe('triggerSearch', () => {
@@ -97,6 +109,31 @@ describe('InputSearchTypeComponent', () => {
 
       component['triggerPartialSearch']();
       expect(onPartialSearchSpy).toHaveBeenCalledWith('abc', component.field);
+    });
+  });
+
+  describe('resetSearch', () => {
+    it('should enable clear button even if search term is invalid', () => {
+      component.field.props!.resetSearch = true;
+      component.formControl.setValue('a');
+      component['syncControl']();
+      fixture.detectChanges();
+
+      const clearBtn = fixture.nativeElement.querySelector('.reset-search-button');
+      expect(clearBtn).toBeTruthy();
+      expect(clearBtn.disabled).toBeFalsy();
+    });
+
+    it('should disable clear button if form control is disabled', () => {
+      component.field.props!.resetSearch = true;
+      component.formControl.setValue('abc');
+      component.formControl.disable();
+      component['syncControl']();
+      fixture.detectChanges();
+
+      const clearBtn = fixture.nativeElement.querySelector('.reset-search-button');
+      expect(clearBtn).toBeTruthy();
+      expect(clearBtn.disabled).toBeTruthy();
     });
   });
 });

--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.ts
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.ts
@@ -12,6 +12,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatTooltip } from '@angular/material/tooltip';
 import { FieldTypeConfig, FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
 import { FieldType } from '@ngx-formly/material/form-field';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -31,6 +32,7 @@ export type InputSearchProps = FieldTypeConfig['props'] & {
     MatButtonModule,
     MatIconModule,
     MatInputModule,
+    MatTooltip,
     FormlyModule,
     ReactiveFormsModule,
     TranslatePipe,


### PR DESCRIPTION
### 🎨 Palette: Improve search input accessibility and UX

#### 💡 What:
Improved the search input component (`InputSearchTypeComponent`) by adding accessible tooltips to its action buttons and refining the interaction logic for clearing search terms.

#### 🎯 Why:
1. **Accessibility:** Icon-only buttons (Search and Clear) now have `matTooltip` in addition to `aria-label`, providing visual hints for mouse users and ensuring compliance with the project's UX standards.
2. **Usability:** Fixed a logic bug where the "Clear" button was disabled if the search term was shorter than the `minLength` (e.g., 1 character). This prevented users from easily clearing a "too short" term via the button. Now, the Clear button is enabled as long as the input has a value and the control is not disabled.
3. **Consistency:** Added missing `form.search` and `form.clear` translation keys to English, Spanish, and Catalan locale files to ensure the tooltips and ARIA labels are correctly localized.

#### ♿ Accessibility:
- Added `matTooltip` to all icon buttons.
- Ensured `aria-label` and `matTooltip` use the same localized strings.
- Improved keyboard/mouse flow by allowing clearing of invalid short inputs.

#### ✅ Verification:
- Ran `yarn nx test input-search` (9/9 passed, including new test cases for tooltip presence and clear button state).
- Ran `yarn nx lint input-search` (Passed).
- Ran `yarn i18n:validate` (Passed).

---
*PR created automatically by Jules for task [4828174129273917843](https://jules.google.com/task/4828174129273917843) started by @plastikaweb*