### PR TITLE
ci: pre-push builds affected projects + skips a11y for docs-only changes

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -23,14 +23,15 @@ if ! yarn nx affected --target=test --parallel --max-parallel=2 --cache; then
 fi
 
 echo "🏗️  Running affected build..."
-# Build production configuration to ensure it's valid
-# Reduced parallelization to avoid disk I/O bottleneck
-if ! yarn nx run-many --target=build --configuration=production --parallel --max-parallel=2; then
+# Build the AFFECTED projects in production configuration to ensure they're valid.
+# `affected` (not `run-many`) so a small change doesn't rebuild every project;
+# `--cache` reuses prior valid build output. Reduced parallelization avoids disk I/O bottleneck.
+if ! yarn nx affected --target=build --configuration=production --parallel --max-parallel=2 --cache; then
   echo "❌ Build failed! Push aborted."
   exit 1
 fi
 
-if echo "$CHANGED_FILES" | grep -Eq '^(apps/eco-store/|libs/eco-store/)'; then
+if echo "$NON_MD_CHANGED" | grep -Eq '^(apps/eco-store/|libs/eco-store/)'; then
   echo "🏁 Running eco-store:a11y (using existing build)..."
   if ! yarn npm-run-all --parallel --race eco-store:http-server eco-store:a11y:run; then
     echo "❌ eco-store:a11y failed! Push aborted."
@@ -40,7 +41,7 @@ else
   echo "ℹ️ Skipping eco-store:a11y (no eco-store changes)"
 fi
 
-if echo "$CHANGED_FILES" | grep -Eq '^(apps/nasa-images/|libs/nasa-images/)'; then
+if echo "$NON_MD_CHANGED" | grep -Eq '^(apps/nasa-images/|libs/nasa-images/)'; then
   echo "🏁 Running nasa-images:a11y (using existing build)..."
   if ! yarn npm-run-all --parallel --race nasa-images:http-server nasa-images:a11y:run; then
     echo "❌ nasa-images:a11y failed! Push aborted."


### PR DESCRIPTION
## Speed up `.husky/pre-push`

The pre-push hook was slow because it did more than affected tests. Two fixes:

### 1. Build affected projects, not all of them
- **Before:** `nx run-many --target=build --configuration=production` — rebuilt **every** app/lib on every push, even for a one-function change.
- **After:** `nx affected --target=build --configuration=production --cache` — builds only what the diff impacts (mirroring the existing affected-test step) and reuses cached build output.

### 2. Don't run a11y for docs-only changes
- **Before:** the eco-store / nasa-images Pa11y gates matched the raw `CHANGED_FILES` against `^(apps/eco-store/|libs/eco-store/)` — so editing `apps/eco-store/TASKS.md` or `BACKLOG.md` triggered a full eco-store **build + http-server + Pa11y** run.
- **After:** they match `NON_MD_CHANGED` (already computed for the markdown-only fast path), so a docs-only change no longer triggers a11y.

### Safety
- Affected **tests** were already affected-only — unchanged.
- **CI** (`.github/workflows/ci.yml`) still runs the full lint/test/build matrix on `develop`, so cross-project build validity is still gated there; this only trims the local pre-push to what the push actually touches.
- Trade-off: `run-many` would have caught breakage in a project nx doesn't model as "affected" (rare, e.g. unmodeled implicit deps). CI remains the backstop.

### Validated
This branch's own push exercised the new hook: affected tests/build ran with no affected projects (fast), and both a11y suites were correctly **skipped** (`ℹ️ Skipping eco-store:a11y (no eco-store changes)`), then `✅ All checks passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rci3KvkjivGpHEEdVzyKoP
