### PR TITLE
fix: remove unsupported --cache flag from pre-push affected build

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -24,9 +24,11 @@ fi
 
 echo "🏗️  Running affected build..."
 # Build the AFFECTED projects in production configuration to ensure they're valid.
-# `affected` (not `run-many`) so a small change doesn't rebuild every project;
-# `--cache` reuses prior valid build output. Reduced parallelization avoids disk I/O bottleneck.
-if ! yarn nx affected --target=build --configuration=production --parallel --max-parallel=2 --cache; then
+# `affected` (not `run-many`) so a small change doesn't rebuild every project. Nx caches
+# `build` automatically (cacheable target), so no `--cache` flag is needed — and the Angular
+# build executor rejects it ("'cache' is not found in schema"). Reduced parallelization
+# avoids a disk I/O bottleneck.
+if ! yarn nx affected --target=build --configuration=production --parallel --max-parallel=2; then
   echo "❌ Build failed! Push aborted."
   exit 1
 fi


### PR DESCRIPTION
## Hotfix: `--cache` breaks the pre-push affected build

Regression introduced by #1178. The build step was changed to:

```
nx affected --target=build --configuration=production --parallel --max-parallel=2 --cache
```

The Angular build executor's option schema has no `cache` property, so nx aborts with **`'cache' is not found in schema`**. Every non-markdown push that has an affected **app** build (eco-store / llecoop / nasa-images) fails at pre-push.

It slipped through #1178's own validation because that PR only touched `.husky/pre-push`, which affects **no** buildable projects — so the affected build was empty and the bad flag never reached a real executor.

### Fix
Remove `--cache` from the build line. Nx caches the `build` target automatically (it's a cacheable target), so the flag was redundant as well as invalid. The `--cache` on the **test** line stays — the vitest executor accepts it.

### Verified
- `nx build nasa-images --configuration=production --cache` → reproduces `'cache' is not found in schema`.
- `nx build nasa-images --configuration=production` → **succeeds** (`Successfully ran target build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rci3KvkjivGpHEEdVzyKoP
