### PR TITLE
🎨 Palette: add tooltip to SharedAlert close button

### DIFF
--- a/libs/shared/alert/ui/src/lib/shared-alert-ui/shared-alert-ui.component.html
+++ b/libs/shared/alert/ui/src/lib/shared-alert-ui/shared-alert-ui.component.html
@@ -19,6 +19,7 @@
     matIconButton
     class="absolute! top-1 right-1 opacity-70 hover:opacity-100"
     [attr.aria-label]="'common.close' | translate"
+    [matTooltip]="'common.close' | translate"
     (click)="closed.emit()">
     <mat-icon>close</mat-icon>
   </button>

--- a/libs/shared/alert/ui/src/lib/shared-alert-ui/shared-alert-ui.component.spec.ts
+++ b/libs/shared/alert/ui/src/lib/shared-alert-ui/shared-alert-ui.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatTooltip } from '@angular/material/tooltip';
 import { By } from '@angular/platform-browser';
 import { TranslateModule } from '@ngx-translate/core';
 import { axe } from 'vitest-axe';
@@ -79,6 +80,18 @@ describe('SharedAlertUiComponent', () => {
   it('should have role="alert" on the host', () => {
     createComponent('WARNING');
     expect(fixture.nativeElement.getAttribute('role')).toBe('alert');
+  });
+
+  it('should have a matTooltip on the close button that matches its aria-label', () => {
+    fixture = createComponent('INFO', true);
+    const closeBtn = fixture.debugElement.query(By.css('button[matIconButton]'));
+    expect(closeBtn).toBeTruthy();
+
+    const ariaLabel = closeBtn.nativeElement.getAttribute('aria-label');
+    const tooltipDirective = closeBtn.injector.get(MatTooltip, null);
+
+    expect(tooltipDirective).toBeTruthy();
+    expect(tooltipDirective?.message).toBe(ariaLabel);
   });
 
   it('should pass accessibility check for INFO type', async () => {

--- a/libs/shared/alert/ui/src/lib/shared-alert-ui/shared-alert-ui.component.ts
+++ b/libs/shared/alert/ui/src/lib/shared-alert-ui/shared-alert-ui.component.ts
@@ -1,12 +1,13 @@
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { ALERT_ICONS, AlertType } from '@plastik/core/entities';
 
 @Component({
   selector: 'plastik-shared-alert',
-  imports: [MatIconModule, MatButtonModule, TranslateModule],
+  imports: [MatIconModule, MatButtonModule, MatTooltipModule, TranslateModule],
   templateUrl: './shared-alert-ui.component.html',
   styleUrl: './shared-alert-ui.component.scss',
   host: {


### PR DESCRIPTION
I added a `matTooltip` to the close button in the `SharedAlertUiComponent`. This ensures that sighted mouse users get a visual hint about the button's function, while maintaining accessibility for screen readers via the existing `aria-label`.

Key changes:
- Imported `MatTooltipModule` in `SharedAlertUiComponent`.
- Added `[matTooltip]` to the close button in `shared-alert-ui.component.html`.
- Updated `shared-alert-ui.component.spec.ts` with a test case to verify that the tooltip is correctly applied and matches the `aria-label`.
- Updated `.jules/palette.md` with learnings regarding icon-only button tooltip consistency.

---
*PR created automatically by Jules for task [16157108408151409108](https://jules.google.com/task/16157108408151409108) started by @plastikaweb*