### PR TITLE
🎨 Palette: Improve textarea character counter accessibility and feedback

### DIFF
--- a/libs/shared/form/ui/textarea-with-counter/src/lib/textarea-with-counter-type.component.html
+++ b/libs/shared/form/ui/textarea-with-counter/src/lib/textarea-with-counter-type.component.html
@@ -15,8 +15,16 @@
     [maxLength]="props.maxLength"
     [minLength]="props.minLength"
     [cdkAutosizeMaxRows]="to['maxRows']"></textarea>
-  <mat-hint [class]="`text-sm ${ta.value.length >= ta.maxLength ? 'text-error' : ''}`"
-    >{{ ta.value.length }} / {{ props.maxLength }}
-    {{ 'common.form.charactersCount' | translate: { count: props.maxLength } }}</mat-hint
-  >
+  <mat-hint
+    class="text-sm"
+    aria-live="polite"
+    [class.text-error]="ta.value.length >= ta.maxLength"
+    [class.text-warning]="
+      props.maxLength &&
+      ta.value.length >= props.maxLength * 0.9 &&
+      ta.value.length < props.maxLength
+    ">
+    {{ ta.value.length }} / {{ props.maxLength || 0 }}
+    {{ 'common.form.charactersCount' | translate: { count: props.maxLength } }}
+  </mat-hint>
 </mat-form-field>

--- a/libs/shared/form/ui/textarea-with-counter/src/lib/textarea-with-counter-type.component.spec.ts
+++ b/libs/shared/form/ui/textarea-with-counter/src/lib/textarea-with-counter-type.component.spec.ts
@@ -50,4 +50,38 @@ describe('TextareaWithCounterTypeComponent', () => {
   test('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  test('should have aria-live="polite" on the character counter', () => {
+    const hint = fixture.nativeElement.querySelector('mat-hint');
+    expect(hint.getAttribute('aria-live')).toBe('polite');
+  });
+
+  test('should apply text-warning class when character count is >= 90% and < maxLength', () => {
+    const maxLength = 100;
+    component.formControl.setValue('a'.repeat(90));
+    fixture.detectChanges();
+
+    const hint = fixture.nativeElement.querySelector('mat-hint');
+    expect(hint.classList.contains('text-warning')).toBe(true);
+    expect(hint.classList.contains('text-error')).toBe(false);
+  });
+
+  test('should apply text-error class when character count is >= maxLength', () => {
+    const maxLength = 100;
+    component.formControl.setValue('a'.repeat(maxLength));
+    fixture.detectChanges();
+
+    const hint = fixture.nativeElement.querySelector('mat-hint');
+    expect(hint.classList.contains('text-error')).toBe(true);
+    expect(hint.classList.contains('text-warning')).toBe(false);
+  });
+
+  test('should not apply warning or error class when character count is < 90%', () => {
+    component.formControl.setValue('a'.repeat(89));
+    fixture.detectChanges();
+
+    const hint = fixture.nativeElement.querySelector('mat-hint');
+    expect(hint.classList.contains('text-warning')).toBe(false);
+    expect(hint.classList.contains('text-error')).toBe(false);
+  });
 });


### PR DESCRIPTION
💡 What: Added aria-live="polite" to the character counter in TextareaWithCounterTypeComponent and implemented a visual warning state (text-warning) when the character count reaches 90% of the maximum limit.
🎯 Why: To improve accessibility for screen reader users and provide proactive feedback to users before they reach the character limit.
♿ Accessibility: Screen readers will now announce character count updates as the user types.

---
*PR created automatically by Jules for task [9092449992413351216](https://jules.google.com/task/9092449992413351216) started by @plastikaweb*