### PR TITLE
⚡ Bolt: cache system timezone in SharedUtilFormattersService

### DIFF
--- a/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
+++ b/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
@@ -30,6 +30,12 @@ export class SharedUtilFormattersService {
   readonly #locale = inject(LOCALE_ID);
 
   /**
+   * The system timezone, cached to avoid expensive `Intl.DateTimeFormat().resolvedOptions().timeZone` calls.
+   * Calling `resolvedOptions()` repeatedly can take ~10ms per 100 calls, whereas caching reduces this to near-zero.
+   */
+  readonly #timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  /**
    * Formats a date value using the specified formatting options.
    * @param {FormattingDateInput} value The date value to format.
    * @param {() => Partial<Pick<FormattingExtras<'DATE'>, 'dateDigitsInfo' | 'locale' | 'timezone'>>} [extras] An optional function that returns additional formatting options, such as locale and timezone.
@@ -42,7 +48,7 @@ export class SharedUtilFormattersService {
     let format = {
       dateDigitsInfo: 'shortDate',
       locale: this.#locale,
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timezone: this.#timezone,
     };
 
     if (extras) {
@@ -69,7 +75,7 @@ export class SharedUtilFormattersService {
   ): string {
     let format = {
       locale: this.#locale,
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timezone: this.#timezone,
     };
 
     if (extras) {
@@ -95,7 +101,7 @@ export class SharedUtilFormattersService {
     let format = {
       dateDigitsInfo: 'shortDate',
       locale: this.#locale,
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timezone: this.#timezone,
     };
 
     if (extras) {


### PR DESCRIPTION
### 💡 What:
Implemented caching for the system timezone in `SharedUtilFormattersService`.

### 🎯 Why:
Repeatedly calling `Intl.DateTimeFormat().resolvedOptions().timeZone` is a known performance bottleneck. In this service, it was being called inline for every date, date-time, and Firebase timestamp formatting operation.

### 📊 Impact:
- **Baseline (repeated calls):** ~9462ms for 100,000 iterations.
- **Optimized (cached):** ~1.3ms for 100,000 iterations.
- **Improvement:** >7000x faster.
- **Benefit:** Significant overhead reduction when rendering large lists or tables containing formatted dates.

### 🔬 Measurement:
A standalone benchmark script (`timezone_bench.js`) was used to quantify the gain.
\`\`\`
Running benchmark with 100000 iterations...
Baseline (repeated calls): 9462.02ms
Cached (once): 1.29ms
Improvement: 7353.27x faster
Total time saved: 9460.74ms
\`\`\`

Verified with:
- \`yarn nx test shared-util-formatters\`
- \`yarn nx lint shared-util-formatters\`

---
*PR created automatically by Jules for task [9110893204804614092](https://jules.google.com/task/9110893204804614092) started by @plastikaweb*