### PR TITLE
ci(husky): pre-push format + lint gate; fix full-range base for rebase/amend commits

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,11 +3,31 @@ set -e
 export NX_CLI_SET=classic
 export PAGER=cat
 
-CHANGED_FILES=$(git diff --name-only @{upstream}...HEAD 2>/dev/null || git diff --name-only HEAD~1...HEAD)
+# Resolve the base of the range being pushed. Prefer this branch's upstream (exactly
+# the commits not yet on the remote); for a brand-new branch with no upstream, fall
+# back to the merge-base with origin/develop so the WHOLE branch is covered — NOT just
+# the tip commit (the old `HEAD~1...HEAD` fallback silently scoped every check to the
+# last commit on new branches, e.g. letting a 2-commit push build/lint nothing).
+BASE=$(git rev-parse @{upstream} 2>/dev/null || git merge-base origin/develop HEAD 2>/dev/null || echo HEAD~1)
+CHANGED_FILES=$(git diff --name-only "$BASE"..HEAD)
+
+# --- FORMAT GATE (runs for EVERY push) ---
+# `git rebase --continue` and `git commit --amend` do NOT fire the pre-commit hook, so
+# Prettier (and lint) never ran on commits authored that way. pre-push is the only hook
+# that always runs regardless of how a commit was created, so this is where that drift
+# is caught — locally, before it reaches the remote and CI. Prettier formats .md too,
+# so this runs even for doc-only pushes (before the markdown fast-path below).
+echo "🎨 Checking formatting (Prettier)..."
+if ! yarn nx format:check --base="$BASE" --head=HEAD; then
+  echo "❌ Formatting drift detected — often from 'git rebase --continue' or 'git commit --amend', which skip the pre-commit hook."
+  echo "   Fix: run 'yarn format:write', then amend/rebase the affected commit(s) and re-push."
+  exit 1
+fi
 
 # --- MARKDOWN-ONLY FAST PATH ---
 # If every file changed across all commits being pushed is a .md, skip tests,
 # build and a11y entirely — none of them are relevant for doc-only pushes.
+# (Formatting was already verified above.)
 NON_MD_CHANGED=$(printf '%s\n' "$CHANGED_FILES" | grep -v '\.md$' | grep -v '^$' || true)
 if [ -z "$NON_MD_CHANGED" ]; then
   echo "📝 Markdown-only push — skipping tests, build and a11y checks"
@@ -15,6 +35,14 @@ if [ -z "$NON_MD_CHANGED" ]; then
   exit 0
 fi
 # --------------------------------
+
+echo "🔍 Running affected lint..."
+# Like the format gate above, this catches lint errors on rebase/amend commits that
+# bypassed the pre-commit lint. Scoped to the exact push range via $BASE..HEAD.
+if ! yarn nx affected --target=lint --base="$BASE" --head=HEAD --parallel --max-parallel=3 --cache; then
+  echo "❌ Lint failed! Push aborted."
+  exit 1
+fi
 
 echo "🏃 Running affected tests..."
 if ! yarn nx affected --target=test --parallel --max-parallel=2 --cache; then

--- a/documentation/git-flow.md
+++ b/documentation/git-flow.md
@@ -186,6 +186,19 @@ yarn i18n:validate
 
 For more details, see [i18n documentation](./i18n.md).
 
+### Pre-push Hook
+
+`.husky/pre-push` is the gate that runs on **every** push, regardless of how a commit
+was authored. This matters because `git rebase --continue` and `git commit --amend` do
+**not** fire the pre-commit hook, so Prettier/lint never run on commits created that way.
+The pre-push hook therefore enforces, scoped to the range being pushed:
+
+- `nx format:check` — runs for every push (including markdown-only ones, since Prettier also formats `.md`). On failure: run `yarn format:write`, amend/rebase the affected commit(s), then re-push.
+- `nx affected --target=lint` — on non-markdown pushes.
+- `nx affected` `test` and production `build` — on non-markdown pushes; plus `eco-store`/`nasa-images` Pa11y when those apps are affected.
+
+Markdown-only pushes skip the test/build/a11y steps (but still run `format:check`).
+
 ## Useful links
 
 - [Github actions](https://docs.github.com/en/actions)

--- a/documentation/git-flow.md
+++ b/documentation/git-flow.md
@@ -17,6 +17,7 @@
     - [During Local Development](#during-local-development)
     - [In CI/CD Pipeline](#in-cicd-pipeline)
     - [Pre-commit Hook](#pre-commit-hook)
+    - [Pre-push Hook](#pre-push-hook)
   - [Useful links](#useful-links)
 
 ## Description


### PR DESCRIPTION
## Problem
`git rebase --continue` and `git commit --amend` **do not fire the `pre-commit` hook**, so Prettier (`format:write`) and lint never ran on commits authored that way. The standing workaround was a manual `git add` + `git commit --amend` to re-trigger pre-commit — easy to forget, and the drift only surfaced later in CI.

## Fix
`pre-push` is the one hook that runs on **every** push regardless of how a commit was created, so the gate now lives there:

1. **`nx format:check`** — runs for *every* push (incl. markdown-only, since Prettier formats `.md`), before the markdown fast-path. Fails with a message pointing to `yarn format:write` + amend/rebase.
2. **`nx affected --target=lint`** — on the non-markdown path, alongside the existing test/build.

Both are scoped to the actual push range.

## Also: full-range base fix (folded in)
The old `@{upstream}...HEAD || HEAD~1...HEAD` fallback scoped **every** check to only the **tip commit** on a new branch with no upstream (this is why a recent 2-commit push built/linted nothing). Now resolves:
```sh
BASE=$(git rev-parse @{upstream} 2>/dev/null || git merge-base origin/develop HEAD 2>/dev/null || echo HEAD~1)
```
so the whole branch is covered.

## Validation
- POSIX `sh -n` syntax check ✓
- `nx format:check --base --head` and `nx affected -t lint --base --head` validated against real ranges ✓
- **This PR's own push exercised the new hook end-to-end** (main checkout's `.husky/pre-push` is what executes for all worktrees) → format + lint + test + build ran, a11y correctly skipped, push passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)