### PR TITLE
🎨 Palette: Add tooltip to breadcrumbs back button

### DIFF
--- a/libs/eco-store/shared/breadcrumbs/src/lib/eco-store-breadcrumbs/eco-store-breadcrumbs.component.html
+++ b/libs/eco-store/shared/breadcrumbs/src/lib/eco-store-breadcrumbs/eco-store-breadcrumbs.component.html
@@ -7,6 +7,7 @@
         matIconButton
         type="button"
         [attr.aria-label]="backAriaLabel()"
+        [matTooltip]="backAriaLabel()"
         (click)="goBack.emit()">
         <mat-icon>arrow_back</mat-icon>
       </button>

--- a/libs/eco-store/shared/breadcrumbs/src/lib/eco-store-breadcrumbs/eco-store-breadcrumbs.component.spec.ts
+++ b/libs/eco-store/shared/breadcrumbs/src/lib/eco-store-breadcrumbs/eco-store-breadcrumbs.component.spec.ts
@@ -1,5 +1,6 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatTooltip } from '@angular/material/tooltip';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
@@ -90,6 +91,18 @@ describe('EcoStoreBreadcrumbsComponent', () => {
     button.nativeElement.click();
 
     expect(goBackSpy).toHaveBeenCalledOnce();
+  });
+
+  it('should render a tooltip on the back button that matches backAriaLabel', async () => {
+    const label = 'Tornar enrere';
+    fixture.componentRef.setInput('backAriaLabel', label);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const button = fixture.debugElement.query(By.css('button[matIconButton]'));
+    const tooltip = button.injector.get(MatTooltip);
+
+    expect(tooltip.message).toBe(label);
   });
 
   it('should have no accessibility violations', async () => {

--- a/libs/eco-store/shared/breadcrumbs/src/lib/eco-store-breadcrumbs/eco-store-breadcrumbs.component.ts
+++ b/libs/eco-store/shared/breadcrumbs/src/lib/eco-store-breadcrumbs/eco-store-breadcrumbs.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 
@@ -34,7 +35,7 @@ export interface BreadcrumbItem {
 
 @Component({
   selector: 'eco-store-breadcrumbs',
-  imports: [MatButtonModule, MatIconModule, RouterLink, TranslatePipe],
+  imports: [MatButtonModule, MatIconModule, MatTooltipModule, RouterLink, TranslatePipe],
   templateUrl: './eco-store-breadcrumbs.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
🎨 Palette: Add tooltip to breadcrumbs back button. This improves the UX by providing a visual description for the icon-only button, complementing the existing aria-label.

♿ Accessibility: Ensures both screen reader and sighted users have access to the button's purpose.

---
*PR created automatically by Jules for task [12979748762758868414](https://jules.google.com/task/12979748762758868414) started by @plastikaweb*