### PR TITLE
🎨 Palette: Add tooltips to icon-only back buttons

### DIFF
--- a/libs/eco-store/auth/feature/container/src/lib/auth-container/eco-store-auth-container.component.html
+++ b/libs/eco-store/auth/feature/container/src/lib/auth-container/eco-store-auth-container.component.html
@@ -12,6 +12,7 @@
           matIconButton
           class="opacity-70 transition-opacity hover:opacity-100"
           [attr.aria-label]="'auth.common.back' | translate"
+          [matTooltip]="'auth.common.back' | translate"
           (click)="goBack()">
           <mat-icon>arrow_back</mat-icon>
         </button>

--- a/libs/eco-store/auth/feature/container/src/lib/auth-container/eco-store-auth-container.component.ts
+++ b/libs/eco-store/auth/feature/container/src/lib/auth-container/eco-store-auth-container.component.ts
@@ -9,6 +9,7 @@ import {
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { NavigationService } from '@plastik/core/router-state';
 import { PocketBaseImageUrlPipe, PwaNavigationService } from '@plastik/eco-store/shared/utils';
@@ -26,6 +27,7 @@ import { MatThemeToggleComponent } from '@plastik/shared/mat-theme-toggle';
     MatCardModule,
     MatButtonModule,
     MatIconModule,
+    MatTooltipModule,
     TranslateModule,
     SharedImgContainerComponent,
     PocketBaseImageUrlPipe,

--- a/libs/eco-store/shared/breadcrumbs/src/lib/eco-store-breadcrumbs/eco-store-breadcrumbs.component.html
+++ b/libs/eco-store/shared/breadcrumbs/src/lib/eco-store-breadcrumbs/eco-store-breadcrumbs.component.html
@@ -7,6 +7,7 @@
         matIconButton
         type="button"
         [attr.aria-label]="backAriaLabel()"
+        [matTooltip]="backAriaLabel()"
         (click)="goBack.emit()">
         <mat-icon>arrow_back</mat-icon>
       </button>

--- a/libs/eco-store/shared/breadcrumbs/src/lib/eco-store-breadcrumbs/eco-store-breadcrumbs.component.ts
+++ b/libs/eco-store/shared/breadcrumbs/src/lib/eco-store-breadcrumbs/eco-store-breadcrumbs.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 
@@ -34,7 +35,7 @@ export interface BreadcrumbItem {
 
 @Component({
   selector: 'eco-store-breadcrumbs',
-  imports: [MatButtonModule, MatIconModule, RouterLink, TranslatePipe],
+  imports: [MatButtonModule, MatIconModule, MatTooltipModule, RouterLink, TranslatePipe],
   templateUrl: './eco-store-breadcrumbs.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
This PR adds tooltips to icon-only "back" buttons in the `EcoStoreBreadcrumbsComponent` and `EcoStoreAuthContainerComponent`. 

Many icon-only buttons in the application provided `aria-label` for screen readers but lacked `matTooltip` for sighted users, making their function less discoverable. This change ensures that hovering over these buttons provides a clear text description of the action.

### Changes:
- Modified `libs/eco-store/shared/breadcrumbs/src/lib/eco-store-breadcrumbs/eco-store-breadcrumbs.component.ts` to import `MatTooltipModule`.
- Updated `libs/eco-store/shared/breadcrumbs/src/lib/eco-store-breadcrumbs/eco-store-breadcrumbs.component.html` to add `[matTooltip]="backAriaLabel()"` to the back button.
- Modified `libs/eco-store/auth/feature/container/src/lib/auth-container/eco-store-auth-container.component.ts` to import `MatTooltipModule`.
- Updated `libs/eco-store/auth/feature/container/src/lib/auth-container/eco-store-auth-container.component.html` to add `[matTooltip]="'auth.common.back' | translate"` to the back button.
- Initialized `.jules/palette.md` to track UX learnings.

### Verification:
- Unit tests for both libraries passed (`yarn nx test eco-store-breadcrumbs` and `yarn nx test eco-store-auth-feature-container`).
- Verified component structure and presence of `matTooltip` via source code inspection and attempted frontend verification.
- Received positive code review confirming the improvement and implementation.

---
*PR created automatically by Jules for task [11040866778124977499](https://jules.google.com/task/11040866778124977499) started by @plastikaweb*