### PR TITLE
perf(shared-util-formatters): #86ca8m6aj TECH-07 cache resolved system timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-27] - Shared: TECH-07 — cache system timezone in `SharedUtilFormattersService`
+
+### Changed
+
+- **`libs/shared/util/formatters` (`SharedUtilFormattersService`)**: the three date formatters (`dateFormatter`, `dateTimeFormatter`, `firebaseTimestampFormatter`) each recomputed `Intl.DateTimeFormat().resolvedOptions().timeZone` inline on every call — an allocation-heavy `Intl.DateTimeFormat` construction repeated under table rendering and change detection. The resolved system timezone is now computed once into a `readonly #timezone` field and reused as the default in all three formatters. Behaviour-identical: per-call `extras()` overrides still take precedence over the cached default, and the resolved zone is stable for a session. Supersedes Jules drafts [#1192](https://github.com/plastikaweb/plastikspace/pull/1192) / [#1194](https://github.com/plastikaweb/plastikspace/pull/1194) / [#1197](https://github.com/plastikaweb/plastikspace/pull/1197) (TECH-07, [#86ca8m6aj](https://app.clickup.com/t/86ca8m6aj)).
+
 ## [2026-06-24] - Shared: A11Y-008 — `SharedAlert` close button tooltip
 
 ### Fixed

--- a/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
+++ b/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
@@ -28,6 +28,7 @@ export class SharedUtilFormattersService {
   readonly #titleCasePipe = inject(TitleCasePipe);
   readonly #sanitizer = inject(DomSanitizer);
   readonly #locale = inject(LOCALE_ID);
+  readonly #timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   /**
    * Formats a date value using the specified formatting options.
@@ -42,7 +43,7 @@ export class SharedUtilFormattersService {
     let format = {
       dateDigitsInfo: 'shortDate',
       locale: this.#locale,
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timezone: this.#timezone,
     };
 
     if (extras) {
@@ -69,7 +70,7 @@ export class SharedUtilFormattersService {
   ): string {
     let format = {
       locale: this.#locale,
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timezone: this.#timezone,
     };
 
     if (extras) {
@@ -95,7 +96,7 @@ export class SharedUtilFormattersService {
     let format = {
       dateDigitsInfo: 'shortDate',
       locale: this.#locale,
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timezone: this.#timezone,
     };
 
     if (extras) {


### PR DESCRIPTION
## TECH-07 — cache system timezone in `SharedUtilFormattersService`

The three date formatters (`dateFormatter`, `dateTimeFormatter`, `firebaseTimestampFormatter`) each recomputed `Intl.DateTimeFormat().resolvedOptions().timeZone` inline on **every** call — an allocation-heavy `Intl.DateTimeFormat` construction repeated under table rendering and change detection.

The resolved system timezone is now computed **once** into a `readonly #timezone` field and reused as the default in all three formatters.

**Behaviour-identical:** per-call `extras()` overrides still take precedence over the cached default, and the resolved zone is stable for a session.

### Verification
- `nx run-many --target=lint,test --projects=shared-util-formatters` → green
- Pre-push gate (affected lint + test + build ×40 projects, production) → green

Supersedes Jules drafts #1192 / #1194 / #1197 (all three were the same one-field cache, regenerated across rounds).

(TECH-07, [#86ca8m6aj](https://app.clickup.com/t/86ca8m6aj))

🤖 Generated with [Claude Code](https://claude.com/claude-code)