### PR TITLE
feat(shared-form-input-search): #86caf5zxh A11Y-010 search input keyboard support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-27] - Shared: A11Y-010 — search input keyboard support
+
+### Added
+
+- **`libs/shared/form/ui/input-search` (`InputSearchTypeComponent`)**: keyboard operability for the shared Formly search type (WCAG 2.1.1). **Enter** now triggers a full search via `(keydown.enter)`, and **Escape** clears the field (when `resetSearch` is enabled) and restores focus to the input via a `viewChild` ref so the user can re-type immediately. The existing `keyup` handler was moved into an `onKeyup()` method that **skips Enter** — Enter is owned solely by `(keydown.enter)` — so a single Enter keypress can no longer fire two searches (the live consumers, eco-store's main + orders-filter search, both run `noButton: true`, where `keyup` already triggered a search; the naive addition would have doubled every fetch). Typing behaviour for all other keys is unchanged. Specs assert Enter→search, Escape→reset+focus, and single-fire on Enter in `noButton` mode (14 tests). Harvest from Jules draft [#1193](https://github.com/plastikaweb/plastikspace/pull/1193) (A11Y-010, [#86caf5zxh](https://app.clickup.com/t/86caf5zxh)).
+
 ## [2026-06-27] - Shared: TECH-07 — cache system timezone in `SharedUtilFormattersService`
 
 ### Changed

--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.html
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.html
@@ -2,6 +2,7 @@
   <mat-label [class.sr-only]="!props.showLabel">{{ props.label }}</mat-label>
   <mat-icon matPrefix class="mr-2" aria-hidden="true">search</mat-icon>
   <input
+    #searchInput
     matInput
     type="text"
     [autocomplete]="props['autocomplete'] || 'off'"
@@ -12,7 +13,9 @@
     [placeholder]="props.placeholder || ''"
     [required]="props.required || false"
     (input)="triggerPartialSearch($event)"
-    (keyup)="!props.noButton ? triggerPartialSearch($event) : triggerSearch($event)" />
+    (keyup)="onKeyup($event)"
+    (keydown.enter)="triggerSearch($event)"
+    (keydown.escape)="$event.stopPropagation(); props.resetSearch && resetSearch()" />
 
   @if (!props.noButton) {
     <button

--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.spec.ts
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.spec.ts
@@ -149,4 +149,52 @@ describe('InputSearchTypeComponent', () => {
       expect(component['isDisabled']()).toBe(true);
     });
   });
+
+  describe('A11Y-010: keyboard support and focus management', () => {
+    it('should trigger a full search on Enter', () => {
+      const onSearchSpy = vi.fn();
+      component.field.props!.onSearch = onSearchSpy;
+      component.formControl.setValue('abc');
+      component['syncControl']();
+
+      const input = fixture.debugElement.query(By.css('input')).nativeElement;
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+      expect(onSearchSpy).toHaveBeenCalledWith('abc', component.field);
+    });
+
+    it('should fire the search only once for a single Enter in noButton mode', () => {
+      // keyup also reacts to typing, so Enter must be owned by keydown alone —
+      // otherwise a noButton consumer fires two searches (and two fetches) per Enter.
+      const onSearchSpy = vi.fn();
+      component.field.props!.noButton = true;
+      component.field.props!.onSearch = onSearchSpy;
+      component.formControl.setValue('abc');
+      component['syncControl']();
+
+      const input = fixture.debugElement.query(By.css('input')).nativeElement;
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      input.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+
+      expect(onSearchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reset the search and restore focus to the input on Escape', () => {
+      component.field.props!.resetSearch = true;
+      const onPartialSearchSpy = vi.fn();
+      component.field.props!.onPartialSearch = onPartialSearchSpy;
+      component.formControl.setValue('abc');
+      component['syncControl']();
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input')).nativeElement;
+      const focusSpy = vi.spyOn(input, 'focus');
+
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+      expect(component.formControl.value).toBe('');
+      expect(onPartialSearchSpy).toHaveBeenCalledWith('', component.field);
+      expect(focusSpy).toHaveBeenCalled();
+    });
+  });
 });

--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.ts
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.ts
@@ -4,8 +4,10 @@ import {
   Component,
   computed,
   DestroyRef,
+  ElementRef,
   inject,
   signal,
+  viewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -48,6 +50,7 @@ export class InputSearchTypeComponent extends FieldType<FieldTypeConfig<InputSea
   readonly #destroyRef = inject(DestroyRef);
   protected readonly formValue = signal<string>('');
   protected readonly formStatus = signal<string>('VALID');
+  protected readonly searchInput = viewChild<ElementRef<HTMLInputElement>>('searchInput');
 
   /**
    * The search button is disabled if the term length is 1,
@@ -94,6 +97,17 @@ export class InputSearchTypeComponent extends FieldType<FieldTypeConfig<InputSea
     this.#handleSearch('onPartialSearch', event);
   }
 
+  protected onKeyup(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      return;
+    }
+    if (this.props.noButton) {
+      this.triggerSearch(event);
+    } else {
+      this.triggerPartialSearch(event);
+    }
+  }
+
   #handleSearch(propName: 'onSearch' | 'onPartialSearch', event?: Event): void {
     event?.preventDefault();
     event?.stopPropagation();
@@ -112,5 +126,6 @@ export class InputSearchTypeComponent extends FieldType<FieldTypeConfig<InputSea
   protected resetSearch(): void {
     this.formControl.patchValue('');
     this.triggerPartialSearch();
+    this.searchInput()?.nativeElement.focus();
   }
 }


### PR DESCRIPTION
## A11Y-010 — keyboard support for the shared search input

Adds keyboard operability (WCAG 2.1.1) to `InputSearchTypeComponent` (`libs/shared/form/ui/input-search`), the shared Formly search type consumed by eco-store (main catalog search + orders filter).

### Changes
- **Enter → full search** via `(keydown.enter)`.
- **Escape → clear + restore focus** (when `resetSearch` is enabled), via a `viewChild` ref so the user can re-type immediately.
- The `keyup` handler moved into an `onKeyup()` method that **skips Enter** — Enter is owned solely by `(keydown.enter)`.

### Why the `onKeyup()` guard matters (not in the source draft)
Both live consumers run `noButton: true`, where the existing `keyup` already triggered a search on every key — including Enter. Naively adding `(keydown.enter)` on top would fire **two** searches (and two PocketBase fetches) per Enter. Routing keyup through `onKeyup()` and excluding Enter keeps it to a single fire. Typing behaviour for all other keys is unchanged.

### Tests
14 tests (was 11): Enter→search, Escape→reset+focus, and **single-fire on Enter in `noButton` mode** (the regression guard).

Supersedes Jules draft #1193.

(A11Y-010, [#86caf5zxh](https://app.clickup.com/t/86caf5zxh))

🤖 Generated with [Claude Code](https://claude.com/claude-code)