### PR TITLE
🎨 Palette: Accessible Expandable Table Rows

### DIFF
--- a/apps/eco-store/public/i18n/ca.json
+++ b/apps/eco-store/public/i18n/ca.json
@@ -84,7 +84,9 @@
       "categoryIcon": "Icona de la categoria {category}",
       "closeSidenav": "Tancar menú lateral",
       "openSidenav": "Obrir menú lateral",
-      "ecoIcon": "Icona ecològica"
+      "ecoIcon": "Icona ecològica",
+      "expandRow": "Desplegar fila {name}",
+      "collapseRow": "Plegar fila {name}"
     },
     "paginator": {
       "firstPage": "Primera pàgina",

--- a/apps/eco-store/public/i18n/en.json
+++ b/apps/eco-store/public/i18n/en.json
@@ -84,7 +84,9 @@
       "categoryIcon": "{category} icon",
       "closeSidenav": "Close side menu",
       "openSidenav": "Open side menu",
-      "ecoIcon": "Eco icon"
+      "ecoIcon": "Eco icon",
+      "expandRow": "Expand row {name}",
+      "collapseRow": "Collapse row {name}"
     },
     "paginator": {
       "firstPage": "First page",

--- a/apps/eco-store/public/i18n/es.json
+++ b/apps/eco-store/public/i18n/es.json
@@ -84,7 +84,9 @@
       "categoryIcon": "{category} icono",
       "closeSidenav": "Cerrar menú lateral",
       "openSidenav": "Abrir menú lateral",
-      "ecoIcon": "Icono ecológico"
+      "ecoIcon": "Icono ecológico",
+      "expandRow": "Desplegar fila {name}",
+      "collapseRow": "Plegar fila {name}"
     },
     "paginator": {
       "firstPage": "Primera página",

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
@@ -275,15 +275,24 @@
             ><span class="invisible">expand</span></mat-header-cell
           >
           <mat-cell *matCellDef="let element" class="max-w-[70px]">
+            @let isExpanded = expandedElement()?.id === element.id;
             <button
               matIconButton
-              aria-label="expand row"
+              type="button"
               class="-left-sub"
+              [attr.aria-label]="
+                (isExpanded ? 'common.a11y.collapseRow' : 'common.a11y.expandRow')
+                  | translate: { name: element.name || '' }
+              "
+              [matTooltip]="
+                (isExpanded ? 'common.a11y.collapseRow' : 'common.a11y.expandRow')
+                  | translate: { name: element.name || '' }
+              "
               (click)="$event.stopPropagation(); updateExpandedElement(element)">
-              @if (expandedElement()?.id === element.id) {
-                <mat-icon>keyboard_arrow_up</mat-icon>
+              @if (isExpanded) {
+                <mat-icon aria-hidden="true">keyboard_arrow_up</mat-icon>
               } @else {
-                <mat-icon>keyboard_arrow_down</mat-icon>
+                <mat-icon aria-hidden="true">keyboard_arrow_down</mat-icon>
               }
             </button>
           </mat-cell>

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
@@ -32,6 +32,7 @@ import { MatSort, MatSortModule, Sort } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
 import { EntityId } from '@ngrx/signals/entities';
 import { BaseEntity, SortConfig } from '@plastik/core/entities';
 import {
@@ -84,6 +85,7 @@ import { OrderTableActionsElementsPipe } from '../utils/order-table-actions-elem
     SharedUtilFormattersModule,
     OrderTableActionsElementsPipe,
     SafeFormattedPipe,
+    TranslateModule,
   ],
   templateUrl: './shared-table-ui.component.html',
   styleUrl: './shared-table-ui.component.scss',


### PR DESCRIPTION
💡 What: Added dynamic, translatable `aria-label` and `matTooltip` to the expand/collapse buttons in the shared table component.
🎯 Why: Generic "expand row" labels lack context. By including the row's name (e.g., "Expand row {name}"), screen reader users can better understand which row they are interacting with.
♿ Accessibility: Improved screen reader navigation and added visual tooltips for discoverability. Icons are now hidden from screen readers to avoid redundant announcements.

---
*PR created automatically by Jules for task [10010217065485650299](https://jules.google.com/task/10010217065485650299) started by @plastikaweb*