### PR TITLE
🛡️ Sentinel: [HIGH] Fix Reflected XSS

### DIFF
--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
@@ -85,4 +85,19 @@ describe('SharedConfirmFeatureComponent', () => {
     expect(rendered).toContain('&lt;b&gt;');
     expect(rendered).not.toContain('<b>x</b>');
   });
+
+  it('should escape non-string parameters to prevent XSS', async () => {
+    const maliciousObject = {
+      toString: () => '<img src=x onerror=alert(1)>',
+    };
+
+    await setup({
+      ...defaultData,
+      params: { name: maliciousObject },
+    });
+
+    const rendered = messageOf();
+    expect(rendered).not.toContain('<img');
+    expect(rendered).toContain('&lt;img');
+  });
 });

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
@@ -38,7 +38,7 @@ export class SharedConfirmFeatureComponent {
       ? Object.fromEntries(
           Object.entries(params).map(([key, value]) => [
             key,
-            typeof value === 'string' ? escapeHtml(value) : value,
+            escapeHtml(String(value ?? '')),
           ])
         )
       : params;


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Reflected XSS

🚨 **Severity**: HIGH
💡 **Vulnerability**: The \`SharedConfirmFeatureComponent\` previously only escaped translation parameters if they were already of type \`string\`. Non-string inputs (like objects or arrays) were passed as-is to \`ngx-translate\`, which stringified them. Since the final translated message was wrapped in \`bypassSecurityTrustHtml\`, this created a reflected XSS vector for any non-string parameter that could be manipulated.
🎯 **Impact**: Potential execution of arbitrary JavaScript in the context of the user's session when a confirmation dialog is displayed with malicious data.
🔧 **Fix**: Updated the parameter processing logic to coerce all values to strings using \`String(value ?? '')\` before applying \`escapeHtml\`.
✅ **Verification**: 
- Added a new unit test in \`libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts\` that uses an object with a malicious \`toString\` method to verify it is correctly escaped.
- Ran \`yarn nx test shared-confirm-data-access\` and confirmed all tests pass.
- Verified changes with a manual code review (#Correct#).

---
*PR created automatically by Jules for task [17071185851555268144](https://jules.google.com/task/17071185851555268144) started by @plastikaweb*