### PR TITLE
🎨 Palette: Improve table expand button accessibility

### DIFF
--- a/apps/eco-store/public/i18n/ca.json
+++ b/apps/eco-store/public/i18n/ca.json
@@ -25,6 +25,7 @@
       "close": "Entès, tancar"
     },
     "delete": "Eliminar",
+    "actions": "Accions",
     "navigation": {
       "previous": "Tornar a la pàgina anterior",
       "next": "Anar a la pàgina següent",
@@ -84,7 +85,9 @@
       "categoryIcon": "Icona de la categoria {category}",
       "closeSidenav": "Tancar menú lateral",
       "openSidenav": "Obrir menú lateral",
-      "ecoIcon": "Icona ecològica"
+      "ecoIcon": "Icona ecològica",
+      "expandRow": "Desplegar fila {name}",
+      "collapseRow": "Plegar fila {name}"
     },
     "paginator": {
       "firstPage": "Primera pàgina",

--- a/apps/eco-store/public/i18n/en.json
+++ b/apps/eco-store/public/i18n/en.json
@@ -25,6 +25,7 @@
       "close": "Got it, close"
     },
     "delete": "Delete",
+    "actions": "Actions",
     "navigation": {
       "previous": "Go to previous page",
       "next": "Go to next page",
@@ -84,7 +85,9 @@
       "categoryIcon": "{category} icon",
       "closeSidenav": "Close side menu",
       "openSidenav": "Open side menu",
-      "ecoIcon": "Eco icon"
+      "ecoIcon": "Eco icon",
+      "expandRow": "Expand row {name}",
+      "collapseRow": "Collapse row {name}"
     },
     "paginator": {
       "firstPage": "First page",

--- a/apps/eco-store/public/i18n/es.json
+++ b/apps/eco-store/public/i18n/es.json
@@ -25,6 +25,7 @@
       "close": "Entendido, cerrar"
     },
     "delete": "Eliminar",
+    "actions": "Acciones",
     "navigation": {
       "previous": "Volver a la página anterior",
       "next": "Ir a la página siguiente",
@@ -84,7 +85,9 @@
       "categoryIcon": "{category} icono",
       "closeSidenav": "Cerrar menú lateral",
       "openSidenav": "Abrir menú lateral",
-      "ecoIcon": "Icono ecológico"
+      "ecoIcon": "Icono ecológico",
+      "expandRow": "Desplegar fila {name}",
+      "collapseRow": "Plegar fila {name}"
     },
     "paginator": {
       "firstPage": "Primera página",

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
@@ -204,7 +204,7 @@
             [class]="
               'mat-cell-actions justify-center overflow-visible ' + (actionsColStyles() || '')
             ">
-            Accions
+            {{ 'common.actions' | translate }}
           </mat-header-cell>
           <mat-cell
             *matCellDef="let element"
@@ -267,18 +267,25 @@
 
       @if (expandable()) {
         <ng-container matColumnDef="expand" sticky="true">
-          <mat-header-cell
-            *matHeaderCellDef
-            aria-label="row"
-            class="max-w-[70px]"
-            aria-hidden="true"
+          <mat-header-cell *matHeaderCellDef class="max-w-[70px]"
             ><span class="invisible">expand</span></mat-header-cell
           >
           <mat-cell *matCellDef="let element" class="max-w-[70px]">
             <button
               matIconButton
-              aria-label="expand row"
               class="-left-sub"
+              [attr.aria-label]="
+                (expandedElement()?.id === element.id
+                  ? 'common.a11y.collapseRow'
+                  : 'common.a11y.expandRow'
+                ) | translate: { name: element.name || '' }
+              "
+              [matTooltip]="
+                (expandedElement()?.id === element.id
+                  ? 'common.a11y.collapseRow'
+                  : 'common.a11y.expandRow'
+                ) | translate: { name: element.name || '' }
+              "
               (click)="$event.stopPropagation(); updateExpandedElement(element)">
               @if (expandedElement()?.id === element.id) {
                 <mat-icon>keyboard_arrow_up</mat-icon>

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
@@ -32,6 +32,7 @@ import { MatSort, MatSortModule, Sort } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
+import { TranslatePipe } from '@ngx-translate/core';
 import { EntityId } from '@ngrx/signals/entities';
 import { BaseEntity, SortConfig } from '@plastik/core/entities';
 import {
@@ -84,6 +85,7 @@ import { OrderTableActionsElementsPipe } from '../utils/order-table-actions-elem
     SharedUtilFormattersModule,
     OrderTableActionsElementsPipe,
     SafeFormattedPipe,
+    TranslatePipe,
   ],
   templateUrl: './shared-table-ui.component.html',
   styleUrl: './shared-table-ui.component.scss',


### PR DESCRIPTION
### 🎨 Palette: Improve table expand button accessibility

#### 💡 What
This PR improves the accessibility and localization of the `SharedTableUiComponent` by:
1.  **Replacing a hardcoded string:** The "Accions" header in the actions column is now localized using the `common.actions` key.
2.  **Enhancing row expansion:** The expand/collapse button now uses dynamic, translatable `aria-label` and `matTooltip` attributes that provide context (e.g., "Expand row [Name]").
3.  **Refining header accessibility:** Removed redundant and confusing ARIA attributes from the expand column's header.
4.  **Adding i18n keys:** Added `common.actions`, `common.a11y.expandRow`, and `common.a11y.collapseRow` to English, Spanish, and Catalan translation files.

#### 🎯 Why
Descriptive actions and localized interfaces are crucial for an intuitive and accessible user experience. Screen reader users now receive specific feedback about which row they are interacting with, and the interface maintains its localized integrity.

#### ♿ Accessibility
-   Descriptive dynamic ARIA labels for state changes (expand/collapse).
-   Visual tooltips for better discoverability of icon-only buttons.
-   Cleaned up redundant ARIA attributes in table headers.

#### ✅ Verification
-   Ran `yarn nx test shared-table-ui`: 14/14 tests passed, including accessibility checks.
-   Manually verified component, template, and i18n file changes.

---
*PR created automatically by Jules for task [8456430306921039013](https://jules.google.com/task/8456430306921039013) started by @plastikaweb*