### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Reflected XSS in Llecoop tables

### DIFF
--- a/libs/llecoop/order-list/feature/user-order-detail/src/lib/user-order-detail-table-form.config.ts
+++ b/libs/llecoop/order-list/feature/user-order-detail/src/lib/user-order-detail-table-form.config.ts
@@ -79,7 +79,7 @@ export class LlecoopUserOrderDetailFormTableConfig implements TableStructureConf
       type: 'CUSTOM',
       execute: (value, element) => {
         const price = `<p>${Number(value).toFixed(2)} €</p>`;
-        const unit = element?.unit ? this.#productBaseUnitTextPipe.transform(element.unit) : '';
+        const unit = element?.unit ? escapeHtml(this.#productBaseUnitTextPipe.transform(element.unit)) : '';
 
         return this.#sanitizer.bypassSecurityTrustHtml(`${price} ${unit}`) as SafeHtml;
       },

--- a/libs/llecoop/order-list/feature/user-order-resume/src/lib/llecoop-user-order-feature-resume/user-order-feature-resume-table.config.ts
+++ b/libs/llecoop/order-list/feature/user-order-resume/src/lib/llecoop-user-order-feature-resume/user-order-feature-resume-table.config.ts
@@ -33,7 +33,7 @@ export class LlecoopUserOrderResumeTableConfig implements TableStructureConfig<L
       execute: (_, product) => {
         const name = `<p class="font-bold uppercase">${escapeHtml(product?.name ?? '')}</p>`;
         const unit = product?.unit
-          ? `<p class="font-bold text-sm">${Number(product?.price).toFixed(2)} € x ${this.#productBaseUnitTextPipe.transform(product.unit)}</p>`
+          ? `<p class="font-bold text-sm">${Number(product?.price).toFixed(2)} € x ${escapeHtml(this.#productBaseUnitTextPipe.transform(product.unit))}</p>`
           : '';
         const info = product?.info
           ? `<p class="font-bold">${escapeHtml(product?.info ?? '')}</p>`


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Reflected XSS in `CUSTOM` table formatters. Several table configurations in the Llecoop application were manually constructing HTML strings and passing them to `DomSanitizer.bypassSecurityTrustHtml()`. While some fields like `name` and `info` were escaped, the output from `LlecoopProductBaseUnitTextPipe.transform()` was not.
🎯 Impact: If a product's unit data (specifically the `base` property) contained malicious HTML or JavaScript, it would be executed in the session of any user viewing the affected tables.
🔧 Fix: Wrapped the call to `this.#productBaseUnitTextPipe.transform()` with the `escapeHtml()` utility in both `LlecoopUserOrderDetailFormTableConfig` and `LlecoopUserOrderResumeTableConfig`.
✅ Verification: Manually verified the code changes to ensure consistent escaping. Ran `yarn nx lint` for both projects (`llecoop-user-order-feature-detail` and `llecoop-user-order-feature-resume`) and they passed. Ran available unit tests for `llecoop-user-order-feature-resume`.

---
*PR created automatically by Jules for task [15821539195898146582](https://jules.google.com/task/15821539195898146582) started by @plastikaweb*