### PR TITLE
🎨 Palette: Add loading state to Shared Button

### DIFF
--- a/libs/shared/button/entities/src/button.ts
+++ b/libs/shared/button/entities/src/button.ts
@@ -12,8 +12,8 @@ interface ButtonBaseConfig {
   dataTestId?: string;
   disabled?: boolean | Observable<boolean>;
   link?: string;
-  doAction?(): Action;
   loading?: boolean | Signal<boolean>;
+  doAction?(): Action;
 }
 
 export type ButtonConfigWithAction = Omit<ButtonBaseConfig, 'link'> & {

--- a/libs/shared/button/entities/src/button.ts
+++ b/libs/shared/button/entities/src/button.ts
@@ -1,3 +1,4 @@
+import { Signal } from '@angular/core';
 import { Action } from '@ngrx/store';
 import { SvgIconConfig } from '@plastik/shared/entities';
 import { Observable } from 'rxjs';
@@ -12,6 +13,7 @@ interface ButtonBaseConfig {
   disabled?: boolean | Observable<boolean>;
   link?: string;
   doAction?(): Action;
+  loading?: boolean | Signal<boolean>;
 }
 
 export type ButtonConfigWithAction = Omit<ButtonBaseConfig, 'link'> & {

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
@@ -2,12 +2,20 @@
   <button
     matButton
     [class]="`button--rounded ${buttonConfig().classes || ''}`"
-    [disabled]="buttonConfig().disabled"
-    [attr.aria-label]="buttonConfig().ariaLabel"
+    [disabled]="buttonConfig().disabled || isLoading()"
+    [attr.aria-label]="
+      isLoading()
+        ? (('common.loading' | translate) + ' ' + buttonConfig().ariaLabel)
+        : buttonConfig().ariaLabel
+    "
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
     [attr.data-test]="buttonConfig().dataTestId"
     (click)="onClick()">
-    <ng-container *ngTemplateOutlet="content"></ng-container>
+    @if (!isLoading()) {
+      <ng-container *ngTemplateOutlet="content"></ng-container>
+    } @else {
+      <mat-progress-spinner mode="indeterminate" diameter="24"></mat-progress-spinner>
+    }
   </button>
 }
 
@@ -16,11 +24,22 @@
     class="block"
     target="_blank"
     rel="noopener noreferrer"
-    [attr.aria-label]="buttonConfig().ariaLabel"
+    [tabindex]="isLoading() ? -1 : 0"
+    [class.pointer-events-none]="isLoading()"
+    [attr.aria-disabled]="isLoading()"
+    [attr.aria-label]="
+      isLoading()
+        ? (('common.loading' | translate) + ' ' + buttonConfig().ariaLabel)
+        : buttonConfig().ariaLabel
+    "
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
     [href]="linkHref()"
     [attr.data-test]="buttonConfig().dataTestId">
-    <ng-container *ngTemplateOutlet="content">button content</ng-container>
+    @if (!isLoading()) {
+      <ng-container *ngTemplateOutlet="content">button content</ng-container>
+    } @else {
+      <mat-progress-spinner mode="indeterminate" diameter="24"></mat-progress-spinner>
+    }
   </a>
 }
 

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
@@ -5,7 +5,7 @@
     [disabled]="buttonConfig().disabled || isLoading()"
     [attr.aria-label]="
       isLoading()
-        ? (('common.loading' | translate) + ' ' + buttonConfig().ariaLabel)
+        ? ('common.loading' | translate) + ' ' + buttonConfig().ariaLabel
         : buttonConfig().ariaLabel
     "
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
@@ -29,7 +29,7 @@
     [attr.aria-disabled]="isLoading()"
     [attr.aria-label]="
       isLoading()
-        ? (('common.loading' | translate) + ' ' + buttonConfig().ariaLabel)
+        ? ('common.loading' | translate) + ' ' + buttonConfig().ariaLabel
         : buttonConfig().ariaLabel
     "
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
@@ -4,8 +4,11 @@ import { axe } from 'vitest-axe';
 
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { provideZonelessChangeDetection } from '@angular/core';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { buttonMock } from '@plastik/shared/button';
 
 import { SharedButtonUiComponent } from './shared-button-ui.component';
@@ -16,13 +19,21 @@ describe('SharedButtonUiComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SharedButtonUiComponent, AngularSvgIconModule.forRoot()],
+      imports: [SharedButtonUiComponent, AngularSvgIconModule.forRoot(), TranslateModule.forRoot()],
       providers: [
         provideZonelessChangeDetection(),
         provideHttpClient(),
         provideHttpClientTesting(),
       ],
     }).compileComponents();
+
+    const translate = TestBed.inject(TranslateService);
+    translate.use('en');
+    translate.setTranslation('en', {
+      common: {
+        loading: 'Loading',
+      },
+    });
 
     fixture = TestBed.createComponent(SharedButtonUiComponent);
     fixture.componentRef.setInput('buttonConfig', buttonMock);
@@ -44,5 +55,31 @@ describe('SharedButtonUiComponent', () => {
   it('should have no accessibility violations', async () => {
     const results = await axe(fixture.nativeElement);
     expect(results).toHaveNoViolations();
+  });
+
+  it('should show spinner and be disabled when loading is true', async () => {
+    fixture.componentRef.setInput('buttonConfig', { ...buttonMock, loading: true });
+    await fixture.whenStable();
+
+    const spinner = fixture.debugElement.query(By.directive(MatProgressSpinner));
+    expect(spinner).toBeTruthy();
+
+    const button = fixture.debugElement.query(By.css('button'));
+    expect(button.nativeElement.disabled).toBeTruthy();
+  });
+
+  it('should show spinner and be disabled when loading is a signal that is true', async () => {
+    const loadingSignal = signal(true);
+    fixture.componentRef.setInput('buttonConfig', { ...buttonMock, loading: loadingSignal });
+    await fixture.whenStable();
+
+    let spinner = fixture.debugElement.query(By.directive(MatProgressSpinner));
+    expect(spinner).toBeTruthy();
+
+    loadingSignal.set(false);
+    await fixture.whenStable();
+
+    spinner = fixture.debugElement.query(By.directive(MatProgressSpinner));
+    expect(spinner).toBeFalsy();
   });
 });

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.ts
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.ts
@@ -1,11 +1,21 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  isSignal,
+  output,
+  Signal,
+} from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { PushPipe } from '@ngrx/component';
 import { Action } from '@ngrx/store';
 import { ButtonConfig, ButtonConfigWithAction, buttonHasALinkGuard } from '@plastik/shared/button';
 import { ReturnAsObservablePipe } from '@plastik/shared/return-as-observable';
+import { TranslatePipe } from '@ngx-translate/core';
 import { AngularSvgIconModule } from 'angular-svg-icon';
 
 @Component({
@@ -14,9 +24,11 @@ import { AngularSvgIconModule } from 'angular-svg-icon';
     NgTemplateOutlet,
     PushPipe,
     MatButtonModule,
+    MatProgressSpinnerModule,
     MatTooltipModule,
     AngularSvgIconModule,
     ReturnAsObservablePipe,
+    TranslatePipe,
   ],
   templateUrl: './shared-button-ui.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -34,6 +46,14 @@ export class SharedButtonUiComponent {
   linkHref = computed(() => {
     const cfg = this.buttonConfig();
     return buttonHasALinkGuard(cfg) ? cfg.link : undefined;
+  });
+
+  /**
+   * @description Computed signal that returns true if the button is in loading state
+   */
+  isLoading = computed(() => {
+    const loading = this.buttonConfig().loading;
+    return isSignal(loading) ? (loading as Signal<boolean>)() : !!loading;
   });
 
   /**


### PR DESCRIPTION
💡 What: Added a loading state to the shared button component (`SharedButtonUiComponent`). When active, the button/link is disabled and shows an indeterminate progress spinner instead of its usual content.

🎯 Why: To provide better visual and assistive feedback to users during asynchronous operations (e.g., submitting a form, loading data).

♿ Accessibility:
- The `aria-label` is prefixed with a "Loading" translation when active.
- Buttons are natively disabled.
- Links are given `aria-disabled="true"`, `tabindex="-1"`, and `pointer-events-none` to prevent interaction and keyboard focus.

✅ Verification:
- Added unit tests in `shared-button-ui.component.spec.ts` covering static and reactive loading states.
- Verified that linting passes.
- Verified accessibility via `axe` in existing tests.

---
*PR created automatically by Jules for task [13099724640060659767](https://jules.google.com/task/13099724640060659767) started by @plastikaweb*