### PR TITLE
🎨 Palette: Improve SharedButtonUi accessibility and robustness

### DIFF
--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
@@ -1,8 +1,10 @@
+@let isDisabled = (buttonConfig().disabled | returnAsObservable | ngrxPush) || false;
+
 @if (buttonConfig().type === 'button') {
   <button
     matButton
     [class]="`button--rounded ${buttonConfig().classes || ''}`"
-    [disabled]="buttonConfig().disabled"
+    [disabled]="isDisabled"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
     [attr.data-test]="buttonConfig().dataTestId"
@@ -13,12 +15,16 @@
 
 @if (buttonConfig().type === 'link') {
   <a
-    class="block"
+    class="block transition-opacity"
     target="_blank"
     rel="noopener noreferrer"
+    [class.opacity-50]="isDisabled"
+    [class.cursor-not-allowed]="isDisabled"
+    [attr.aria-disabled]="isDisabled"
+    [tabindex]="isDisabled ? -1 : 0"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
-    [href]="linkHref()"
+    [attr.href]="isDisabled ? null : linkHref()"
     [attr.data-test]="buttonConfig().dataTestId">
     <ng-container *ngTemplateOutlet="content">button content</ng-container>
   </a>
@@ -31,6 +37,7 @@
     }
     @if (element.type === 'icon') {
       <svg-icon
+        aria-hidden="true"
         [src]="(element.content | returnAsObservable | ngrxPush)?.iconPath || ''"
         [svgClass]="(element.content | returnAsObservable | ngrxPush)?.svgClass || ''"></svg-icon>
     }

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
@@ -1,4 +1,5 @@
 import { AngularSvgIconModule } from 'angular-svg-icon';
+import { of } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 import { axe } from 'vitest-axe';
 
@@ -39,6 +40,18 @@ describe('SharedButtonUiComponent', () => {
     component.sendAction.subscribe(action => (result = action));
     component.onClick();
     expect(result).toEqual(result);
+  });
+
+  it('should handle disabled as an Observable', async () => {
+    fixture.componentRef.setInput('buttonConfig', {
+      ...buttonMock,
+      disabled: of(true),
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const buttonElement: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(buttonElement.disabled).toBe(true);
   });
 
   it('should have no accessibility violations', async () => {


### PR DESCRIPTION
💡 **What:** Improved the `SharedButtonUiComponent` to handle reactive `disabled` states and enhanced its accessibility, particularly for the link variant.

🎯 **Why:** The component previously didn't support `disabled` as an Observable in its template, and link-based buttons lacked proper accessibility and visual feedback when they should have been disabled.

♿ **Accessibility:**
- Added `aria-disabled` and `tabindex="-1"` to disabled links.
- Nullified `href` on disabled links to natively remove them from the tab order.
- Added `aria-hidden="true"` to decorative icons to prevent redundant screen reader announcements.
- Ensured primary text content remains visible to assistive technology.
- Maintained tooltip functionality on disabled links to explain the disabled state to users.


---
*PR created automatically by Jules for task [15595167695133916773](https://jules.google.com/task/15595167695133916773) started by @plastikaweb*