### PR TITLE
🎨 Palette: Improve SharedButtonUi accessibility and reactivity

### DIFF
--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
@@ -1,8 +1,10 @@
+@let isDisabled = (buttonConfig().disabled | returnAsObservable | ngrxPush) || false;
+
 @if (buttonConfig().type === 'button') {
   <button
     matButton
     [class]="`button--rounded ${buttonConfig().classes || ''}`"
-    [disabled]="buttonConfig().disabled"
+    [disabled]="isDisabled"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
     [attr.data-test]="buttonConfig().dataTestId"
@@ -14,23 +16,27 @@
 @if (buttonConfig().type === 'link') {
   <a
     class="block"
+    [class.opacity-50]="isDisabled"
     target="_blank"
     rel="noopener noreferrer"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
-    [href]="linkHref()"
+    [attr.href]="isDisabled ? null : linkHref()"
+    [attr.aria-disabled]="isDisabled"
+    [tabindex]="isDisabled ? -1 : 0"
     [attr.data-test]="buttonConfig().dataTestId">
-    <ng-container *ngTemplateOutlet="content">button content</ng-container>
+    <ng-container *ngTemplateOutlet="content"></ng-container>
   </a>
 }
 
 <ng-template #content>
   @for (element of buttonConfig().elements; track $index) {
     @if (element.type === 'text') {
-      <span>{{ element.content | returnAsObservable | ngrxPush }}</span>
+      <span aria-hidden="true">{{ element.content | returnAsObservable | ngrxPush }}</span>
     }
     @if (element.type === 'icon') {
       <svg-icon
+        aria-hidden="true"
         [src]="(element.content | returnAsObservable | ngrxPush)?.iconPath || ''"
         [svgClass]="(element.content | returnAsObservable | ngrxPush)?.svgClass || ''"></svg-icon>
     }

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
@@ -1,4 +1,5 @@
 import { AngularSvgIconModule } from 'angular-svg-icon';
+import { of } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 import { axe } from 'vitest-axe';
 
@@ -6,7 +7,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { buttonMock } from '@plastik/shared/button';
+import { buttonAsLinkMock, buttonMock } from '@plastik/shared/button';
 
 import { SharedButtonUiComponent } from './shared-button-ui.component';
 
@@ -44,5 +45,52 @@ describe('SharedButtonUiComponent', () => {
   it('should have no accessibility violations', async () => {
     const results = await axe(fixture.nativeElement);
     expect(results).toHaveNoViolations();
+  });
+
+  describe('disabled state', () => {
+    it('should handle boolean disabled state for button', () => {
+      fixture.componentRef.setInput('buttonConfig', { ...buttonMock, disabled: true });
+      fixture.detectChanges();
+      const button = fixture.nativeElement.querySelector('button');
+      expect(button.disabled).toBe(true);
+    });
+
+    it('should handle observable disabled state for button', () => {
+      fixture.componentRef.setInput('buttonConfig', { ...buttonMock, disabled: of(true) });
+      fixture.detectChanges();
+      const button = fixture.nativeElement.querySelector('button');
+      expect(button.disabled).toBe(true);
+    });
+
+    it('should handle boolean disabled state for link', () => {
+      fixture.componentRef.setInput('buttonConfig', { ...buttonAsLinkMock, disabled: true, link: '/test' });
+      fixture.detectChanges();
+      const link = fixture.nativeElement.querySelector('a');
+      expect(link.getAttribute('aria-disabled')).toBe('true');
+      expect(link.getAttribute('tabindex')).toBe('-1');
+      expect(link.getAttribute('href')).toBeNull();
+      expect(link.classList.contains('opacity-50')).toBe(true);
+    });
+
+    it('should handle observable disabled state for link', () => {
+      fixture.componentRef.setInput('buttonConfig', { ...buttonAsLinkMock, disabled: of(true), link: '/test' });
+      fixture.detectChanges();
+      const link = fixture.nativeElement.querySelector('a');
+      expect(link.getAttribute('aria-disabled')).toBe('true');
+      expect(link.getAttribute('tabindex')).toBe('-1');
+      expect(link.getAttribute('href')).toBeNull();
+      expect(link.classList.contains('opacity-50')).toBe(true);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should hide internal elements from screen readers', () => {
+      fixture.componentRef.setInput('buttonConfig', buttonAsLinkMock);
+      fixture.detectChanges();
+      const span = fixture.nativeElement.querySelector('span');
+      const icon = fixture.nativeElement.querySelector('svg-icon');
+      expect(span.getAttribute('aria-hidden')).toBe('true');
+      expect(icon.getAttribute('aria-hidden')).toBe('true');
+    });
   });
 });


### PR DESCRIPTION
💡 What: Improved the `SharedButtonUiComponent` by implementing a robust, accessible disabled state for both buttons and links, and refining screen reader behavior for internal content.

🎯 Why: Standard links don't support the `disabled` attribute, leading to inconsistent UX. Also, reactive `disabled` inputs (Observables) weren't correctly handled in the template.

♿ Accessibility:
- Links now correctly signal their disabled state to screen readers via `aria-disabled="true"` and are removed from tab order via `tabindex="-1"`.
- Decorative internal icons and text are hidden from screen readers using `aria-hidden="true"` to prevent redundant announcements when an `aria-label` is provided on the parent.
- Functional "disabling" of links is achieved by nullifying the `href` attribute.

✅ Verification:
- Added and ran unit tests in `shared-button-ui.component.spec.ts` covering:
  - Boolean and Observable disabled states for buttons.
  - Boolean and Observable disabled states for links (checking aria-disabled, tabindex, href, and visual class).
  - Presence of `aria-hidden="true"` on internal elements.
- All tests passed successfully.

---
*PR created automatically by Jules for task [1292270789910298665](https://jules.google.com/task/1292270789910298665) started by @plastikaweb*