### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix XSS and stability in SharedConfirmFeatureComponent

### DIFF
--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
@@ -48,8 +48,12 @@ describe('SharedConfirmFeatureComponent', () => {
     fixture.detectChanges();
   }
 
-  const messageOf = (): string | undefined =>
-    (component as unknown as { message: () => string }).message()?.toString();
+  const messageOf = (): any => {
+    const msg = (component as unknown as { message: () => any }).message();
+    return msg && typeof msg === 'object' && 'changingThisBreaksApplicationSecurity' in msg
+      ? msg.toString()
+      : msg;
+  };
 
   it('should create', async () => {
     await setup();
@@ -84,5 +88,42 @@ describe('SharedConfirmFeatureComponent', () => {
     expect(rendered).toContain('<strong>');
     expect(rendered).toContain('&lt;b&gt;');
     expect(rendered).not.toContain('<b>x</b>');
+  });
+
+  it('should escape non-string translation parameters', async () => {
+    await setup(
+      {
+        ...defaultData,
+        params: {
+          items: ['<img src=x onerror=alert(1)>'],
+          details: { info: '<script>alert(1)</script>' },
+        },
+      },
+      {
+        'test.message': 'Items: {{items}}, Details: {{details}}',
+      }
+    );
+
+    const rendered = messageOf().toString();
+    expect(rendered).not.toContain('<img');
+    expect(rendered).not.toContain('<script');
+    expect(rendered).toContain('&lt;img');
+    expect(rendered).toContain('&lt;script');
+  });
+
+  it('should not crash and skip translation when message is already SafeHtml', async () => {
+    // Mocking SafeHtml by using an object that is not a string
+    const safeHtmlMessage = {
+      changingThisBreaksApplicationSecurity: '<strong>Trusted HTML</strong>',
+      toString: () => '<strong>Trusted HTML</strong>',
+    };
+
+    await setup({
+      ...defaultData,
+      message: safeHtmlMessage,
+    });
+
+    const rendered = (component as any).message();
+    expect(rendered).toBe(safeHtmlMessage);
   });
 });

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
@@ -4,6 +4,7 @@ import {
   Component,
   computed,
   inject,
+  Signal,
   ViewEncapsulation,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
@@ -32,16 +33,23 @@ export class SharedConfirmFeatureComponent {
 
   protected readonly icon = computed(() => this.data.icon || 'help_outline');
 
-  protected readonly message = computed(() => {
+  protected readonly message: Signal<SafeHtml | string> = computed(() => {
     const params = this.data.params;
     const escapedParams = params
       ? Object.fromEntries(
           Object.entries(params).map(([key, value]) => [
             key,
-            typeof value === 'string' ? escapeHtml(value) : value,
+            typeof value === 'object' && value !== null
+              ? escapeHtml(JSON.stringify(value))
+              : escapeHtml(String(value ?? '')),
           ])
         )
       : params;
+
+    if (typeof this.data.message !== 'string') {
+      return this.data.message;
+    }
+
     const translated = this.#translate.instant(this.data.message, escapedParams);
     return this.#sanitizer.bypassSecurityTrustHtml(translated);
   });


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix XSS and stability in SharedConfirmFeatureComponent

🚨 **Severity**: MEDIUM

💡 **Vulnerability**: 
1. **Reflected XSS**: The `SharedConfirmFeatureComponent` only escaped string-typed translation parameters. Non-string parameters (objects, arrays) were passed raw to `ngx-translate`, which stringified them into the final trusted HTML output, allowing potential script execution if they contained malicious markup.
2. **Stability (Crash)**: Passing a `SafeHtml` object as the `message` to the confirmation dialog caused `ngx-translate` to throw a `TypeError: key.split is not a function`, crashing the dialog.

🎯 **Impact**:
- Maliciously crafted objects or arrays in translation parameters could lead to XSS.
- Certain admin dialogs (like "Iniciar nova comanda") that pass `SafeHtml` messages were broken.

🔧 **Fix**:
- Updated the `message` computed signal to stringify all parameters (using `JSON.stringify` for objects/arrays) and escape them using `escapeHtml`.
- Added a guard to check if `data.message` is a string. If it's already a non-string (e.g., `SafeHtml`), it bypasses the translation service and is used directly.
- Added explicit return types to the `message` signal for better safety.

✅ **Verification**:
- Added new test cases to `libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts`:
  - Verified that array and object parameters are stringified and HTML-escaped.
  - Verified that `SafeHtml` messages do not cause a crash and are rendered correctly.
- Ran `yarn nx test shared-confirm-data-access` (all 6 tests passed).
- Ran `yarn nx lint shared-confirm-data-access` (passed).

---
*PR created automatically by Jules for task [1370749249344332785](https://jules.google.com/task/1370749249344332785) started by @plastikaweb*