### PR TITLE
🎨 Palette: contextual expand-row labels and actions header i18n

### DIFF
--- a/apps/eco-store/public/i18n/ca.json
+++ b/apps/eco-store/public/i18n/ca.json
@@ -9,6 +9,7 @@
     "submit": "Enviar",
     "save": "Guardar",
     "update": "Actualitzar",
+    "actions": "Accions",
     "pwa": {
       "title": "Porta l'Eco al teu mòbil",
       "description": "Aquest lloc té funcionalitats d'aplicació. Instal·la'l al teu dispositiu per a una àmplia experiència i fàcil accés.",
@@ -84,7 +85,8 @@
       "categoryIcon": "Icona de la categoria {category}",
       "closeSidenav": "Tancar menú lateral",
       "openSidenav": "Obrir menú lateral",
-      "ecoIcon": "Icona ecològica"
+      "ecoIcon": "Icona ecològica",
+      "expandRow": "Expandir la fila: {name}"
     },
     "paginator": {
       "firstPage": "Primera pàgina",

--- a/apps/eco-store/public/i18n/en.json
+++ b/apps/eco-store/public/i18n/en.json
@@ -9,6 +9,7 @@
     "submit": "Submit",
     "save": "Save",
     "update": "Update",
+    "actions": "Actions",
     "pwa": {
       "title": "Bring Eco to your mobile",
       "description": "Install our app for a faster, more secure experience with offline access to your orders.",
@@ -84,7 +85,8 @@
       "categoryIcon": "{category} icon",
       "closeSidenav": "Close side menu",
       "openSidenav": "Open side menu",
-      "ecoIcon": "Eco icon"
+      "ecoIcon": "Eco icon",
+      "expandRow": "Expand row: {name}"
     },
     "paginator": {
       "firstPage": "First page",

--- a/apps/eco-store/public/i18n/es.json
+++ b/apps/eco-store/public/i18n/es.json
@@ -9,6 +9,7 @@
     "submit": "Enviar",
     "save": "Guardar",
     "update": "Actualizar",
+    "actions": "Acciones",
     "pwa": {
       "title": "Lleva lo Eco en tu móvil",
       "description": "Instala nuestra app para una experiencia más rápida, segura y con acceso a tus pedidos sin conexión.",
@@ -84,7 +85,8 @@
       "categoryIcon": "{category} icono",
       "closeSidenav": "Cerrar menú lateral",
       "openSidenav": "Abrir menú lateral",
-      "ecoIcon": "Icono ecológico"
+      "ecoIcon": "Icono ecológico",
+      "expandRow": "Expandir la fila: {name}"
     },
     "paginator": {
       "firstPage": "Primera página",

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
@@ -204,7 +204,7 @@
             [class]="
               'mat-cell-actions justify-center overflow-visible ' + (actionsColStyles() || '')
             ">
-            Accions
+            {{ 'common.actions' | translate }}
           </mat-header-cell>
           <mat-cell
             *matCellDef="let element"
@@ -267,17 +267,14 @@
 
       @if (expandable()) {
         <ng-container matColumnDef="expand" sticky="true">
-          <mat-header-cell
-            *matHeaderCellDef
-            aria-label="row"
-            class="max-w-[70px]"
-            aria-hidden="true"
-            ><span class="invisible">expand</span></mat-header-cell
-          >
+          <mat-header-cell *matHeaderCellDef class="max-w-[70px]">
+            <span class="invisible">expand</span>
+          </mat-header-cell>
           <mat-cell *matCellDef="let element" class="max-w-[70px]">
             <button
               matIconButton
-              aria-label="expand row"
+              [attr.aria-label]="'common.a11y.expandRow' | translate: { name: resolveName(element) }"
+              [matTooltip]="'common.a11y.expandRow' | translate: { name: resolveName(element) }"
               class="-left-sub"
               (click)="$event.stopPropagation(); updateExpandedElement(element)">
               @if (expandedElement()?.id === element.id) {

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.spec.ts
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideTranslateService } from '@ngx-translate/core';
+import { TranslateModule, provideTranslateService } from '@ngx-translate/core';
 import { PageEventConfig } from '@plastik/shared/table/entities';
 
 import { ComponentRef, provideZonelessChangeDetection } from '@angular/core';
@@ -14,7 +14,7 @@ describe('SharedTableUiComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SharedTableUiComponent],
+      imports: [SharedTableUiComponent, TranslateModule.forRoot()],
       providers: [provideZonelessChangeDetection(), provideTranslateService()],
     }).compileComponents();
 

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
@@ -14,6 +14,7 @@ import {
   effect,
   inject,
   input,
+  LOCALE_ID,
   output,
   signal,
   TemplateRef,
@@ -32,8 +33,9 @@ import { MatSort, MatSortModule, Sort } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { EntityId } from '@ngrx/signals/entities';
-import { BaseEntity, SortConfig } from '@plastik/core/entities';
+import { BaseEntity, LocalizedFields, SortConfig } from '@plastik/core/entities';
 import {
   FormattingTypes,
   SafeFormattedPipe,
@@ -84,6 +86,7 @@ import { OrderTableActionsElementsPipe } from '../utils/order-table-actions-elem
     SharedUtilFormattersModule,
     OrderTableActionsElementsPipe,
     SafeFormattedPipe,
+    TranslateModule,
   ],
   templateUrl: './shared-table-ui.component.html',
   styleUrl: './shared-table-ui.component.scss',
@@ -197,6 +200,8 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
 
   protected expandedElement = signal<T | null>(null);
   readonly #liveAnnouncer = inject(LiveAnnouncer);
+  readonly #translate = inject(TranslateService);
+  readonly #localeId = inject(LOCALE_ID);
 
   constructor() {
     this.dataSource.sortingDataAccessor = (data: T, sortHeaderId: string): string | number => {
@@ -302,6 +307,25 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
     requestAnimationFrame(() => {
       this.expandedElement.set(this.expandedElement()?.id === element?.id ? null : element);
     });
+  }
+
+  /**
+   * @description Resolves the name of the row entity.
+   * @param {T} row
+   * @returns {string}
+   */
+  protected resolveName(row: T): string {
+    const name = row.name;
+    if (!name) {
+      return '';
+    }
+
+    if (typeof name === 'string') {
+      return name;
+    }
+
+    const language = this.#localeId.split('-')[0];
+    return (name as LocalizedFields)[language] || Object.values(name)[0] || '';
   }
 
   #announceSortChange(sortState: Sort) {


### PR DESCRIPTION
This PR improves the accessibility and internationalization of the `SharedTableUiComponent`. It replaces the hardcoded "Accions" header with a localized version and provides contextual, translatable ARIA labels and tooltips for expandable row buttons (e.g., "Expand row: [Name]" instead of just "expand row"). It also cleans up confusing ARIA attributes on the expansion column header to ensure correct screen reader perception of the table structure.

---
*PR created automatically by Jules for task [7872163211851075551](https://jules.google.com/task/7872163211851075551) started by @plastikaweb*