### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix XSS in llecoop order-list configs

### DIFF
--- a/libs/llecoop/order-list/feature/user-order-detail/src/lib/user-order-detail-table-form.config.ts
+++ b/libs/llecoop/order-list/feature/user-order-detail/src/lib/user-order-detail-table-form.config.ts
@@ -79,7 +79,10 @@ export class LlecoopUserOrderDetailFormTableConfig implements TableStructureConf
       type: 'CUSTOM',
       execute: (value, element) => {
         const price = `<p>${Number(value).toFixed(2)} €</p>`;
-        const unit = element?.unit ? this.#productBaseUnitTextPipe.transform(element.unit) : '';
+        // SECURITY (XSS): Escape dynamic content from the pipe before using bypassSecurityTrustHtml.
+        const unit = element?.unit
+          ? escapeHtml(this.#productBaseUnitTextPipe.transform(element.unit))
+          : '';
 
         return this.#sanitizer.bypassSecurityTrustHtml(`${price} ${unit}`) as SafeHtml;
       },

--- a/libs/llecoop/order-list/feature/user-order-resume/src/lib/llecoop-user-order-feature-resume/user-order-feature-resume-table.config.ts
+++ b/libs/llecoop/order-list/feature/user-order-resume/src/lib/llecoop-user-order-feature-resume/user-order-feature-resume-table.config.ts
@@ -32,8 +32,9 @@ export class LlecoopUserOrderResumeTableConfig implements TableStructureConfig<L
       type: 'CUSTOM',
       execute: (_, product) => {
         const name = `<p class="font-bold uppercase">${escapeHtml(product?.name ?? '')}</p>`;
+        // SECURITY (XSS): Escape dynamic content from the pipe before using bypassSecurityTrustHtml.
         const unit = product?.unit
-          ? `<p class="font-bold text-sm">${Number(product?.price).toFixed(2)} € x ${this.#productBaseUnitTextPipe.transform(product.unit)}</p>`
+          ? `<p class="font-bold text-sm">${Number(product?.price).toFixed(2)} € x ${escapeHtml(this.#productBaseUnitTextPipe.transform(product.unit))}</p>`
           : '';
         const info = product?.info
           ? `<p class="font-bold">${escapeHtml(product?.info ?? '')}</p>`


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix XSS in llecoop order-list configs

🚨 Severity: MEDIUM
💡 Vulnerability: Potential XSS via `bypassSecurityTrustHtml` using unescaped pipe output in table column formatters.
🎯 Impact: If a product's unit data (specifically the `base` field) contains malicious HTML/JavaScript, it could be executed when rendered in the order detail or resume tables, as `bypassSecurityTrustHtml` disables Angular's built-in sanitization.
🔧 Fix: 
- Wrapped the output of `LlecoopProductBaseUnitTextPipe.transform()` in `escapeHtml()` before interpolation.
- Added `// SECURITY (XSS):` comments to explain the rationale.
- Ensured `escapeHtml` is imported from `@plastik/shared/objects`.
✅ Verification: 
- Manual code inspection confirmed correct application of `escapeHtml()` and comments.
- Ran `yarn nx lint` on `llecoop-user-order-feature-detail` and `llecoop-user-order-feature-resume`.
- Ran `yarn nx test` on affected libraries (where tests exist).

---
*PR created automatically by Jules for task [2983719600197649163](https://jules.google.com/task/2983719600197649163) started by @plastikaweb*