### PR TITLE
🎨 Palette: implement reactive disabled states and improve accessibility in SharedButtonUiComponent

### DIFF
--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
@@ -1,8 +1,10 @@
+@let isDisabled = (buttonConfig().disabled | returnAsObservable | ngrxPush) || false;
+
 @if (buttonConfig().type === 'button') {
   <button
     matButton
     [class]="`button--rounded ${buttonConfig().classes || ''}`"
-    [disabled]="buttonConfig().disabled"
+    [disabled]="isDisabled"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
     [attr.data-test]="buttonConfig().dataTestId"
@@ -16,9 +18,12 @@
     class="block"
     target="_blank"
     rel="noopener noreferrer"
+    [class.opacity-50]="isDisabled"
     [attr.aria-label]="buttonConfig().ariaLabel"
+    [attr.aria-disabled]="isDisabled"
+    [tabindex]="isDisabled ? -1 : 0"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
-    [href]="linkHref()"
+    [href]="isDisabled ? null : linkHref()"
     [attr.data-test]="buttonConfig().dataTestId">
     <ng-container *ngTemplateOutlet="content">button content</ng-container>
   </a>
@@ -31,6 +36,7 @@
     }
     @if (element.type === 'icon') {
       <svg-icon
+        aria-hidden="true"
         [src]="(element.content | returnAsObservable | ngrxPush)?.iconPath || ''"
         [svgClass]="(element.content | returnAsObservable | ngrxPush)?.svgClass || ''"></svg-icon>
     }


### PR DESCRIPTION
💡 What: Added reactive handling for the disabled state in `SharedButtonUiComponent` using Angular's `@let` syntax. Improved accessibility for links and icons.
🎯 Why: Native anchor tags don't support the `disabled` attribute. This fix ensures that when a `SharedButtonUiComponent` of type 'link' is disabled, it is correctly announced by screen readers, removed from keyboard navigation, and visually indicates its state. It also prevents redundant icon announcements.
♿ Accessibility:
- Added `aria-disabled` and `tabindex` management for link buttons.
- Nullified `href` for disabled links to prevent navigation.
- Added `aria-hidden="true"` to decorative icons inside buttons that have an `aria-label`.

---
*PR created automatically by Jules for task [13437652507456040046](https://jules.google.com/task/13437652507456040046) started by @plastikaweb*