### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix XSS in SharedConfirmFeatureComponent parameters

### DIFF
--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
@@ -85,4 +85,35 @@ describe('SharedConfirmFeatureComponent', () => {
     expect(rendered).toContain('&lt;b&gt;');
     expect(rendered).not.toContain('<b>x</b>');
   });
+
+  it('should escape non-string params after stringifying them', async () => {
+    await setup(
+      {
+        ...defaultData,
+        params: { list: ['<img src=x>', 'safe'] },
+      },
+      { 'test.message': 'List: {{list}}' }
+    );
+
+    const rendered = messageOf();
+    // ngx-translate stringifies arrays as comma-separated values
+    // We want to ensure the <img part is escaped
+    expect(rendered).toContain('&lt;img');
+    expect(rendered).not.toContain('<img');
+  });
+
+  it('should not throw TypeError if message is SafeHtml (non-string)', async () => {
+    const safeMessage = {
+      changingThisBreaksApplicationSecurity: '<strong>Safe</strong>',
+    };
+
+    await setup({
+      ...defaultData,
+      message: safeMessage,
+    });
+
+    // If it didn't throw, we're good.
+    // The current implementation calls instant() on it, which might throw.
+    expect(messageOf()).toBeDefined();
+  });
 });

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
@@ -38,11 +38,20 @@ export class SharedConfirmFeatureComponent {
       ? Object.fromEntries(
           Object.entries(params).map(([key, value]) => [
             key,
-            typeof value === 'string' ? escapeHtml(value) : value,
+            // SECURITY (XSS): Stringify and escape all parameters before they are
+            // interpolated into the translation string and marked as SafeHtml.
+            escapeHtml(String(value ?? '')),
           ])
         )
       : params;
-    const translated = this.#translate.instant(this.data.message, escapedParams);
+
+    const message = this.data.message;
+    // SECURITY (XSS): Only translate if the message is a string key.
+    // If it's already SafeHtml, we bypass the translation to avoid TypeErrors
+    // and keep the trusted content intact.
+    const translated =
+      typeof message === 'string' ? this.#translate.instant(message, escapedParams) : message;
+
     return this.#sanitizer.bypassSecurityTrustHtml(translated);
   });
 }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix XSS in SharedConfirmFeatureComponent parameters

🚨 Severity: MEDIUM
💡 Vulnerability: Reflected XSS via non-string translation parameters and TypeError when passing SafeHtml as message key.
🎯 Impact: Malicious data in non-string translation parameters could execute arbitrary JS when rendered as SafeHtml. Admin dialogs using SafeHtml messages would crash due to ngx-translate expecting a string key.
🔧 Fix: Stringify and escape all translation parameters using `escapeHtml(String(value ?? ''))` and skip `ngx-translate` for non-string message inputs.
✅ Verification: Unit tests in `shared-confirm-data-access` specifically verify that array parameters are escaped and that SafeHtml messages do not trigger TypeErrors.

---
*PR created automatically by Jules for task [15266676363037466412](https://jules.google.com/task/15266676363037466412) started by @plastikaweb*