### PR TITLE
🎨 Palette: Localized Table Expansion and Actions

### DIFF
--- a/apps/eco-store/public/i18n/ca.json
+++ b/apps/eco-store/public/i18n/ca.json
@@ -24,6 +24,7 @@
       "later": "Més tard",
       "close": "Entès, tancar"
     },
+    "actions": "Accions",
     "delete": "Eliminar",
     "navigation": {
       "previous": "Tornar a la pàgina anterior",
@@ -84,7 +85,8 @@
       "categoryIcon": "Icona de la categoria {category}",
       "closeSidenav": "Tancar menú lateral",
       "openSidenav": "Obrir menú lateral",
-      "ecoIcon": "Icona ecològica"
+      "ecoIcon": "Icona ecològica",
+      "expandRow": "Expandir fila: {name}"
     },
     "paginator": {
       "firstPage": "Primera pàgina",

--- a/apps/eco-store/public/i18n/en.json
+++ b/apps/eco-store/public/i18n/en.json
@@ -24,6 +24,7 @@
       "later": "Later",
       "close": "Got it, close"
     },
+    "actions": "Actions",
     "delete": "Delete",
     "navigation": {
       "previous": "Go to previous page",
@@ -84,7 +85,8 @@
       "categoryIcon": "{category} icon",
       "closeSidenav": "Close side menu",
       "openSidenav": "Open side menu",
-      "ecoIcon": "Eco icon"
+      "ecoIcon": "Eco icon",
+      "expandRow": "Expand row: {name}"
     },
     "paginator": {
       "firstPage": "First page",

--- a/apps/eco-store/public/i18n/es.json
+++ b/apps/eco-store/public/i18n/es.json
@@ -24,6 +24,7 @@
       "later": "Más tarde",
       "close": "Entendido, cerrar"
     },
+    "actions": "Acciones",
     "delete": "Eliminar",
     "navigation": {
       "previous": "Volver a la página anterior",
@@ -84,7 +85,8 @@
       "categoryIcon": "{category} icono",
       "closeSidenav": "Cerrar menú lateral",
       "openSidenav": "Abrir menú lateral",
-      "ecoIcon": "Icono ecológico"
+      "ecoIcon": "Icono ecológico",
+      "expandRow": "Expandir fila: {name}"
     },
     "paginator": {
       "firstPage": "Primera página",

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
@@ -277,7 +277,9 @@
               [attr.aria-label]="
                 'common.a11y.expandRow' | translate: { name: resolveName(element.name) }
               "
-              [matTooltip]="'common.a11y.expandRow' | translate: { name: resolveName(element.name) }"
+              [matTooltip]="
+                'common.a11y.expandRow' | translate: { name: resolveName(element.name) }
+              "
               (click)="$event.stopPropagation(); updateExpandedElement(element)">
               @if (expandedElement()?.id === element.id) {
                 <mat-icon>keyboard_arrow_up</mat-icon>

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
@@ -171,7 +171,7 @@
                   fill
                   priority
                   placeholder="https://placehold.co/200"
-                  [alt]="row.name || ''"
+                  [alt]="resolveName(row.name)"
                   [ngSrc]="row[column.key] || ''"
                   [class]="column.cssClasses?.[1] || ''" />
               }
@@ -204,7 +204,7 @@
             [class]="
               'mat-cell-actions justify-center overflow-visible ' + (actionsColStyles() || '')
             ">
-            Accions
+            {{ 'common.actions' | translate }}
           </mat-header-cell>
           <mat-cell
             *matCellDef="let element"
@@ -267,18 +267,17 @@
 
       @if (expandable()) {
         <ng-container matColumnDef="expand" sticky="true">
-          <mat-header-cell
-            *matHeaderCellDef
-            aria-label="row"
-            class="max-w-[70px]"
-            aria-hidden="true"
+          <mat-header-cell *matHeaderCellDef class="max-w-[70px]"
             ><span class="invisible">expand</span></mat-header-cell
           >
           <mat-cell *matCellDef="let element" class="max-w-[70px]">
             <button
               matIconButton
-              aria-label="expand row"
               class="-left-sub"
+              [attr.aria-label]="
+                'common.a11y.expandRow' | translate: { name: resolveName(element.name) }
+              "
+              [matTooltip]="'common.a11y.expandRow' | translate: { name: resolveName(element.name) }"
               (click)="$event.stopPropagation(); updateExpandedElement(element)">
               @if (expandedElement()?.id === element.id) {
                 <mat-icon>keyboard_arrow_up</mat-icon>

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.spec.ts
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.spec.ts
@@ -62,4 +62,24 @@ describe('SharedTableUiComponent', () => {
     const results = await axe(fixture.nativeElement);
     expect(results).toHaveNoViolations();
   });
+
+  describe('resolveName', () => {
+    it('should return empty string if name is null', () => {
+      expect(component['resolveName'](null as any)).toBe('');
+    });
+
+    it('should return name if it is a string', () => {
+      expect(component['resolveName']('Test Name')).toBe('Test Name');
+    });
+
+    it('should resolve localized name based on locale', () => {
+      const localizedName = { ca: 'Nom', en: 'Name', es: 'Nombre' };
+      expect(component['resolveName'](localizedName)).toBe('Name');
+    });
+
+    it('should return first localized name if current locale is not found', () => {
+      const localizedName = { ca: 'Nom' };
+      expect(component['resolveName'](localizedName)).toBe('Nom');
+    });
+  });
 });

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
@@ -14,6 +14,7 @@ import {
   effect,
   inject,
   input,
+  LOCALE_ID,
   output,
   signal,
   TemplateRef,
@@ -32,8 +33,9 @@ import { MatSort, MatSortModule, Sort } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
 import { EntityId } from '@ngrx/signals/entities';
-import { BaseEntity, SortConfig } from '@plastik/core/entities';
+import { BaseEntity, LocalizedFields, SortConfig } from '@plastik/core/entities';
 import {
   FormattingTypes,
   SafeFormattedPipe,
@@ -84,6 +86,7 @@ import { OrderTableActionsElementsPipe } from '../utils/order-table-actions-elem
     SharedUtilFormattersModule,
     OrderTableActionsElementsPipe,
     SafeFormattedPipe,
+    TranslateModule,
   ],
   templateUrl: './shared-table-ui.component.html',
   styleUrl: './shared-table-ui.component.scss',
@@ -197,6 +200,7 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
 
   protected expandedElement = signal<T | null>(null);
   readonly #liveAnnouncer = inject(LiveAnnouncer);
+  readonly #locale = inject(LOCALE_ID);
 
   constructor() {
     this.dataSource.sortingDataAccessor = (data: T, sortHeaderId: string): string | number => {
@@ -302,6 +306,23 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
     requestAnimationFrame(() => {
       this.expandedElement.set(this.expandedElement()?.id === element?.id ? null : element);
     });
+  }
+
+  /**
+   * Resolves the name of an entity based on the current locale.
+   * @param {BaseEntity['name']} name The name to resolve.
+   * @returns {string} The resolved name.
+   */
+  protected resolveName(name: BaseEntity['name']): string {
+    if (!name) {
+      return '';
+    }
+    if (typeof name === 'string') {
+      return name;
+    }
+    const lang = this.#locale.split('-')[0];
+    const localized = name as LocalizedFields;
+    return localized[lang] || Object.values(localized)[0] || '';
   }
 
   #announceSortChange(sortState: Sort) {


### PR DESCRIPTION
### 🎨 Palette: Localized Table Expansion and Actions

#### 💡 What
This enhancement improves the accessibility and internationalization of the shared table component used across the monorepo. Specifically:
- The **"Actions"** column header is now localized using translation keys.
- **Expansion buttons** now feature contextual, localized `aria-label` and `matTooltip` (e.g., "Expand row: [Name]" instead of just "expand row").
- **Image alt tags** in table cells now use the localized entity name.
- Redundant and contradictory ARIA attributes on the expansion header have been removed for better screen reader compatibility.

#### 🎯 Why
Generic labels like "Accions" (hardcoded in Catalan) or "expand row" provide poor context for international users and assistive technology. By providing localized, contextual labels, we make the data grid more intuitive and accessible for everyone.

#### ♿ Accessibility
- Replaced generic expansion `aria-label` with a contextual one: `{{ 'common.a11y.expandRow' | translate: { name: resolveName(element.name) } }}`.
- Added `matTooltip` to the expansion button for visual consistency with the ARIA label.
- Removed `aria-label="row"` and `aria-hidden="true"` from the expansion header to follow best practices for non-content columns.
- Ensured image alt tags are localized.

#### ✅ Verification
- **Unit Tests:** Added and passed tests for the new `resolveName` utility in `shared-table-ui.component.spec.ts`.
- **Monorepo Coverage:** Ran `yarn test:ci` covering 22 projects (including `eco-store`, `llecoop`, and `nasa-images`) with 100% success.
- **Linter/i18n:** Verified all changes with `yarn lint` and `yarn i18n:validate`.
- **Build:** Verified with `yarn nx build eco-store`.

---
*PR created automatically by Jules for task [12355232392035111618](https://jules.google.com/task/12355232392035111618) started by @plastikaweb*