### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Reflected XSS and runtime errors in SharedConfirmFeatureComponent

### DIFF
--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
@@ -1,6 +1,7 @@
 import { DIALOG_DATA } from '@angular/cdk/dialog';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DomSanitizer } from '@angular/platform-browser';
 
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
@@ -29,6 +30,7 @@ describe('SharedConfirmFeatureComponent', () => {
     data: Record<string, unknown> = defaultData,
     translations: Record<string, string> = { 'test.message': 'Hello {{name}}' }
   ): Promise<void> {
+    TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [SharedConfirmFeatureComponent, TranslateModule.forRoot()],
       providers: [
@@ -84,5 +86,33 @@ describe('SharedConfirmFeatureComponent', () => {
     expect(rendered).toContain('<strong>');
     expect(rendered).toContain('&lt;b&gt;');
     expect(rendered).not.toContain('<b>x</b>');
+  });
+
+  it('should escape non-string params (arrays/objects) to prevent XSS', async () => {
+    await setup(
+      {
+        ...defaultData,
+        params: { list: ['<img src=x onerror=alert(1)>'] },
+      },
+      { 'test.message': 'Items: {{list}}' }
+    );
+
+    const rendered = messageOf();
+    expect(rendered).not.toContain('<img');
+    expect(rendered).toContain('&lt;img');
+  });
+
+  it('should not throw if the message is already SafeHtml (bypass translate.instant)', async () => {
+    await setup();
+    const sanitizer = TestBed.inject(DomSanitizer);
+    const safeMessage = sanitizer.bypassSecurityTrustHtml('<b>Safe</b>');
+
+    await setup({
+      ...defaultData,
+      message: safeMessage,
+    });
+
+    expect(() => messageOf()).not.toThrow();
+    expect(messageOf()?.toString()).toContain('<b>Safe</b>');
   });
 });

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
@@ -33,16 +33,19 @@ export class SharedConfirmFeatureComponent {
   protected readonly icon = computed(() => this.data.icon || 'help_outline');
 
   protected readonly message = computed(() => {
+    const message = this.data.message;
+    if (typeof message !== 'string') {
+      return message;
+    }
+
     const params = this.data.params;
     const escapedParams = params
       ? Object.fromEntries(
-          Object.entries(params).map(([key, value]) => [
-            key,
-            typeof value === 'string' ? escapeHtml(value) : value,
-          ])
+          Object.entries(params).map(([key, value]) => [key, escapeHtml(String(value ?? ''))])
         )
       : params;
-    const translated = this.#translate.instant(this.data.message, escapedParams);
+
+    const translated = this.#translate.instant(message, escapedParams);
     return this.#sanitizer.bypassSecurityTrustHtml(translated);
   });
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Reflected XSS via non-string translation parameters and Runtime error when passing pre-sanitized HTML.
🎯 Impact: Malicious users (or compromised admin data) could execute arbitrary JS if arrays/objects with malicious payloads were passed as translation parameters. Pre-sanitized `SafeHtml` messages would cause a `TypeError`, breaking admin dialogs.
🛠️ Fix:
- Updated `SharedConfirmFeatureComponent` to stringify and escape all translation parameters using `escapeHtml(String(value ?? ''))`.
- Added a type check to skip `translate.instant()` if the message is already a non-string (e.g., `SafeHtml`), preventing runtime errors and preserving pre-sanitized content.
✅ Verification:
- Added 2 new test cases to `shared-confirm-feature.component.spec.ts` covering non-string params and `SafeHtml` messages.
- Ran `yarn nx test shared-confirm-data-access`.
- Ran `yarn nx affected:test`.

---
*PR created automatically by Jules for task [6707660418778697148](https://jules.google.com/task/6707660418778697148) started by @plastikaweb*