### PR TITLE
🎨 Palette: Enhance button accessibility and disabled link state

### DIFF
--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
@@ -1,8 +1,10 @@
+@let isDisabled = (buttonConfig().disabled | returnAsObservable | ngrxPush) || false;
+
 @if (buttonConfig().type === 'button') {
   <button
     matButton
     [class]="`button--rounded ${buttonConfig().classes || ''}`"
-    [disabled]="buttonConfig().disabled"
+    [disabled]="isDisabled"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
     [attr.data-test]="buttonConfig().dataTestId"
@@ -16,9 +18,12 @@
     class="block"
     target="_blank"
     rel="noopener noreferrer"
+    [class.opacity-50]="isDisabled"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
-    [href]="linkHref()"
+    [attr.href]="isDisabled ? null : linkHref()"
+    [attr.tabindex]="isDisabled ? -1 : null"
+    [attr.aria-disabled]="isDisabled"
     [attr.data-test]="buttonConfig().dataTestId">
     <ng-container *ngTemplateOutlet="content">button content</ng-container>
   </a>
@@ -31,6 +36,7 @@
     }
     @if (element.type === 'icon') {
       <svg-icon
+        aria-hidden="true"
         [src]="(element.content | returnAsObservable | ngrxPush)?.iconPath || ''"
         [svgClass]="(element.content | returnAsObservable | ngrxPush)?.svgClass || ''"></svg-icon>
     }

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
@@ -6,7 +6,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { buttonMock } from '@plastik/shared/button';
+import { buttonAsLinkMock, buttonMock } from '@plastik/shared/button';
 
 import { SharedButtonUiComponent } from './shared-button-ui.component';
 
@@ -44,5 +44,31 @@ describe('SharedButtonUiComponent', () => {
   it('should have no accessibility violations', async () => {
     const results = await axe(fixture.nativeElement);
     expect(results).toHaveNoViolations();
+  });
+
+  it('should be disabled when buttonConfig.disabled is true', () => {
+    fixture.componentRef.setInput('buttonConfig', { ...buttonMock, disabled: true });
+    fixture.detectChanges();
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.disabled).toBe(true);
+  });
+
+  it('should handle link disabled state correctly', () => {
+    fixture.componentRef.setInput('buttonConfig', {
+      ...buttonAsLinkMock,
+      disabled: true,
+      link: 'http://example.com',
+    });
+    fixture.detectChanges();
+    const link = fixture.nativeElement.querySelector('a');
+    expect(link.getAttribute('href')).toBeNull();
+    expect(link.getAttribute('tabindex')).toBe('-1');
+    expect(link.getAttribute('aria-disabled')).toBe('true');
+    expect(link.classList.contains('opacity-50')).toBe(true);
+  });
+
+  it('should have aria-hidden="true" on svg-icon', () => {
+    const svgIcon = fixture.nativeElement.querySelector('svg-icon');
+    expect(svgIcon.getAttribute('aria-hidden')).toBe('true');
   });
 });


### PR DESCRIPTION
💡 What: Enhanced the `SharedButtonUiComponent` to properly handle disabled states for both buttons and links, and improved icon accessibility.
🎯 Why: Standard HTML links don't support the `disabled` attribute, leading to poor UX and accessibility when they need to be deactivated. Redundant icons were also being announced by screen readers.
♿ Accessibility: 
- Disabled links now have `aria-disabled="true"` and `tabindex="-1"`, and their `href` is removed to prevent navigation.
- Icons are now hidden from screen readers using `aria-hidden="true"` as the parent button already has a mandatory `aria-label`.

---
*PR created automatically by Jules for task [3856637086220523682](https://jules.google.com/task/3856637086220523682) started by @plastikaweb*