### PR TITLE
🎨 Palette: Improve table accessibility and localization

### DIFF
--- a/apps/eco-store/public/i18n/ca.json
+++ b/apps/eco-store/public/i18n/ca.json
@@ -9,6 +9,7 @@
     "submit": "Enviar",
     "save": "Guardar",
     "update": "Actualitzar",
+    "actions": "Accions",
     "pwa": {
       "title": "Porta l'Eco al teu mòbil",
       "description": "Aquest lloc té funcionalitats d'aplicació. Instal·la'l al teu dispositiu per a una àmplia experiència i fàcil accés.",
@@ -84,7 +85,9 @@
       "categoryIcon": "Icona de la categoria {category}",
       "closeSidenav": "Tancar menú lateral",
       "openSidenav": "Obrir menú lateral",
-      "ecoIcon": "Icona ecològica"
+      "ecoIcon": "Icona ecològica",
+      "expandRow": "Expandir fila: {name}",
+      "collapseRow": "Contraure fila: {name}"
     },
     "paginator": {
       "firstPage": "Primera pàgina",

--- a/apps/eco-store/public/i18n/en.json
+++ b/apps/eco-store/public/i18n/en.json
@@ -9,6 +9,7 @@
     "submit": "Submit",
     "save": "Save",
     "update": "Update",
+    "actions": "Actions",
     "pwa": {
       "title": "Bring Eco to your mobile",
       "description": "Install our app for a faster, more secure experience with offline access to your orders.",
@@ -84,7 +85,9 @@
       "categoryIcon": "{category} icon",
       "closeSidenav": "Close side menu",
       "openSidenav": "Open side menu",
-      "ecoIcon": "Eco icon"
+      "ecoIcon": "Eco icon",
+      "expandRow": "Expand row: {name}",
+      "collapseRow": "Collapse row: {name}"
     },
     "paginator": {
       "firstPage": "First page",

--- a/apps/eco-store/public/i18n/es.json
+++ b/apps/eco-store/public/i18n/es.json
@@ -9,6 +9,7 @@
     "submit": "Enviar",
     "save": "Guardar",
     "update": "Actualizar",
+    "actions": "Acciones",
     "pwa": {
       "title": "Lleva lo Eco en tu móvil",
       "description": "Instala nuestra app para una experiencia más rápida, segura y con acceso a tus pedidos sin conexión.",
@@ -84,7 +85,9 @@
       "categoryIcon": "{category} icono",
       "closeSidenav": "Cerrar menú lateral",
       "openSidenav": "Abrir menú lateral",
-      "ecoIcon": "Icono ecológico"
+      "ecoIcon": "Icono ecológico",
+      "expandRow": "Expandir fila: {name}",
+      "collapseRow": "Contraer fila: {name}"
     },
     "paginator": {
       "firstPage": "Primera página",

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.html
@@ -204,7 +204,7 @@
             [class]="
               'mat-cell-actions justify-center overflow-visible ' + (actionsColStyles() || '')
             ">
-            Accions
+            {{ 'common.actions' | translate }}
           </mat-header-cell>
           <mat-cell
             *matCellDef="let element"
@@ -275,12 +275,21 @@
             ><span class="invisible">expand</span></mat-header-cell
           >
           <mat-cell *matCellDef="let element" class="max-w-[70px]">
+            @let rowName = resolveName(element.name);
+            @let isExpanded = expandedElement()?.id === element.id;
             <button
               matIconButton
-              aria-label="expand row"
               class="-left-sub"
+              [attr.aria-label]="
+                (isExpanded ? 'common.a11y.collapseRow' : 'common.a11y.expandRow')
+                  | translate: { name: rowName }
+              "
+              [matTooltip]="
+                (isExpanded ? 'common.a11y.collapseRow' : 'common.a11y.expandRow')
+                  | translate: { name: rowName }
+              "
               (click)="$event.stopPropagation(); updateExpandedElement(element)">
-              @if (expandedElement()?.id === element.id) {
+              @if (isExpanded) {
                 <mat-icon>keyboard_arrow_up</mat-icon>
               } @else {
                 <mat-icon>keyboard_arrow_down</mat-icon>

--- a/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
+++ b/libs/shared/table/ui/src/lib/shared-table-ui/shared-table-ui.component.ts
@@ -14,6 +14,7 @@ import {
   effect,
   inject,
   input,
+  LOCALE_ID,
   output,
   signal,
   TemplateRef,
@@ -33,6 +34,7 @@ import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
 import { EntityId } from '@ngrx/signals/entities';
+import { TranslatePipe } from '@ngx-translate/core';
 import { BaseEntity, SortConfig } from '@plastik/core/entities';
 import {
   FormattingTypes,
@@ -84,6 +86,7 @@ import { OrderTableActionsElementsPipe } from '../utils/order-table-actions-elem
     SharedUtilFormattersModule,
     OrderTableActionsElementsPipe,
     SafeFormattedPipe,
+    TranslatePipe,
   ],
   templateUrl: './shared-table-ui.component.html',
   styleUrl: './shared-table-ui.component.scss',
@@ -197,6 +200,7 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
 
   protected expandedElement = signal<T | null>(null);
   readonly #liveAnnouncer = inject(LiveAnnouncer);
+  readonly #locale = inject(LOCALE_ID);
 
   constructor() {
     this.dataSource.sortingDataAccessor = (data: T, sortHeaderId: string): string | number => {
@@ -296,6 +300,17 @@ export class SharedTableUiComponent<T extends BaseEntity & { [key: string]: unkn
     }
     const result = editableAttr.onChanges?.(value, element);
     this.getChangedData.emit(result);
+  }
+
+  protected resolveName(name: BaseEntity['name']): string {
+    if (!name) {
+      return '';
+    }
+    if (typeof name === 'string') {
+      return name;
+    }
+    const lang = this.#locale.split('-')[0] as keyof LocalizedFields;
+    return name[lang] || '';
   }
 
   protected updateExpandedElement(element: T | null): void {


### PR DESCRIPTION
💡 What: This PR improves the accessibility and localization of the \`SharedTableUiComponent\`.
- Replaced the hardcoded Catalan "Accions" header with a translatable key.
- Replaced generic "expand row" ARIA labels with contextual ones that include the row's name (e.g., "Expand row: Apple").
- Added tooltips to the expansion buttons for visual consistency and clarity.
- Implemented a \`resolveName\` helper to correctly display names from both simple strings and localized field objects based on the current \`LOCALE_ID\`.

🎯 Why: 
- Screen reader users need context when interacting with multiple similar buttons (like expanding rows). 
- Hardcoded strings in shared components prevent full internationalization support.

♿ Accessibility:
- Contextual ARIA labels provide screen reader users with the name of the entity they are expanding or collapsing.
- Match tooltips with ARIA labels to ensure visual and non-visual consistency.

✅ Verification:
- Ran \`yarn nx lint shared-table-ui\`.
- Ran \`yarn nx test shared-table-ui\`.
- Ran \`yarn i18n:validate\`.

---
*PR created automatically by Jules for task [10567872774431446114](https://jules.google.com/task/10567872774431446114) started by @plastikaweb*