### PR TITLE
🎨 Palette: improve shared button UI accessibility and robustness

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-06 - Accessible Link Disabling
+**Learning:** Standard anchor links (`<a>`) in Angular do not support a native `disabled` state like buttons. Simply adding a class like `opacity-50` or `pointer-events-none` is insufficient because it fails screen-reader requirements and keyboard navigation (users can still tab into and activate it). To properly disable a link, one must nullify its `href` attribute, set `tabindex` to `-1`, add `aria-disabled="true"`, and apply visual cues.
+**Action:** When creating or refactoring custom components that act as links, ensure the `href` attribute is conditionally bound (`[attr.href]="isDisabled ? null : linkHref"`) and always pair it with `[attr.aria-disabled]="isDisabled"` and `[tabindex]="isDisabled ? -1 : 0"`.

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
@@ -1,8 +1,10 @@
+@let isDisabled = (buttonConfig().disabled | returnAsObservable | ngrxPush) || false;
+
 @if (buttonConfig().type === 'button') {
   <button
     matButton
     [class]="`button--rounded ${buttonConfig().classes || ''}`"
-    [disabled]="buttonConfig().disabled"
+    [disabled]="isDisabled"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
     [attr.data-test]="buttonConfig().dataTestId"
@@ -13,12 +15,16 @@
 
 @if (buttonConfig().type === 'link') {
   <a
-    class="block"
+    class="block transition-opacity"
     target="_blank"
     rel="noopener noreferrer"
+    [class.opacity-50]="isDisabled"
+    [class.cursor-not-allowed]="isDisabled"
+    [attr.aria-disabled]="isDisabled"
+    [tabindex]="isDisabled ? -1 : 0"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
-    [href]="linkHref()"
+    [attr.href]="isDisabled ? null : linkHref()"
     [attr.data-test]="buttonConfig().dataTestId">
     <ng-container *ngTemplateOutlet="content">button content</ng-container>
   </a>
@@ -31,6 +37,7 @@
     }
     @if (element.type === 'icon') {
       <svg-icon
+        aria-hidden="true"
         [src]="(element.content | returnAsObservable | ngrxPush)?.iconPath || ''"
         [svgClass]="(element.content | returnAsObservable | ngrxPush)?.svgClass || ''"></svg-icon>
     }

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
@@ -1,4 +1,5 @@
 import { AngularSvgIconModule } from 'angular-svg-icon';
+import { of } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 import { axe } from 'vitest-axe';
 
@@ -39,6 +40,18 @@ describe('SharedButtonUiComponent', () => {
     component.sendAction.subscribe(action => (result = action));
     component.onClick();
     expect(result).toEqual(result);
+  });
+
+  it('should handle disabled as an Observable', async () => {
+    fixture.componentRef.setInput('buttonConfig', {
+      ...buttonMock,
+      disabled: of(true),
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const buttonElement: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(buttonElement.disabled).toBe(true);
   });
 
   it('should have no accessibility violations', async () => {


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Enhanced `SharedButtonUiComponent` to handle `disabled` inputs more robustly and accessibly for both button and link variants.
- Integrated the Angular `@let` syntax to evaluate the disabled property (supporting both boolean and Observable types).
- Added `aria-hidden="true"` to SVG icons within the button content template to keep screen readers clean of decorative clutter.
- Implemented full keyboard and screen reader accessibility for disabled link variants by nullifying `href`, setting `tabindex` to `-1`, declaring `aria-disabled="true"`, and styling the disabled link state.
- Added a robust unit test to cover `disabled` as an Observable in the component spec.
- Added a Palette journal entry highlighting learnings around the challenges of disabling standard anchor elements in HTML.

### 🎯 Why: The user problem it solves
Interactive elements (especially links) that represent disabled states are often styled with lower opacity or `pointer-events-none` but remain fully accessible to screen readers and keyboard tab order, leading to broken interactions and confusing UX.

### 🖼️ Before/After
- **Before:** Disabled links would still have an active `href`, would be tab-focusable, and screen readers wouldn't know they are disabled. Inner decorative icons were announced by screen readers.
- **After:** Disabled links completely inhibit focus (`tabindex="-1"`), clear their target navigation (`href="null"`), announce their state accurately (`aria-disabled="true"`), and look disabled with high visual polish. Decorative icons are invisible to screen readers.

### ♿ Accessibility
- Uses `aria-hidden="true"` on decorative icons.
- Sets proper `aria-disabled` and `tabindex` on the anchor variant.
- Passed accessibility validation via `vitest-axe` in unit tests.

---
*PR created automatically by Jules for task [12465846222843012139](https://jules.google.com/task/12465846222843012139) started by @plastikaweb*