### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix XSS parameter bypasses and runtime crashes in SharedConfirmFeatureComponent

### DIFF
--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
@@ -85,4 +85,44 @@ describe('SharedConfirmFeatureComponent', () => {
     expect(rendered).toContain('&lt;b&gt;');
     expect(rendered).not.toContain('<b>x</b>');
   });
+
+  it('should return non-string messages directly (e.g. SafeHtml objects) to prevent split/runtime crashes', async () => {
+    const fakeSafeHtml = {
+      changingThisBreaksApplicationSecurity: 'bypass',
+      toString: () => '<span>Safe Message</span>',
+    };
+    await setup({
+      ...defaultData,
+      message: fakeSafeHtml,
+    });
+
+    const rendered = messageOf();
+    expect(rendered).toBe(fakeSafeHtml.toString());
+  });
+
+  it('should escape HTML in non-string params like arrays and objects to prevent XSS bypasses', async () => {
+    await setup({
+      ...defaultData,
+      params: { name: ['<img src=x onerror=alert(2)>', 'safe'] },
+    });
+
+    const rendered = messageOf();
+    expect(rendered).not.toContain('<img');
+    expect(rendered).toContain('&lt;img');
+  });
+
+  it('should preserve numbers unescaped to retain ICU pluralization functionality', async () => {
+    await setup(
+      {
+        ...defaultData,
+        params: { count: 123 },
+      },
+      {
+        'test.message': 'There are {{count}} items',
+      }
+    );
+
+    const rendered = messageOf();
+    expect(rendered).toContain('There are 123 items');
+  });
 });

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
@@ -33,13 +33,24 @@ export class SharedConfirmFeatureComponent {
   protected readonly icon = computed(() => this.data.icon || 'help_outline');
 
   protected readonly message = computed(() => {
+    // SECURITY (XSS): If the message is already SafeHtml (not a string), skip translation (instant)
+    // to prevent runtime TypeError in ngx-translate.
+    if (typeof this.data.message !== 'string') {
+      return this.data.message;
+    }
+
     const params = this.data.params;
+    // SECURITY (XSS): Escape user-controlled parameters to prevent Reflected XSS.
+    // Numbers are preserved unescaped to retain ICU pluralization functionality in ngx-translate.
+    // All other types (including arrays/objects) are stringified and HTML-escaped.
     const escapedParams = params
       ? Object.fromEntries(
-          Object.entries(params).map(([key, value]) => [
-            key,
-            typeof value === 'string' ? escapeHtml(value) : value,
-          ])
+          Object.entries(params).map(([key, value]) => {
+            if (typeof value === 'number') {
+              return [key, value];
+            }
+            return [key, escapeHtml(String(value ?? ''))];
+          })
         )
       : params;
     const translated = this.#translate.instant(this.data.message, escapedParams);


### PR DESCRIPTION
### 🚨 Severity
**Severity:** MEDIUM (Security Hardening and Defense-in-Depth Enhancement)

### 💡 Vulnerability
1. **Reflected XSS Bypass:** In `SharedConfirmFeatureComponent`, translation parameters were only escaped if they were exactly of type `string`. This allowed arrays or objects (such as `['<img src=x onerror=alert(1)>']`) to bypass the `typeof value === 'string'` check, get implicitly stringified by `ngx-translate` into the translation string, and subsequently bypassed by Angular's sanitization via `bypassSecurityTrustHtml()`, resulting in Reflected XSS.
2. **Runtime App Crash:** If `message` passed to `SharedConfirmFeatureComponent` was not a string (for example, a pre-sanitized `SafeHtml` object), calling `this.#translate.instant(this.data.message)` threw a `TypeError: key.split is not a function` in `ngx-translate`, causing critical administration confirmation dialogs to crash and fail to open.

### 🎯 Impact
- Attackers could potentially exploit dialog parameters to execute arbitrary JavaScript in the context of the user's browser session (Reflected XSS).
- The application crashes under specific workflows when rendering complex pre-sanitized HTML messages in confirmation dialogs, degrading user experience and breaking essential admin workflows.

### 🔧 Fix
- Skip translation (`instant()`) and directly return the message if it is a non-string object (e.g., `SafeHtml`), safely addressing SEC-07 and preventing runtime crashes.
- Whitelist `number` parameter types unescaped/unstringified to preserve ICU pluralization in `ngx-translate`.
- Cast and HTML-escape all other types (strings, arrays, objects, etc.) using `escapeHtml(String(value ?? ''))` to enforce complete sanitization and prevent any XSS bypass.
- Documented these security guarantees with `// SECURITY (XSS):` annotations.

### ✅ Verification
- Enhanced unit tests in `libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts` covering non-string messages, non-string translation parameters, and unescaped number parameters.
- Verified test suite passes successfully:
  ```bash
  yarn nx test shared-confirm-data-access
  ```
- Verified ESLint configuration:
  ```bash
  yarn nx lint shared-confirm-data-access
  ```

---
*PR created automatically by Jules for task [4413675695289715475](https://jules.google.com/task/4413675695289715475) started by @plastikaweb*