### PR TITLE
⚡ Bolt: Optimize property resolution hot-path in DataFormatFactoryService

### DIFF
--- a/libs/shared/util/formatters/src/lib/services/data-format-factory.service.ts
+++ b/libs/shared/util/formatters/src/lib/services/data-format-factory.service.ts
@@ -21,6 +21,7 @@ import { SharedUtilFormattersService } from './shared-util-formatters.service';
  */
 export class DataFormatFactoryService<T extends FormattingInput<keyof T> & BaseEntity> {
   readonly #formatter = inject(SharedUtilFormattersService);
+  readonly #pathCache = new Map<string, string[]>();
 
   /**
    * @description Factory to get the correct formatted value from item property with a custom formatting option.
@@ -93,9 +94,28 @@ export class DataFormatFactoryService<T extends FormattingInput<keyof T> & BaseE
    * @returns {FormattingOutput} The value at the specified path, or an empty string if not found.
    */
   #getValueFromRow(property: string, item: T extends BaseEntity ? T : never): FormattingOutput {
-    return property.split('.').reduce((accObject: unknown, currentProp: string) => {
-      const object = (accObject as T)[currentProp as keyof T];
-      return isNil(object) ? '' : (object as FormattingOutput);
-    }, item);
+    // Fast path: flat property (no dots).
+    if (property.indexOf('.') === -1) {
+      const val = item[property as keyof T];
+      return isNil(val) ? '' : (val as unknown as FormattingOutput);
+    }
+
+    // Cached path splitting.
+    let parts = this.#pathCache.get(property);
+    if (!parts) {
+      parts = property.split('.');
+      this.#pathCache.set(property, parts);
+    }
+
+    let acc: unknown = item;
+    const len = parts.length;
+    for (let i = 0; i < len; i++) {
+      if (isNil(acc)) {
+        return '';
+      }
+      acc = (acc as Record<string, unknown>)[parts[i]];
+    }
+
+    return isNil(acc) ? '' : (acc as FormattingOutput);
   }
 }


### PR DESCRIPTION
💡 **What:** Optimized the `#getValueFromRow` method in `DataFormatFactoryService` to make data formatting inside grid cells lightning-fast.

🎯 **Why:** Previously, `#getValueFromRow` was called for every cell rendering and split the dot-separated paths on every invocation. This caused heavy garbage collection overhead, function call/closure overhead due to `.reduce()`, and redundant string splits.

📊 **Impact:**
- Drastically reduces memory allocations and string splits on hot-paths (renders grids with multiple columns and thousands of rows).
- Fast-path for flat properties avoids any splitting or allocations.
- Loop-based nested resolution avoids `.reduce()` closure allocations.

🔬 **Measurement:** Tested with existing unit test suite in `shared-util-formatters`.

---
*PR created automatically by Jules for task [8694480913922750754](https://jules.google.com/task/8694480913922750754) started by @plastikaweb*