### PR TITLE
🎨 Palette: decouple search clear button from form validity

### DIFF
--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.html
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.html
@@ -37,7 +37,6 @@
       type="button"
       [attr.aria-label]="'common.form.clear' | translate"
       [matTooltip]="'common.form.clear' | translate"
-      [disabled]="formStatus() === 'INVALID' && !props.buttonEnabledIfValue"
       (click)="resetSearch()">
       <mat-icon aria-hidden="true">clear</mat-icon>
     </button>

--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.spec.ts
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.spec.ts
@@ -139,6 +139,7 @@ describe('InputSearchTypeComponent', () => {
     it('should keep the clear button enabled for a below-minLength term so it can be cleared', () => {
       component.field.props!.resetSearch = true;
       component.formControl.setValue('a');
+      component.formControl.setErrors({ minlength: true });
       component['syncControl']();
       fixture.detectChanges();
 


### PR DESCRIPTION
💡 What:
Removed the restriction that disabled the clear/reset search button when the input was in an 'INVALID' validation state.

🎯 Why:
Previously, if a user typed a search term that didn't meet validation rules (e.g., shorter than minLength), the entire form became INVALID and the clear button was disabled. This left the user stuck with an invalid input that they couldn't reset or clear using mouse or keyboard, resulting in a frustrating deadlock.

♿ Accessibility:
Ensured that the clear/reset button is always focusable, clickable, and reachable via keyboard/mouse when there is text inside the search input, regardless of validation status.

---
*PR created automatically by Jules for task [10746661454962169173](https://jules.google.com/task/10746661454962169173) started by @plastikaweb*