### PR TITLE
🎨 Palette: Improve SharedButtonUi reactive disabled states and link accessibility

### DIFF
--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
@@ -1,8 +1,10 @@
+@let isDisabled = (buttonConfig().disabled | returnAsObservable | ngrxPush) || false;
+
 @if (buttonConfig().type === 'button') {
   <button
     matButton
     [class]="`button--rounded ${buttonConfig().classes || ''}`"
-    [disabled]="buttonConfig().disabled"
+    [disabled]="isDisabled"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
     [attr.data-test]="buttonConfig().dataTestId"
@@ -16,9 +18,13 @@
     class="block"
     target="_blank"
     rel="noopener noreferrer"
+    [class.opacity-50]="isDisabled"
+    [class.cursor-not-allowed]="isDisabled"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
-    [href]="linkHref()"
+    [attr.href]="isDisabled ? null : linkHref()"
+    [attr.tabindex]="isDisabled ? -1 : null"
+    [attr.aria-disabled]="isDisabled ? 'true' : null"
     [attr.data-test]="buttonConfig().dataTestId">
     <ng-container *ngTemplateOutlet="content">button content</ng-container>
   </a>
@@ -31,6 +37,7 @@
     }
     @if (element.type === 'icon') {
       <svg-icon
+        aria-hidden="true"
         [src]="(element.content | returnAsObservable | ngrxPush)?.iconPath || ''"
         [svgClass]="(element.content | returnAsObservable | ngrxPush)?.svgClass || ''"></svg-icon>
     }

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
@@ -1,4 +1,5 @@
 import { AngularSvgIconModule } from 'angular-svg-icon';
+import { of } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 import { axe } from 'vitest-axe';
 
@@ -6,7 +7,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { buttonMock } from '@plastik/shared/button';
+import { buttonAsLinkMock, buttonMock } from '@plastik/shared/button';
 
 import { SharedButtonUiComponent } from './shared-button-ui.component';
 
@@ -38,11 +39,112 @@ describe('SharedButtonUiComponent', () => {
     let result;
     component.sendAction.subscribe(action => (result = action));
     component.onClick();
-    expect(result).toEqual(result);
+    expect(result).not.toBeNull();
   });
 
   it('should have no accessibility violations', async () => {
     const results = await axe(fixture.nativeElement);
     expect(results).toHaveNoViolations();
+  });
+
+  describe('disabled state for type: button', () => {
+    it('should natively disable the button when config.disabled is true', async () => {
+      fixture.componentRef.setInput('buttonConfig', {
+        ...buttonMock,
+        disabled: true,
+      });
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const buttonEl = fixture.nativeElement.querySelector('button');
+      expect(buttonEl.disabled).toBe(true);
+    });
+
+    it('should natively disable the button when config.disabled is an observable emitting true', async () => {
+      fixture.componentRef.setInput('buttonConfig', {
+        ...buttonMock,
+        disabled: of(true),
+      });
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const buttonEl = fixture.nativeElement.querySelector('button');
+      expect(buttonEl.disabled).toBe(true);
+    });
+
+    it('should not disable the button when config.disabled is false', async () => {
+      fixture.componentRef.setInput('buttonConfig', {
+        ...buttonMock,
+        disabled: false,
+      });
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const buttonEl = fixture.nativeElement.querySelector('button');
+      expect(buttonEl.disabled).toBe(false);
+    });
+  });
+
+  describe('disabled state for type: link', () => {
+    it('should handle standard enabled links correctly', async () => {
+      fixture.componentRef.setInput('buttonConfig', {
+        ...buttonAsLinkMock,
+        link: 'https://example.com',
+        disabled: false,
+      });
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const linkEl = fixture.nativeElement.querySelector('a');
+      expect(linkEl.getAttribute('href')).toBe('https://example.com');
+      expect(linkEl.getAttribute('tabindex')).toBeNull();
+      expect(linkEl.getAttribute('aria-disabled')).toBeNull();
+      expect(linkEl.classList.contains('opacity-50')).toBe(false);
+      expect(linkEl.classList.contains('cursor-not-allowed')).toBe(false);
+    });
+
+    it('should modify anchor attributes and classes when link is disabled', async () => {
+      fixture.componentRef.setInput('buttonConfig', {
+        ...buttonAsLinkMock,
+        link: 'https://example.com',
+        disabled: true,
+      });
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const linkEl = fixture.nativeElement.querySelector('a');
+      expect(linkEl.getAttribute('href')).toBeNull();
+      expect(linkEl.getAttribute('tabindex')).toBe('-1');
+      expect(linkEl.getAttribute('aria-disabled')).toBe('true');
+      expect(linkEl.classList.contains('opacity-50')).toBe(true);
+      expect(linkEl.classList.contains('cursor-not-allowed')).toBe(true);
+    });
+
+    it('should modify anchor attributes when link is disabled by observable', async () => {
+      fixture.componentRef.setInput('buttonConfig', {
+        ...buttonAsLinkMock,
+        link: 'https://example.com',
+        disabled: of(true),
+      });
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const linkEl = fixture.nativeElement.querySelector('a');
+      expect(linkEl.getAttribute('href')).toBeNull();
+      expect(linkEl.getAttribute('tabindex')).toBe('-1');
+      expect(linkEl.getAttribute('aria-disabled')).toBe('true');
+    });
+  });
+
+  describe('SVG icon accessibility', () => {
+    it('should set aria-hidden="true" on internal decorative icons', async () => {
+      fixture.componentRef.setInput('buttonConfig', buttonMock);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const iconEl = fixture.nativeElement.querySelector('svg-icon');
+      expect(iconEl).toBeTruthy();
+      expect(iconEl.getAttribute('aria-hidden')).toBe('true');
+    });
   });
 });


### PR DESCRIPTION
🎨 Palette: Improve SharedButtonUi reactive disabled states and link accessibility

💡 What:
- Implemented reactive state management for disabled buttons and links.
- Set proper accessibility tags on disabled links (`tabindex="-1"`, `aria-disabled="true"`, and conditional `href` nullification).
- Appended `aria-hidden="true"` to decorative inner icons.
- Reordered template attributes to satisfy `@angular-eslint` rules.
- Expanded vitest coverage with 7 additional high-quality test cases for the disabled behaviors.

🎯 Why:
- Native HTML anchor (`<a>`) elements do not support `disabled`. Simply using CSS `pointer-events-none` prevents tooltips and other hover interactions from functioning.
- Screen readers should ignore inner icons when screen reader text is already present.

♿ Accessibility:
- Handled keyboard navigation for disabled links by removing them from focus flow via `tabindex="-1"`.
- Handled screen readers correctly with `aria-disabled="true"` and `aria-hidden="true"` where appropriate.

---
*PR created automatically by Jules for task [12133892313197961860](https://jules.google.com/task/12133892313197961860) started by @plastikaweb*