### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix XSS in Llecoop order tables

### DIFF
--- a/libs/llecoop/order-list/feature/user-order-detail/src/lib/user-order-detail-table-form.config.ts
+++ b/libs/llecoop/order-list/feature/user-order-detail/src/lib/user-order-detail-table-form.config.ts
@@ -79,7 +79,10 @@ export class LlecoopUserOrderDetailFormTableConfig implements TableStructureConf
       type: 'CUSTOM',
       execute: (value, element) => {
         const price = `<p>${Number(value).toFixed(2)} €</p>`;
-        const unit = element?.unit ? this.#productBaseUnitTextPipe.transform(element.unit) : '';
+        // SECURITY (XSS): escape the dynamic unit text since it is passed into bypassSecurityTrustHtml
+        const unit = element?.unit
+          ? escapeHtml(this.#productBaseUnitTextPipe.transform(element.unit))
+          : '';
 
         return this.#sanitizer.bypassSecurityTrustHtml(`${price} ${unit}`) as SafeHtml;
       },

--- a/libs/llecoop/order-list/feature/user-order-resume/src/lib/llecoop-user-order-feature-resume/user-order-feature-resume-table.config.ts
+++ b/libs/llecoop/order-list/feature/user-order-resume/src/lib/llecoop-user-order-feature-resume/user-order-feature-resume-table.config.ts
@@ -32,8 +32,9 @@ export class LlecoopUserOrderResumeTableConfig implements TableStructureConfig<L
       type: 'CUSTOM',
       execute: (_, product) => {
         const name = `<p class="font-bold uppercase">${escapeHtml(product?.name ?? '')}</p>`;
+        // SECURITY (XSS): escape the dynamic unit text since it is passed into bypassSecurityTrustHtml
         const unit = product?.unit
-          ? `<p class="font-bold text-sm">${Number(product?.price).toFixed(2)} € x ${this.#productBaseUnitTextPipe.transform(product.unit)}</p>`
+          ? `<p class="font-bold text-sm">${Number(product?.price).toFixed(2)} € x ${escapeHtml(this.#productBaseUnitTextPipe.transform(product.unit))}</p>`
           : '';
         const info = product?.info
           ? `<p class="font-bold">${escapeHtml(product?.info ?? '')}</p>`


### PR DESCRIPTION
### 🚨 Severity
MEDIUM

### 💡 Vulnerability
Unescaped dynamic values from `LlecoopProductBaseUnitTextPipe.transform()` are directly concatenated into safe HTML templates within `bypassSecurityTrustHtml` inside table column formatting execution handlers.

### 🎯 Impact
Maliciously crafted product unit fields stored in the database could bypass sanitization sinks, potentially allowing stored Cross-Site Scripting (XSS) when rendered inside order detail or resume grids.

### 🛠️ Fix
Wrapped `this.#productBaseUnitTextPipe.transform()` results in `escapeHtml()` in both config files and added `// SECURITY (XSS):` comments to document the mitigation context.

### ✅ Verification
Ran `yarn nx test` and `yarn nx lint` for both `llecoop-user-order-feature-detail` and `llecoop-user-order-feature-resume` projects. All tests passed, and formatting is secure and compliant.

---
*PR created automatically by Jules for task [1985573681591000649](https://jules.google.com/task/1985573681591000649) started by @plastikaweb*