### PR TITLE
⚡ Bolt: Optimize Shared Grid Cell Formatters and Property Resolution Hot-paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-07-06] - Shared: TECH-14 — Optimize Shared Grid Cell Formatters and Property Resolution Hot-paths
+
+### Changed
+
+- **`libs/shared/util/formatters` (`SharedUtilFormattersService`, `DataFormatFactoryService`)**: optimized grid cell formatters to use a zero-allocation fast-path when optional `extras` are omitted, and completely eliminated object-spread/destructuring overhead when `extras` are provided. Also optimized property resolution hot-path `#getValueFromRow` in `DataFormatFactoryService` by implementing a flat-property fast-path (bypassing split and reduce entirely) and caching pre-split nested path strings in a private `#pathCache` Map to reduce garbage collection pressure.
+
 ## [2026-07-05] - Eco Store: PRV-02c — in-session password change
 
 ### Added

--- a/libs/shared/util/formatters/src/lib/services/data-format-factory.service.ts
+++ b/libs/shared/util/formatters/src/lib/services/data-format-factory.service.ts
@@ -21,6 +21,7 @@ import { SharedUtilFormattersService } from './shared-util-formatters.service';
  */
 export class DataFormatFactoryService<T extends FormattingInput<keyof T> & BaseEntity> {
   readonly #formatter = inject(SharedUtilFormattersService);
+  readonly #pathCache = new Map<string, string[]>();
 
   /**
    * @description Factory to get the correct formatted value from item property with a custom formatting option.
@@ -93,9 +94,26 @@ export class DataFormatFactoryService<T extends FormattingInput<keyof T> & BaseE
    * @returns {FormattingOutput} The value at the specified path, or an empty string if not found.
    */
   #getValueFromRow(property: string, item: T extends BaseEntity ? T : never): FormattingOutput {
-    return property.split('.').reduce((accObject: unknown, currentProp: string) => {
-      const object = (accObject as T)[currentProp as keyof T];
-      return isNil(object) ? '' : (object as FormattingOutput);
-    }, item);
+    if (!property.includes('.')) {
+      const value = item[property as keyof T];
+      return isNil(value) ? '' : (value as FormattingOutput);
+    }
+
+    let parts = this.#pathCache.get(property);
+    if (!parts) {
+      parts = property.split('.');
+      this.#pathCache.set(property, parts);
+    }
+
+    let current: unknown = item;
+    const length = parts.length;
+    for (let i = 0; i < length; i++) {
+      if (isNil(current)) {
+        return '';
+      }
+      current = (current as Record<string, unknown>)[parts[i]];
+    }
+
+    return isNil(current) ? '' : (current as FormattingOutput);
   }
 }

--- a/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
+++ b/libs/shared/util/formatters/src/lib/services/shared-util-formatters.service.ts
@@ -40,20 +40,19 @@ export class SharedUtilFormattersService {
     value: FormattingDateInput,
     extras?: () => Partial<Pick<FormattingExtras<'DATE'>, 'dateDigitsInfo' | 'locale' | 'timezone'>>
   ): string {
-    let format = {
-      dateDigitsInfo: 'shortDate',
-      locale: this.#locale,
-      timezone: this.#timezone,
-    };
-
-    if (extras) {
-      format = {
-        ...format,
-        ...extras(),
-      };
+    if (!extras) {
+      return formatDate(value, 'shortDate', this.#locale, this.#timezone) || '';
     }
 
-    return formatDate(value, format.dateDigitsInfo, format.locale, format.timezone) || '';
+    const format = extras();
+    return (
+      formatDate(
+        value,
+        format.dateDigitsInfo ?? 'shortDate',
+        format.locale ?? this.#locale,
+        format.timezone ?? this.#timezone
+      ) || ''
+    );
   }
 
   /**
@@ -68,18 +67,19 @@ export class SharedUtilFormattersService {
     value: FormattingDateInput,
     extras?: () => Partial<Pick<FormattingExtras<'DATE_TIME'>, 'locale' | 'timezone'>>
   ): string {
-    let format = {
-      locale: this.#locale,
-      timezone: this.#timezone,
-    };
-
-    if (extras) {
-      format = {
-        ...format,
-        ...extras(),
-      };
+    if (!extras) {
+      return formatDate(value, 'M/d/yy, HH:mm:ss', this.#locale, this.#timezone) || '';
     }
-    return formatDate(value, 'M/d/yy, HH:mm:ss', format.locale, format.timezone) || '';
+
+    const format = extras();
+    return (
+      formatDate(
+        value,
+        'M/d/yy, HH:mm:ss',
+        format.locale ?? this.#locale,
+        format.timezone ?? this.#timezone
+      ) || ''
+    );
   }
 
   /**
@@ -93,22 +93,23 @@ export class SharedUtilFormattersService {
     value: Timestamp,
     extras?: () => Partial<Pick<FormattingExtras<'DATE'>, 'dateDigitsInfo' | 'locale' | 'timezone'>>
   ): string {
-    let format = {
-      dateDigitsInfo: 'shortDate',
-      locale: this.#locale,
-      timezone: this.#timezone,
-    };
-
-    if (extras) {
-      format = {
-        ...format,
-        ...extras(),
-      };
+    if (!value) {
+      return '-';
     }
 
-    return value
-      ? formatDate(value?.toDate(), format.dateDigitsInfo, format.locale, format.timezone)
-      : '-';
+    if (!extras) {
+      return formatDate(value.toDate(), 'shortDate', this.#locale, this.#timezone) || '';
+    }
+
+    const format = extras();
+    return (
+      formatDate(
+        value.toDate(),
+        format.dateDigitsInfo ?? 'shortDate',
+        format.locale ?? this.#locale,
+        format.timezone ?? this.#timezone
+      ) || ''
+    );
   }
 
   /**
@@ -121,18 +122,18 @@ export class SharedUtilFormattersService {
     value: number,
     extras?: () => Partial<Pick<FormattingExtras<'PERCENTAGE'>, 'numberDigitsInfo' | 'locale'>>
   ): string {
-    let format = {
-      numberDigitsInfo: '1.2-2',
-      locale: this.#locale,
-    };
-    if (extras) {
-      format = {
-        ...format,
-        ...extras(),
-      };
+    if (!extras) {
+      return formatPercent(Number(value) / 100, this.#locale, '1.2-2') || '';
     }
 
-    return formatPercent(Number(value) / 100, format.locale, format.numberDigitsInfo) || '';
+    const format = extras();
+    return (
+      formatPercent(
+        Number(value) / 100,
+        format.locale ?? this.#locale,
+        format.numberDigitsInfo ?? '1.2-2'
+      ) || ''
+    );
   }
 
   /**
@@ -150,25 +151,18 @@ export class SharedUtilFormattersService {
       >
     >
   ): string {
-    let format = {
-      numberDigitsInfo: '1.2-2',
-      locale: this.#locale,
-      currency: '€',
-      currencyCode: 'EUR',
-    };
-    if (extras) {
-      format = {
-        ...format,
-        ...extras(),
-      };
+    if (!extras) {
+      return formatCurrency(value, this.#locale, '€', 'EUR', '1.2-2') || '';
     }
+
+    const format = extras();
     return (
       formatCurrency(
         value,
-        format.locale,
-        format.currency,
-        format.currencyCode,
-        format.numberDigitsInfo
+        format.locale ?? this.#locale,
+        format.currency ?? '€',
+        format.currencyCode ?? 'EUR',
+        format.numberDigitsInfo ?? '1.2-2'
       ) || ''
     );
   }
@@ -184,17 +178,15 @@ export class SharedUtilFormattersService {
     value: number,
     extras?: () => Partial<Pick<FormattingExtras<'NUMBER'>, 'numberDigitsInfo' | 'locale'>>
   ): string {
-    let format = {
-      numberDigitsInfo: '1.2-2',
-      locale: this.#locale,
-    };
-    if (extras) {
-      format = {
-        ...format,
-        ...extras(),
-      };
+    if (!extras) {
+      return formatNumber(Number(value), this.#locale, '1.2-2') || '';
     }
-    return formatNumber(Number(value), format.locale, format.numberDigitsInfo) || '';
+
+    const format = extras();
+    return (
+      formatNumber(Number(value), format.locale ?? this.#locale, format.numberDigitsInfo ?? '1.2-2') ||
+      ''
+    );
   }
 
   /**
@@ -214,20 +206,20 @@ export class SharedUtilFormattersService {
       Pick<FormattingExtras<'QUANTITY'>, 'numberDigitsInfo' | 'locale' | 'suffix' | 'prefix'>
     >
   ): string {
-    let format = {
-      numberDigitsInfo: '1.2-2',
-      locale: this.#locale,
-      suffix: '',
-      prefix: '',
-    };
-    if (extras) {
-      format = {
-        ...format,
-        ...extras(item),
-      };
+    if (!extras) {
+      const formattedNumber = formatNumber(Number(value), this.#locale, '1.2-2');
+      return formattedNumber.trim();
     }
-    const formattedNumber = formatNumber(Number(value), format.locale, format.numberDigitsInfo);
-    return `${format.prefix || ''}${formattedNumber}${format.suffix || ''}`.trim();
+
+    const format = extras(item);
+    const formattedNumber = formatNumber(
+      Number(value),
+      format.locale ?? this.#locale,
+      format.numberDigitsInfo ?? '1.2-2'
+    );
+    const prefix = format.prefix || '';
+    const suffix = format.suffix || '';
+    return `${prefix}${formattedNumber}${suffix}`.trim();
   }
 
   /**
@@ -250,18 +242,17 @@ export class SharedUtilFormattersService {
     value: boolean,
     extras?: () => FormattingExtras<'BOOLEAN_WITH_ICON'>
   ): SafeHtml {
-    let format = {
-      iconTrue: 'check',
-      iconFalse: 'close',
-    };
-    if (extras) {
-      format = {
-        ...format,
-        ...extras(),
-      };
+    if (!extras) {
+      return this.#sanitizer.bypassSecurityTrustHtml(
+        `<span class="material-icons">${escapeHtml(value ? 'check' : 'close')}</span>`
+      );
     }
+
+    const format = extras();
     return this.#sanitizer.bypassSecurityTrustHtml(
-      `<span class="material-icons">${escapeHtml(value ? format.iconTrue : format.iconFalse)}</span>`
+      `<span class="material-icons">${escapeHtml(
+        value ? format.iconTrue ?? 'check' : format.iconFalse ?? 'close'
+      )}</span>`
     );
   }
 


### PR DESCRIPTION
### 💡 What
Optimized performance across `SharedUtilFormattersService` and `DataFormatFactoryService`.

### 🎯 Why
- **`SharedUtilFormattersService`**: Default options objects were being repeatedly allocated and shallow-merged (using object-spread operations) even when `extras` was omitted or when it returned simple defaults. This caused high garbage collection (GC) churn inside templates and grids.
- **`DataFormatFactoryService`**: In `#getValueFromRow`, resolving nested properties always split the path key by `.` and ran `.reduce()` over the array. For flat properties, this created unnecessary intermediate arrays and closures on every row evaluation.

### 📊 Expected Impact
- **Zero-allocation fast-paths** for formatters when `extras` is omitted.
- Bypassing string splitting and `.reduce` entirely for flat property resolutions.
- **Pre-cached path splitting via Map** for nested paths, avoiding string parsing on subsequent template evaluates.
- Significant reduction in CPU time and GC overhead in tables and grids.

### 🔬 Measurement
All `shared-util-formatters` unit tests have run and passed successfully.

---
*PR created automatically by Jules for task [8653284396553973813](https://jules.google.com/task/8653284396553973813) started by @plastikaweb*