### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS and pluralization crash in confirm dialog

### DIFF
--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.spec.ts
@@ -85,4 +85,42 @@ describe('SharedConfirmFeatureComponent', () => {
     expect(rendered).toContain('&lt;b&gt;');
     expect(rendered).not.toContain('<b>x</b>');
   });
+
+  it('should not escape numeric translation parameters to preserve ICU pluralization', async () => {
+    await setup(
+      { ...defaultData, params: { count: 123 } },
+      {
+        'test.message': 'You have {{count}} items',
+      }
+    );
+
+    const rendered = messageOf();
+    expect(rendered).toContain('You have 123 items');
+  });
+
+  it('should safely stringify and escape array or object translation parameters', async () => {
+    await setup(
+      { ...defaultData, params: { name: ['<script>alert(1)</script>', 'clean'] } },
+      {
+        'test.message': 'Items: {{name}}',
+      }
+    );
+
+    const rendered = messageOf();
+    expect(rendered).not.toContain('<script>');
+    expect(rendered).toContain('&lt;script&gt;alert(1)&lt;&#x2F;script&gt;,clean');
+  });
+
+  it('should bypass translation and return non-string messages directly (like SafeHtml)', async () => {
+    const fakeSafeHtml = {
+      changingThisBreaksApplicationSecurity: '<strong>Trusted SafeHtml</strong>',
+    };
+    await setup({
+      ...defaultData,
+      message: fakeSafeHtml,
+    });
+
+    const rendered = (component as unknown as { message: () => unknown }).message();
+    expect(rendered).toBe(fakeSafeHtml);
+  });
 });

--- a/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
+++ b/libs/shared/confirm/data-access/src/lib/shared-confirm-feature.component.ts
@@ -33,16 +33,21 @@ export class SharedConfirmFeatureComponent {
   protected readonly icon = computed(() => this.data.icon || 'help_outline');
 
   protected readonly message = computed(() => {
+    const message = this.data.message;
+    if (typeof message !== 'string') {
+      // SECURITY (XSS): Skip translation and return message as-is if it is already SafeHtml or not a string to avoid runtime translation errors.
+      return message;
+    }
     const params = this.data.params;
     const escapedParams = params
       ? Object.fromEntries(
           Object.entries(params).map(([key, value]) => [
             key,
-            typeof value === 'string' ? escapeHtml(value) : value,
+            typeof value === 'number' ? value : escapeHtml(String(value ?? '')),
           ])
         )
       : params;
-    const translated = this.#translate.instant(this.data.message, escapedParams);
+    const translated = this.#translate.instant(message, escapedParams);
     return this.#sanitizer.bypassSecurityTrustHtml(translated);
   });
 }


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix XSS and pluralization crash in confirm dialog

🚨 **Severity**: HIGH

💡 **Vulnerability**: Potential Reflected XSS via translation parameters (if non-string parameter types bypassed the previous guard) and a runtime crash (if non-string `SafeHtml` message keys were processed by the translation service).

🎯 **Impact**: Attackers could execute arbitrary scripts in the administrator context if dynamic parameters contained unescaped markup. Additionally, any actions attempting to render `SafeHtml` directly inside confirmation dialogs would fail and crash with `TypeError`.

🛠️ **Fix**: 
- Updated `SharedConfirmFeatureComponent` to skip translation and return the message directly if it is not of type `string` (such as `SafeHtml`).
- Updated parameter escaping to stringify and escape all values (`escapeHtml(String(value ?? ''))`) EXCEPT those of type `number` (preserving ICU pluralization functionality).
- Added comprehensive unit tests in `shared-confirm-feature.component.spec.ts`.
- Documented findings in `.jules/sentinel.md`.

✅ **Verification**: Ran `yarn nx test shared-confirm-data-access` which compiles and executes all 7 tests successfully.

---
*PR created automatically by Jules for task [3348489677710836742](https://jules.google.com/task/3348489677710836742) started by @plastikaweb*