### PR TITLE
🎨 Palette: ensure search clear button remains interactive when invalid

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+# Palette's UX & Accessibility Journal
+
+This journal logs critical UX and accessibility (a11y) insights, surprising behaviors, design system constraints, and lessons learned.
+
+## 2026-07-07 - Unconditional Search Reset Pattern
+**Learning:** The clear/reset button for a search input field should never be disabled, even if the form control is invalid (for example, when the search term is below the mandatory `minLength`). Disabling this button traps keyboard and mouse users, forcing them to manually backspace or select-all and delete the text rather than clearing it with a single, highly accessible click/action.
+**Action:** Ensure reset buttons are always interactive as long as a value is present in the input field, decoupling their disabled status from standard form validation states.

--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.html
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.html
@@ -37,7 +37,6 @@
       type="button"
       [attr.aria-label]="'common.form.clear' | translate"
       [matTooltip]="'common.form.clear' | translate"
-      [disabled]="formStatus() === 'INVALID' && !props.buttonEnabledIfValue"
       (click)="resetSearch()">
       <mat-icon aria-hidden="true">clear</mat-icon>
     </button>


### PR DESCRIPTION
💡 What: Removed the [disabled] property binding on the clear/reset button in the Formly search input component.
🎯 Why: When the search query is too short (below minLength), Formly sets the control to INVALID, which disabled the clear button. This trapped users, forcing them to manually clear the input field with backspace/delete instead of using the simple, highly accessible clear/reset button.
📸 Before/After: Before: reset button is disabled and unclickable when search query is shorter than minLength. After: reset button remains fully interactive and functional.
♿ Accessibility: Ensures keyboard and mouse users can always reset and clear invalid/short search terms unconditionally.

---
*PR created automatically by Jules for task [12897118981167445427](https://jules.google.com/task/12897118981167445427) started by @plastikaweb*