### PR TITLE
🎨 Palette: Enhance accessibility and reactive disabled state in SharedButtonUiComponent

### DIFF
--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.html
@@ -1,8 +1,10 @@
+@let isDisabled = (buttonConfig().disabled | returnAsObservable | ngrxPush) || false;
+
 @if (buttonConfig().type === 'button') {
   <button
     matButton
     [class]="`button--rounded ${buttonConfig().classes || ''}`"
-    [disabled]="buttonConfig().disabled"
+    [disabled]="isDisabled"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
     [attr.data-test]="buttonConfig().dataTestId"
@@ -16,9 +18,12 @@
     class="block"
     target="_blank"
     rel="noopener noreferrer"
+    [class.opacity-50]="isDisabled"
+    [attr.tabindex]="isDisabled ? -1 : null"
+    [attr.aria-disabled]="isDisabled ? 'true' : null"
     [attr.aria-label]="buttonConfig().ariaLabel"
     [matTooltip]="buttonConfig().tooltip || buttonConfig().ariaLabel"
-    [href]="linkHref()"
+    [attr.href]="isDisabled ? null : linkHref()"
     [attr.data-test]="buttonConfig().dataTestId">
     <ng-container *ngTemplateOutlet="content">button content</ng-container>
   </a>
@@ -31,6 +36,7 @@
     }
     @if (element.type === 'icon') {
       <svg-icon
+        [attr.aria-hidden]="buttonConfig().ariaLabel ? 'true' : null"
         [src]="(element.content | returnAsObservable | ngrxPush)?.iconPath || ''"
         [svgClass]="(element.content | returnAsObservable | ngrxPush)?.svgClass || ''"></svg-icon>
     }

--- a/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
+++ b/libs/shared/button/ui/src/lib/shared-button-ui/shared-button-ui.component.spec.ts
@@ -1,3 +1,4 @@
+import { of } from 'rxjs';
 import { AngularSvgIconModule } from 'angular-svg-icon';
 import { describe, expect, it } from 'vitest';
 import { axe } from 'vitest-axe';
@@ -6,7 +7,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { buttonMock } from '@plastik/shared/button';
+import { buttonAsLinkMock, buttonMock } from '@plastik/shared/button';
 
 import { SharedButtonUiComponent } from './shared-button-ui.component';
 
@@ -39,6 +40,66 @@ describe('SharedButtonUiComponent', () => {
     component.sendAction.subscribe(action => (result = action));
     component.onClick();
     expect(result).toEqual(result);
+  });
+
+  it('should support button disabled state', async () => {
+    fixture.componentRef.setInput('buttonConfig', {
+      ...buttonMock,
+      disabled: true,
+    });
+    fixture.detectChanges();
+
+    const buttonEl = fixture.nativeElement.querySelector('button');
+    expect(buttonEl.disabled).toBe(true);
+  });
+
+  it('should support button disabled state via Observable', async () => {
+    fixture.componentRef.setInput('buttonConfig', {
+      ...buttonMock,
+      disabled: of(true),
+    });
+    fixture.detectChanges();
+
+    const buttonEl = fixture.nativeElement.querySelector('button');
+    expect(buttonEl.disabled).toBe(true);
+  });
+
+  it('should support active link button', async () => {
+    const linkMock = {
+      ...buttonAsLinkMock,
+      link: 'https://example.com',
+    };
+    fixture.componentRef.setInput('buttonConfig', linkMock);
+    fixture.detectChanges();
+
+    const linkEl = fixture.nativeElement.querySelector('a');
+    expect(linkEl).toBeTruthy();
+    expect(linkEl.getAttribute('href')).toBe('https://example.com');
+    expect(linkEl.getAttribute('tabindex')).toBeNull();
+    expect(linkEl.getAttribute('aria-disabled')).toBeNull();
+    expect(linkEl.classList.contains('opacity-50')).toBe(false);
+
+    // Verify aria-hidden on internal icon
+    const iconEl = fixture.nativeElement.querySelector('svg-icon');
+    expect(iconEl).toBeTruthy();
+    expect(iconEl.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('should support disabled link button', async () => {
+    const linkMock = {
+      ...buttonAsLinkMock,
+      link: 'https://example.com',
+      disabled: true,
+    };
+    fixture.componentRef.setInput('buttonConfig', linkMock);
+    fixture.detectChanges();
+
+    const linkEl = fixture.nativeElement.querySelector('a');
+    expect(linkEl).toBeTruthy();
+    expect(linkEl.getAttribute('href')).toBeNull();
+    expect(linkEl.getAttribute('tabindex')).toBe('-1');
+    expect(linkEl.getAttribute('aria-disabled')).toBe('true');
+    expect(linkEl.classList.contains('opacity-50')).toBe(true);
   });
 
   it('should have no accessibility violations', async () => {


### PR DESCRIPTION
### 💡 What:
Enhanced the `SharedButtonUiComponent` wrapper component to handle reactive disabled states correctly for both buttons and links, using Angular's `@let` syntax with the `returnAsObservable | ngrxPush` pipeline.

### 🎯 Why:
Anchor links `<a>` do not support a native `disabled` attribute. When a custom wrapper is passed a disabled link, the link remained fully interactive via mouse and keyboard, violating expectations and causing potential navigation bugs.

### 📸 Before/After:
Before:
- Disabled link buttons retained their `href` attribute, allowing navigation and keyboard focus. No visual or screen reader indication of disabled state.

After:
- Disabled link buttons nullify `href`, add `tabindex="-1"`, apply `aria-disabled="true"`, and style with `opacity-50` for visual indication, keeping the tooltip accessible.

### ♿ Accessibility:
- Correctly nullifies `href` and sets `tabindex="-1"` on disabled links to block focus.
- Adds `aria-disabled="true"` to signal state to screen readers.
- Sets `aria-hidden="true"` on internal decorative icons when the button wrapper has an explicit `aria-label`.

---
*PR created automatically by Jules for task [674942180887869773](https://jules.google.com/task/674942180887869773) started by @plastikaweb*