### PR TITLE
⚡ Bolt: optimize isEmpty & isObject check and adopt in hot paths

### DIFF
--- a/libs/eco-store/core/tenant/src/eco-store-tenant.store.ts
+++ b/libs/eco-store/core/tenant/src/eco-store-tenant.store.ts
@@ -385,7 +385,7 @@ export const ecoStoreTenantStore = signalStore(
         const address = store.addresses().find(a => a.id === addressId);
 
         if (address) {
-          if (address.slots && Object.keys(address.slots).length > 0) {
+          if (address.slots && !isEmpty(address.slots)) {
             return { type: 'slots', slots: address.slots };
           }
           // Check address instructions
@@ -399,7 +399,7 @@ export const ecoStoreTenantStore = signalStore(
       }
 
       // 2. Fallback: Global configuration (applicable to Delivery and Pickup without own configuration)
-      if (deliveryOption.slots && Object.keys(deliveryOption.slots).length > 0) {
+      if (deliveryOption.slots && !isEmpty(deliveryOption.slots)) {
         return { type: 'slots', slots: deliveryOption.slots };
       }
 

--- a/libs/eco-store/core/tenant/src/eco-store-tenant.utils.ts
+++ b/libs/eco-store/core/tenant/src/eco-store-tenant.utils.ts
@@ -153,8 +153,7 @@ export function isShippingMethodConfigured(
   if (!option?.enabled) return false;
 
   if (type === 'pickup') {
-    const hasGlobalPickupConfig =
-      (option.slots && !isEmpty(option.slots)) || !!option.instructions;
+    const hasGlobalPickupConfig = (option.slots && !isEmpty(option.slots)) || !!option.instructions;
 
     const hasAddressConfig = addresses.some(
       address => (address.slots && !isEmpty(address.slots)) || !!address.instructions

--- a/libs/eco-store/core/tenant/src/eco-store-tenant.utils.ts
+++ b/libs/eco-store/core/tenant/src/eco-store-tenant.utils.ts
@@ -7,6 +7,7 @@ import {
   EcoStoreTenantWindowStatus,
   SlotDays,
 } from '@plastik/eco-store/entities';
+import { isEmpty } from '@plastik/shared/objects';
 import { addDays, addWeeks, differenceInMilliseconds, getDay, isBefore, set } from 'date-fns';
 
 /**
@@ -153,17 +154,17 @@ export function isShippingMethodConfigured(
 
   if (type === 'pickup') {
     const hasGlobalPickupConfig =
-      (option.slots && Object.keys(option.slots).length > 0) || !!option.instructions;
+      (option.slots && !isEmpty(option.slots)) || !!option.instructions;
 
     const hasAddressConfig = addresses.some(
-      address => (address.slots && Object.keys(address.slots).length > 0) || !!address.instructions
+      address => (address.slots && !isEmpty(address.slots)) || !!address.instructions
     );
 
     return hasGlobalPickupConfig || hasAddressConfig;
   }
 
   if (type === 'delivery') {
-    return !!(option.slots && Object.keys(option.slots).length > 0);
+    return !!(option.slots && !isEmpty(option.slots));
   }
 
   return false;

--- a/libs/shared/signal-state/data-access-pocketbase/src/lib/stores/with-pocketbase-params.store.ts
+++ b/libs/shared/signal-state/data-access-pocketbase/src/lib/stores/with-pocketbase-params.store.ts
@@ -5,7 +5,7 @@ import {
   BasePocketBaseEntityPagination,
   SortConfig,
 } from '@plastik/core/entities';
-import { areObjectEntriesEqual } from '@plastik/shared/objects';
+import { areObjectEntriesEqual, isEmpty } from '@plastik/shared/objects';
 import { initialGetListState, PocketBaseGetListState } from '../pocketbase-store.types';
 
 interface NormalizedPocketBaseParams {
@@ -99,7 +99,7 @@ const normalizePocketBaseParams = (
   return {
     pagination,
     sort: sorting,
-    filter: Object.keys(filterEntries).length > 0 ? filterEntries : defaultState.filter,
+    filter: !isEmpty(filterEntries) ? filterEntries : defaultState.filter,
   };
 };
 

--- a/libs/shared/util/objects/src/util-objects.spec.ts
+++ b/libs/shared/util/objects/src/util-objects.spec.ts
@@ -32,6 +32,24 @@ describe('Object Util', () => {
     it('should return false if array is not empty', () => {
       expect(isEmpty([1, 2])).toBeFalsy();
     });
+
+    it('should return true if string is empty', () => {
+      expect(isEmpty('')).toBeTruthy();
+    });
+
+    it('should return false if string is not empty', () => {
+      expect(isEmpty('hello')).toBeFalsy();
+    });
+
+    it('should return true if null-prototype object is empty', () => {
+      expect(isEmpty(Object.create(null))).toBeTruthy();
+    });
+
+    it('should return false if null-prototype object is not empty', () => {
+      const obj = Object.create(null);
+      obj.a = 1;
+      expect(isEmpty(obj)).toBeFalsy();
+    });
   });
 
   describe('isString method', () => {
@@ -50,6 +68,10 @@ describe('Object Util', () => {
   describe('isObject method', () => {
     it('should return true if parameter is an object', () => {
       expect(isObject({})).toBeTruthy();
+    });
+
+    it('should return true if parameter is a null-prototype object', () => {
+      expect(isObject(Object.create(null))).toBeTruthy();
     });
 
     it('should return false if parameter is not an object', () => {

--- a/libs/shared/util/objects/src/util-objects.ts
+++ b/libs/shared/util/objects/src/util-objects.ts
@@ -9,8 +9,11 @@ import { coerceBooleanProperty } from '@angular/cdk/coercion';
 export function isEmpty(obj: unknown): boolean {
   if (obj === null || obj === undefined) return true;
 
-  const constructor = (obj as object).constructor;
-  if (constructor === Array || constructor === Object) {
+  if (typeof obj === 'string' || Array.isArray(obj)) {
+    return obj.length === 0;
+  }
+
+  if (isObject(obj)) {
     for (const key in obj as object) {
       if (Object.prototype.hasOwnProperty.call(obj, key)) {
         return false;
@@ -46,7 +49,11 @@ export function isNil(value: unknown): boolean {
  * @returns {boolean}.
  */
 export function isObject(obj: unknown): boolean {
-  return obj instanceof Object && obj.constructor === Object;
+  if (obj === null || typeof obj !== 'object') {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(obj);
+  return proto === Object.prototype || proto === null;
 }
 
 /**


### PR DESCRIPTION
### 💡 What:
Implemented a high-performance, O(1) optimization for array and string emptiness checking, as well as an early-exit `for...in` loop check for plain objects in the `isEmpty()` utility. Also updated the core `isObject()` utility to support prototype-less objects created via `Object.create(null)` by validating prototypes using `Object.getPrototypeOf(obj)`.

Finally, we adopted these optimized checks in the following high-frequency state management/computed store paths to replace expensive, memory-allocating `Object.keys(obj).length > 0` checks:
1. `ecoStoreTenantStore` (`eco-store-tenant.store.ts`)
2. Tenant Logistics utils (`eco-store-tenant.utils.ts`)
3. `withPocketBaseParamsFeature` (`with-pocketbase-params.store.ts`)

---

### 🎯 Why:
1. `Object.keys(obj)` allocates a full array of property names in memory, which has $O(N)$ time and memory complexity. When performed inside computed signals, reactive effects, or change-detection hot paths, this causes unnecessary garbage collection pressure and CPU overhead.
2. The existing `isEmpty` check had some performance regressions, lacked primitive string length checking, and did not correctly support prototype-less objects (`Object.create(null)`), which are commonly used in Javascript maps.

---

### 📊 Impact:
- **Zero Allocations:** Completely drops $O(N)$ array allocation overhead during empty-checks.
- **O(1) Array/String Checks:** Accelerates array and string checks from a loop-based check to a direct `.length` property lookup.
- **Improved Garbage Collection:** Minimizes garbage collection pressure during reactive store computed recalculations.

---

### 🔬 Measurement:
1. Run `yarn nx test shared-util-objects` to verify core optimizations and new test assertions pass.
2. Run `yarn nx lint eco-store-tenant-data-access` and `yarn nx lint data-access-pocketbase` to confirm clean builds.

---
*PR created automatically by Jules for task [5973981542522530769](https://jules.google.com/task/5973981542522530769) started by @plastikaweb*