### PR TITLE
🎨 Palette: Ensure Search Clear Button is Always Enabled for Invalid Inputs

### DIFF
--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.html
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.html
@@ -37,7 +37,6 @@
       type="button"
       [attr.aria-label]="'common.form.clear' | translate"
       [matTooltip]="'common.form.clear' | translate"
-      [disabled]="formStatus() === 'INVALID' && !props.buttonEnabledIfValue"
       (click)="resetSearch()">
       <mat-icon aria-hidden="true">clear</mat-icon>
     </button>

--- a/libs/shared/form/ui/input-search/src/lib/input-search-type.component.spec.ts
+++ b/libs/shared/form/ui/input-search/src/lib/input-search-type.component.spec.ts
@@ -148,6 +148,19 @@ describe('InputSearchTypeComponent', () => {
       // The search button, by contrast, stays disabled for the same 1-char term.
       expect(component['isDisabled']()).toBe(true);
     });
+
+    it('should keep the clear button enabled when the form status is INVALID', () => {
+      component.field.props!.resetSearch = true;
+      component.formControl.setValue('invalid-val');
+      component.formControl.setErrors({ invalid: true });
+      component['syncControl']();
+      fixture.detectChanges();
+
+      const clearButton = fixture.nativeElement.querySelector('.reset-search-button');
+      expect(clearButton).toBeTruthy();
+      expect(clearButton.disabled).toBe(false);
+      expect(component.formControl.status).toBe('INVALID');
+    });
   });
 
   describe('A11Y-010: keyboard support and focus management', () => {


### PR DESCRIPTION
### 💡 What
Removed the conditional `[disabled]` property from the clear/reset button in `InputSearchTypeComponent`.

### 🎯 Why
Previously, if a search input was invalid (e.g., fewer characters than `minLength` or other form validation issues), the clear button would become disabled. This created a highly frustrating UX, forcing the user to manually highlight and backspace their query to clear it, rather than just clicking the reset button.

### 📸 Before/After
- **Before:** The reset (clear) button was disabled when the search field status was `INVALID`.
- **After:** The reset (clear) button remains unconditionally enabled and clickable when there is any value in the input, allowing users to clear invalid queries easily.

### ♿ Accessibility
This allows keyboard and mouse users to unconditionally clear and exit invalid input states, restoring focus to the input element smoothly and without keyboard traps.

---
*PR created automatically by Jules for task [14804068510544535646](https://jules.google.com/task/14804068510544535646) started by @plastikaweb*